### PR TITLE
fix(coding-master): support --repo flag in submit-pr for multi-repo w…

### DIFF
--- a/skills/coding-master/SKILL.md
+++ b/skills/coding-master/SKILL.md
@@ -33,7 +33,7 @@ All commands return JSON: `{"ok": true, "data": {...}}` or `{"ok": false, "error
 | `$D workspace-check --repos <name> --task "<desc>" [--engine ENGINE]` | 获取锁，返回 workspace |
 | `$D develop --workspace <ws> --task "<desc>" [--engine ENGINE]` | 引擎写代码（timeout=600） |
 | `$D test --workspace <ws>` | 工作区内跑测试 |
-| `$D submit-pr --workspace <ws> --title "<title>" [--body "<body>"]` | 提交 PR |
+| `$D submit-pr --workspace <ws> [--repo <name>] --title "<title>" [--body "<body>"]` | 提交 PR（多 repo workspace 须指定 `--repo`） |
 | `$D release --workspace <ws>` | 释放锁（必须） |
 
 ### 复杂度判断

--- a/skills/coding-master/scripts/dispatch.py
+++ b/skills/coding-master/scripts/dispatch.py
@@ -757,7 +757,23 @@ def cmd_test(args) -> dict:
 def cmd_submit_pr(args) -> dict:
     ws_path = args._ws_path
 
-    git = GitOps(ws_path)
+    # When --repo is provided, operate on the repo subdirectory within the workspace
+    repo_name = getattr(args, "repo", None)
+    if repo_name:
+        config = ConfigManager()
+        repo_info = config.get_repo(repo_name)
+        if repo_info is None:
+            return {"ok": False, "error": f"repo '{repo_name}' not found in config",
+                    "error_code": "REPO_NOT_FOUND"}
+        # Repo lives as a subdirectory inside the workspace
+        repo_path = str(Path(ws_path) / repo_name)
+        if not Path(repo_path).is_dir():
+            return {"ok": False, "error": f"repo directory not found: {repo_path}",
+                    "error_code": "PATH_NOT_FOUND",
+                    "hint": f"Expected repo '{repo_name}' at {repo_path}. Check workspace layout."}
+        git = GitOps(repo_path)
+    else:
+        git = GitOps(ws_path)
 
     def do_submit():
         result = git.submit_pr(
@@ -987,6 +1003,7 @@ def _build_parser() -> argparse.ArgumentParser:
 
     sp = sub.add_parser("submit-pr", help="Commit, push, create PR")
     sp.add_argument("--workspace", required=True)
+    sp.add_argument("--repo", default=None, help="Repo name within workspace (e.g. 'alfred'). Uses workspace root if omitted.")
     sp.add_argument("--title", required=True)
     sp.add_argument("--body", default="")
 

--- a/skills/coding-master/scripts/git_ops.py
+++ b/skills/coding-master/scripts/git_ops.py
@@ -78,11 +78,14 @@ class GitOps:
         if branch in PROTECTED_BRANCHES:
             return {"ok": False, "error": f"cannot submit PR from protected branch: {branch}"}
 
-        # commit
+        # commit (skip if working tree is clean)
         msg = commit_message or title
         commit_result = self.stage_and_commit(msg)
         if not commit_result.get("ok"):
-            return commit_result
+            err = commit_result.get("error", "")
+            if "nothing to commit" not in err:
+                return commit_result
+            # Clean tree is fine — just push existing commits
 
         # push
         push_result = self.push(branch)


### PR DESCRIPTION
…orkspaces

submit-pr was using the workspace root as GitOps cwd, which fails in multi-repo workspaces where the target repo is a subdirectory (e.g. env1/alfred). Add --repo flag to resolve the correct repo path. Also skip commit step when working tree is clean instead of erroring out.