### PR TITLE
refactor(session): delegate context-budget control to Dolphin, remove…

### DIFF
--- a/src/everbot/core/session/persistence.py
+++ b/src/everbot/core/session/persistence.py
@@ -14,6 +14,7 @@ import logging
 
 from ...infra.dolphin_state_adapter import DolphinStateAdapter
 from .compressor import SessionCompressor
+from .history_utils import _is_heartbeat, _is_placeholder
 from .session_data import SessionData
 from . import session_ids as _sid
 
@@ -23,8 +24,6 @@ logger = logging.getLogger(__name__)
 class SessionPersistence:
     """Session 持久化管理器"""
 
-    # Keep a larger restoration window to reduce truncation-related context loss.
-    MAX_RESTORED_HISTORY_MESSAGES = 120
     SESSION_ID_PATTERN = re.compile(r"^[A-Za-z0-9._-]+$")
 
     def __init__(self, sessions_dir: Path):
@@ -139,20 +138,14 @@ class SessionPersistence:
     def _filter_heartbeat_messages(messages: list) -> list:
         """Remove heartbeat-injected messages and their placeholder artifacts.
 
-        Heartbeat results (metadata.source == 'heartbeat') and the placeholder
-        messages inserted by inject_history_message — '(acknowledged)' and
-        '[Background notification follows]' — are filtered so they don't
-        pollute the LLM conversation context during restore.
+        Uses shared _is_heartbeat / _is_placeholder from history_utils for
+        consistent identification (metadata + legacy content matching).
         """
-        _PLACEHOLDER_CONTENTS = {"(acknowledged)", "[Background notification follows]"}
         return [
             m for m in messages
-            if isinstance(m, dict) and not (
-                # Heartbeat-sourced messages
-                (isinstance(m.get("metadata"), dict) and m["metadata"].get("source") == "heartbeat")
-                # Placeholder artifacts
-                or (isinstance(m.get("content"), str) and m["content"] in _PLACEHOLDER_CONTENTS)
-            )
+            if isinstance(m, dict)
+            and not _is_heartbeat(m)
+            and not _is_placeholder(m)
         ]
 
     def _get_session_path(self, session_id: str) -> Path:
@@ -222,13 +215,13 @@ class SessionPersistence:
                 revision=next_revision,
             )
 
-            # Compress history for primary sessions before persisting.
-            if data.session_type == "primary":
+            # Compress history for long-lived sessions before persisting.
+            if data.session_type in ("primary", "channel"):
                 try:
                     compressor = SessionCompressor(agent.executor.context)
-                    compressed, new_history = await compressor.maybe_compress(data.history_messages)
-                    if compressed:
-                        data.history_messages = new_history
+                    data.history_messages = await compressor.compress_history(
+                        data.history_messages
+                    )
                 except Exception:
                     logger.warning("History compression failed; saving uncompressed", exc_info=True)
 
@@ -437,44 +430,41 @@ class SessionPersistence:
             logger.info("Session 文件已删除: %s", session_id)
 
     async def restore_to_agent(self, agent: Any, session_data: SessionData):
-        """
-        恢复 Session 数据到 Agent
+        """Restore session data into a Dolphin agent.
+
+        Responsibility boundary
+        -----------------------
+        EverBot restore handles **data hygiene** only:
+          - Strip structurally invalid messages (empty assistant with no tool_calls).
+          - Strip heartbeat / placeholder messages (async-only artifacts that must
+            not enter LLM conversation context).
+          - Filter non-restorable variables (re-injected at runtime or internal-only).
+
+        Context-budget management (token limits) is fully delegated to Dolphin
+        runtime, which enforces the guardrail before each LLM call.  EverBot
+        restore does NOT truncate history by message count — doing so silently
+        discards context that save() already paid the cost to compress.
 
         Args:
-            agent: DolphinAgent 实例
-            session_data: Session 数据
+            agent: DolphinAgent instance.
+            session_data: Session data loaded from disk.
         """
         try:
             # 0a. Strip bare empty assistant messages (content="" with no tool_calls).
             #     These are artifacts from failed/timed-out tool executions and will
             #     cause API errors (e.g. DeepSeek 400 "assistant must not be empty").
-            session_data.history_messages = self._filter_empty_assistant_messages(
+            history = self._filter_empty_assistant_messages(
                 session_data.history_messages or []
             )
 
             # 0b. Strip heartbeat-injected messages and placeholder artifacts.
-            #     Heartbeat results are for async notification only and should not
+            #     Heartbeat results are for async notification only; they must not
             #     be restored into the LLM conversation context.
-            session_data.history_messages = self._filter_heartbeat_messages(
-                session_data.history_messages
-            )
+            history = self._filter_heartbeat_messages(history)
 
-            # 1. Compact history (SDK has no max_messages truncation)
-            compacted_history = session_data.history_messages or []
-            if compacted_history:
-                compacted_history = DolphinStateAdapter.compact_session_state(
-                    compacted_history,
-                    max_messages=self.MAX_RESTORED_HISTORY_MESSAGES,
-                )
-                if len(compacted_history) < len(session_data.history_messages):
-                    logger.info(
-                        "Truncating restored history from %s to last %s messages for session_id=%s.",
-                        len(session_data.history_messages),
-                        self.MAX_RESTORED_HISTORY_MESSAGES,
-                        session_data.session_id,
-                    )
-
-            # 2. Build portable state, filtering non-restorable variables
+            # 1. Build portable state, filtering non-restorable variables.
+            #    workspace_instructions is re-injected at runtime; _history is
+            #    already captured in history_messages above.
             _NON_RESTORABLE_VARS = {"workspace_instructions", "_history"}
             restore_variables = {
                 k: v for k, v in (session_data.variables or {}).items()
@@ -484,11 +474,13 @@ class SessionPersistence:
             portable_state = {
                 "schema_version": "portable_session.v1",
                 "session_id": session_data.session_id,
-                "history_messages": compacted_history,
+                "history_messages": history,
                 "variables": restore_variables,
             }
 
-            # 3. Import via SDK (handles history, variables, session_id, and repair)
+            # 2. Import via SDK (handles history, variables, session_id, and repair).
+            #    repair=True lets Dolphin fix structural issues (orphaned tool_calls,
+            #    role-order violations) before the first LLM call.
             report = agent.snapshot.import_portable_session(portable_state, repair=True)
 
             if report and report.get("issues_after"):
@@ -506,7 +498,7 @@ class SessionPersistence:
                 )
 
             logger.info("Session 已恢复: %s, 历史消息: %s 条",
-                       session_data.session_id, len(compacted_history))
+                       session_data.session_id, len(history))
 
         except Exception as e:
             logger.error("恢复 Session 失败: %s", e)

--- a/tests/integration/test_channel_session_compression.py
+++ b/tests/integration/test_channel_session_compression.py
@@ -72,9 +72,21 @@ def _append_turn(history: list, turn_id: int) -> list:
 async def test_channel_session_history_stays_bounded():
     """Simulate many save-restore cycles on a channel session.
 
-    After enough turns to exceed the compression threshold, the persisted
-    history must stay bounded, not grow linearly.
+    Uses long-content messages so the token budget (COMPACT_TOKEN_BUDGET=40K)
+    is exceeded during the save cycles, triggering LLM summary compression.
+    After compression fires, the persisted history must stay bounded — not grow
+    linearly with turn count.
     """
+    # Each message needs ~600 chars so that ~200 messages exceed the 40K-token
+    # budget (200 × (600+12) / 3 ≈ 40,800 tokens > COMPACT_TOKEN_BUDGET).
+    _LONG = "x" * 600
+
+    def _append_long_turn(history: list, turn_id: int) -> list:
+        return history + [
+            {"role": "user", "content": f"{_LONG} turn-{turn_id}-question"},
+            {"role": "assistant", "content": f"{_LONG} turn-{turn_id}-answer"},
+        ]
+
     with tempfile.TemporaryDirectory() as tmpdir:
         session_dir = Path(tmpdir)
         manager = SessionManager(session_dir)
@@ -90,7 +102,7 @@ async def test_channel_session_history_stays_bounded():
             for turn in range(100):
                 loaded = await manager.load_session(session_id)
                 history = loaded.history_messages if loaded and loaded.history_messages else []
-                history = _append_turn(history, turn)
+                history = _append_long_turn(history, turn)
 
                 context = Context()
                 context.set_variable(KEY_HISTORY, history)
@@ -100,21 +112,33 @@ async def test_channel_session_history_stays_bounded():
             final = await manager.load_session(session_id)
             assert final is not None
 
-            max_expected = COMPRESS_THRESHOLD + 2
-            assert len(final.history_messages) <= max_expected, (
-                f"History grew to {len(final.history_messages)} messages, "
-                f"expected at most {max_expected} (bounded by compression cycle)"
+            # Token-based compression must have fired: summary injected at head.
+            assert SUMMARY_TAG in final.history_messages[0]["content"], (
+                "Compression never triggered — token budget may not have been exceeded"
             )
+            # History must be bounded below the raw accumulated size.
             assert len(final.history_messages) < 200, (
-                "History was never compressed — still at raw size"
+                f"History grew to {len(final.history_messages)} messages — "
+                "compression did not reduce history size"
             )
-            assert SUMMARY_TAG in final.history_messages[0]["content"]
-            assert final.history_messages[-1]["content"] == "turn-99-answer"
+            # Most-recent turn must still be verbatim in the kept window.
+            assert final.history_messages[-1]["content"].endswith("turn-99-answer")
 
 
 @pytest.mark.asyncio
 async def test_primary_session_history_also_stays_bounded():
-    """Same boundedness check for primary sessions (no regression)."""
+    """Same boundedness check for primary sessions (no regression).
+
+    Uses long-content messages to exceed the token budget and trigger compression.
+    """
+    _LONG = "x" * 600
+
+    def _append_long_turn(history: list, turn_id: int) -> list:
+        return history + [
+            {"role": "user", "content": f"{_LONG} turn-{turn_id}-question"},
+            {"role": "assistant", "content": f"{_LONG} turn-{turn_id}-answer"},
+        ]
+
     with tempfile.TemporaryDirectory() as tmpdir:
         session_dir = Path(tmpdir)
         manager = SessionManager(session_dir)
@@ -130,7 +154,7 @@ async def test_primary_session_history_also_stays_bounded():
             for turn in range(100):
                 loaded = await manager.load_session(session_id)
                 history = loaded.history_messages if loaded and loaded.history_messages else []
-                history = _append_turn(history, turn)
+                history = _append_long_turn(history, turn)
 
                 context = Context()
                 context.set_variable(KEY_HISTORY, history)
@@ -139,8 +163,9 @@ async def test_primary_session_history_also_stays_bounded():
 
             final = await manager.load_session(session_id)
             assert final is not None
-            max_expected = COMPRESS_THRESHOLD + 2
-            assert len(final.history_messages) <= max_expected
+            assert SUMMARY_TAG in final.history_messages[0]["content"], (
+                "Compression never triggered for primary session"
+            )
             assert len(final.history_messages) < 200
 
 
@@ -169,60 +194,67 @@ async def test_channel_session_below_threshold_no_compression():
 
 
 @pytest.mark.asyncio
-async def test_e2e_restored_channel_session_llm_context_bounded():
-    """End-to-end: save a large channel session → restore to agent →
-    verify that dolphin's assembled LLM messages are bounded.
+async def test_e2e_restore_preserves_compressed_result():
+    """End-to-end: save compresses history → restore passes the result through intact.
 
-    This crosses both the everbot persistence layer and the dolphin
-    context assembly layer, catching issues in either.
+    Verifies the responsibility boundary:
+    - save() compresses history (token-budget based, via SessionCompressor).
+    - restore_to_agent() performs data hygiene only (strips empty/heartbeat
+      messages) and must NOT further truncate what save() already compressed.
+    - Token-based context guardrail for LLM calls is Dolphin's responsibility
+      and is not tested here.
     """
     with tempfile.TemporaryDirectory() as tmpdir:
         session_dir = Path(tmpdir)
         manager = SessionManager(session_dir)
         session_id = "tg_session_demo_agent__12345"
 
-        # Step 1: Build a large history (200 messages) and save with compression
+        # Step 1: Build a large history (200 messages) and save with compression.
+        # Messages need enough content to exceed the 40K-token budget so that
+        # save() actually compresses (200 × (600+12) / 3 ≈ 40,800 tokens).
+        _LONG = "x" * 600
+
+        def _make_long_history(n: int) -> list:
+            msgs = []
+            for i in range(n):
+                msgs.append({"role": "user", "content": f"{_LONG} msg-{i}"})
+                msgs.append({"role": "assistant", "content": f"{_LONG} reply-{i}"})
+            return msgs
+
         with patch(
             "src.everbot.core.session.compressor.SessionCompressor._generate_summary",
             new_callable=AsyncMock,
             return_value="这是100轮对话的摘要",
         ):
-            history = _make_history(100)  # 200 messages
+            history = _make_long_history(100)  # 200 messages with long content
             context = Context()
             context.set_variable(KEY_HISTORY, history)
             agent = _make_mock_agent(context)
             await manager.save_session(session_id, agent)
 
-        # Verify persistence compressed it
         saved = await manager.load_session(session_id)
-        assert len(saved.history_messages) < 200
+        assert len(saved.history_messages) < 200, "save() should have compressed history"
+        compressed_count = len(saved.history_messages)
 
-        # Step 2: Create a fresh agent and restore the compressed session
+        # Step 2: Restore into a fresh agent; intercept import_portable_session
+        # to capture exactly what EverBot passes to Dolphin.
         fresh_context = Context()
         fresh_agent = _make_mock_agent(fresh_context)
+        imported_state: dict = {}
+        original_import = fresh_agent.snapshot.import_portable_session
+
+        def capture_import(state, **kwargs):
+            imported_state.update(state)
+            return original_import(state, **kwargs)
+
+        fresh_agent.snapshot.import_portable_session = capture_import
         await manager.restore_to_agent(fresh_agent, saved)
 
-        # Step 3: Simulate what dolphin does before an LLM call —
-        # assemble messages via context_manager.to_dph_messages()
-        ctx = fresh_agent.executor.context
-        cm = ctx.context_manager
-        if cm is not None:
-            llm_messages = cm.to_dph_messages()
-            msg_count = len(llm_messages.get_messages())
-        else:
-            # Fallback: check history directly from context
-            llm_messages = ctx.get_messages()
-            msg_count = len(llm_messages.get_messages())
-
-        # The messages sent to LLM must be bounded
-        max_llm_messages = SessionPersistence.MAX_RESTORED_HISTORY_MESSAGES + 10  # small headroom
-        assert msg_count <= max_llm_messages, (
-            f"LLM would receive {msg_count} messages after restore, "
-            f"expected at most ~{max_llm_messages}. "
-            f"Context is unbounded — compression or restore truncation failed."
-        )
-        # Must not be the raw 200
-        assert msg_count < 200, (
-            f"LLM context has {msg_count} messages — neither compression "
-            f"nor restore truncation reduced the history."
+        # Step 3: restore must pass the compressed history intact — no additional loss.
+        # (The test history has no heartbeat/empty messages, so hygiene filters are no-ops.)
+        assert "history_messages" in imported_state, "import_portable_session was not called"
+        assert len(imported_state["history_messages"]) == compressed_count, (
+            f"restore introduced additional truncation: "
+            f"save produced {compressed_count} messages but "
+            f"restore passed {len(imported_state['history_messages'])} to Dolphin"
         )

--- a/tests/unit/test_history_policy.py
+++ b/tests/unit/test_history_policy.py
@@ -1,0 +1,549 @@
+"""Tests for history policy: heartbeat isolation + token-budget compact."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from src.everbot.core.session.history_utils import (
+    MAX_HEARTBEAT_MESSAGES,
+    COMPACT_TOKEN_BUDGET,
+    COMPACT_WINDOW_TOKENS,
+    _is_heartbeat,
+    _is_placeholder,
+    _estimate_tokens,
+    evict_oldest_heartbeat,
+)
+from src.everbot.core.session.compressor import (
+    SessionCompressor,
+    COMPRESS_THRESHOLD,
+    WINDOW_SIZE,
+    SUMMARY_TAG,
+)
+from src.everbot.core.session.persistence import SessionPersistence
+
+
+# ── Test factories ────────────────────────────────────────────────────
+
+
+def _user(content, **meta):
+    msg = {"role": "user", "content": content}
+    if meta:
+        msg["metadata"] = meta
+    return msg
+
+
+def _assistant(content, **meta):
+    msg = {"role": "assistant", "content": content}
+    if meta:
+        msg["metadata"] = meta
+    return msg
+
+
+def _heartbeat_msg(run_id, content="检测正常"):
+    return _assistant(content, source="heartbeat", run_id=run_id)
+
+
+def _placeholder_ack(run_id):
+    return _assistant("(acknowledged)", source="system", category="placeholder", run_id=run_id)
+
+
+def _placeholder_bg(run_id):
+    return _user("[Background notification follows]", source="system", category="placeholder", run_id=run_id)
+
+
+def _heartbeat_turn(run_id, content="检测正常"):
+    """A complete heartbeat turn: ack placeholder + bg placeholder + heartbeat message."""
+    return [_placeholder_ack(run_id), _placeholder_bg(run_id), _heartbeat_msg(run_id, content)]
+
+
+def _legacy_heartbeat(content="结果正常"):
+    """Legacy heartbeat message (content prefix identification)."""
+    return _assistant(f"[此消息由心跳系统自动执行例行任务生成]\n\n{content}")
+
+
+# ── 6.2 TestIsHeartbeat ──────────────────────────────────────────────
+
+
+class TestIsHeartbeat:
+    def test_metadata_heartbeat(self):
+        msg = {"role": "assistant", "content": "ok", "metadata": {"source": "heartbeat"}}
+        assert _is_heartbeat(msg) is True
+
+    def test_legacy_prefix(self):
+        msg = _legacy_heartbeat("test")
+        assert _is_heartbeat(msg) is True
+
+    def test_normal_assistant(self):
+        msg = {"role": "assistant", "content": "hello"}
+        assert _is_heartbeat(msg) is False
+
+    def test_placeholder_not_heartbeat(self):
+        msg = {"role": "assistant", "content": "(acknowledged)", "metadata": {"source": "system"}}
+        assert _is_heartbeat(msg) is False
+
+    def test_no_metadata(self):
+        msg = {"role": "assistant", "content": "regular message"}
+        assert _is_heartbeat(msg) is False
+
+
+# ── 6.2b TestIsPlaceholder ───────────────────────────────────────────
+
+
+class TestIsPlaceholder:
+    def test_metadata_placeholder(self):
+        msg = {"role": "assistant", "content": "(acknowledged)",
+               "metadata": {"category": "placeholder", "source": "system"}}
+        assert _is_placeholder(msg) is True
+
+    def test_legacy_acknowledged(self):
+        msg = {"role": "assistant", "content": "(acknowledged)"}
+        assert _is_placeholder(msg) is True
+
+    def test_legacy_bg_notification(self):
+        msg = {"role": "user", "content": "[Background notification follows]"}
+        assert _is_placeholder(msg) is True
+
+    def test_normal_user_message(self):
+        msg = {"role": "user", "content": "hello"}
+        assert _is_placeholder(msg) is False
+
+    def test_partial_match_not_placeholder(self):
+        msg = {"role": "assistant", "content": "(acknowledged) and more"}
+        assert _is_placeholder(msg) is False
+
+
+# ── 6.4b TestEstimateTokens ──────────────────────────────────────────
+
+
+class TestEstimateTokens:
+    def test_simple_string_content(self):
+        msgs = [{"role": "user", "content": "a" * 300}]
+        tokens = _estimate_tokens(msgs)
+        # (300 + 12) // 3 = 104
+        assert tokens == 104
+
+    def test_list_content_with_text(self):
+        msgs = [{"role": "user", "content": [{"type": "text", "text": "a" * 300}]}]
+        tokens = _estimate_tokens(msgs)
+        assert tokens == 104
+
+    def test_empty_messages(self):
+        assert _estimate_tokens([]) == 0
+
+    def test_tool_calls_counted(self):
+        msg_plain = {"role": "assistant", "content": "a" * 100}
+        msg_tool = {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{
+                "id": "call_abc123",
+                "function": {"name": "bash", "arguments": '{"cmd":"ls -la"}'},
+            }],
+        }
+        tokens_plain = _estimate_tokens([msg_plain])
+        tokens_tool = _estimate_tokens([msg_tool])
+        # tool msg has function name + arguments + id counted
+        assert tokens_tool > 0
+        # Both have overhead, but tool has extra from tool_calls
+        assert tokens_tool > _estimate_tokens([{"role": "assistant", "content": ""}])
+
+    def test_tool_response_counted(self):
+        msg = {"role": "tool", "content": "result data", "tool_call_id": "call_abc123"}
+        tokens = _estimate_tokens([msg])
+        # content + tool_call_id + overhead all counted
+        assert tokens > 0
+
+    def test_tool_heavy_vs_chat_only(self):
+        chat_msgs = [{"role": "user", "content": "a" * 100} for _ in range(10)]
+        tool_msgs = [
+            {
+                "role": "assistant",
+                "content": "a" * 100,
+                "tool_calls": [{
+                    "id": f"call_{i}",
+                    "function": {"name": "execute", "arguments": "b" * 500},
+                }],
+            }
+            for i in range(10)
+        ]
+        chat_tokens = _estimate_tokens(chat_msgs)
+        tool_tokens = _estimate_tokens(tool_msgs)
+        assert tool_tokens > chat_tokens * 3
+
+    def test_message_overhead(self):
+        msg = {"role": "assistant", "content": ""}
+        tokens = _estimate_tokens([msg])
+        assert tokens > 0  # structural overhead
+
+
+# ── 6.3 TestEvictOldestHeartbeat ─────────────────────────────────────
+
+
+class TestEvictOldestHeartbeat:
+    def test_under_limit_no_change(self):
+        hb = [_heartbeat_msg(f"hb_{i}") for i in range(5)]
+        result = evict_oldest_heartbeat(hb)
+        assert result == hb
+
+    def test_evict_oldest_fifo(self):
+        hb = [_heartbeat_msg(f"hb_{i}") for i in range(25)]
+        result = evict_oldest_heartbeat(hb)
+        assert len(result) == MAX_HEARTBEAT_MESSAGES
+        # Kept the newest 20
+        assert result[0] == hb[5]
+        assert result[-1] == hb[24]
+
+    def test_placeholder_evicted_with_heartbeat_new_format(self):
+        history = []
+        for i in range(25):
+            history.extend(_heartbeat_turn(f"hb_{i}"))
+        result = evict_oldest_heartbeat(history)
+        # 20 heartbeats * 3 messages each = 60
+        hb_count = sum(1 for m in result if _is_heartbeat(m))
+        assert hb_count == MAX_HEARTBEAT_MESSAGES
+        # No orphan placeholders (each placeholder should have its heartbeat)
+        ph_count = sum(1 for m in result if _is_placeholder(m))
+        assert ph_count == MAX_HEARTBEAT_MESSAGES * 2
+
+    def test_placeholder_evicted_with_heartbeat_legacy(self):
+        history = []
+        for i in range(25):
+            # Legacy format: bare placeholders + legacy heartbeat
+            history.append({"role": "assistant", "content": "(acknowledged)"})
+            history.append({"role": "user", "content": "[Background notification follows]"})
+            history.append(_legacy_heartbeat(f"result_{i}"))
+        result = evict_oldest_heartbeat(history)
+        hb_count = sum(1 for m in result if _is_heartbeat(m))
+        assert hb_count == MAX_HEARTBEAT_MESSAGES
+        # Legacy placeholders should also be evicted
+        total = len(result)
+        assert total == MAX_HEARTBEAT_MESSAGES * 3  # 20 turns of 3 msgs each
+
+    def test_placeholder_evicted_mixed_format(self):
+        history = []
+        # 13 new-format turns
+        for i in range(13):
+            history.extend(_heartbeat_turn(f"hb_{i}"))
+        # 12 legacy turns
+        for i in range(12):
+            history.append({"role": "assistant", "content": "(acknowledged)"})
+            history.append({"role": "user", "content": "[Background notification follows]"})
+            history.append(_legacy_heartbeat(f"legacy_{i}"))
+        result = evict_oldest_heartbeat(history)
+        hb_count = sum(1 for m in result if _is_heartbeat(m))
+        assert hb_count == MAX_HEARTBEAT_MESSAGES
+
+    def test_chat_messages_preserved(self):
+        history = []
+        chat_msgs = [_user(f"chat_{i}") for i in range(10)]
+        hb_msgs = [_heartbeat_msg(f"hb_{i}") for i in range(25)]
+        history = chat_msgs + hb_msgs
+        result = evict_oldest_heartbeat(history)
+        # All chat preserved
+        result_chat = [m for m in result if not _is_heartbeat(m)]
+        assert len(result_chat) == 10
+        assert result_chat == chat_msgs
+
+    def test_legacy_heartbeat_evicted(self):
+        history = [_legacy_heartbeat(f"r_{i}") for i in range(25)]
+        result = evict_oldest_heartbeat(history)
+        assert len(result) == MAX_HEARTBEAT_MESSAGES
+
+    def test_empty_history(self):
+        assert evict_oldest_heartbeat([]) == []
+
+    def test_no_heartbeat(self):
+        history = [_user(f"msg_{i}") for i in range(10)]
+        result = evict_oldest_heartbeat(history)
+        assert result == history
+
+    def test_interleaved_order_preserved(self):
+        history = []
+        for i in range(25):
+            history.append(_user(f"chat_{i}"))
+            history.append(_heartbeat_msg(f"hb_{i}"))
+        result = evict_oldest_heartbeat(history)
+        hb_count = sum(1 for m in result if _is_heartbeat(m))
+        assert hb_count == MAX_HEARTBEAT_MESSAGES
+        # Relative order preserved
+        chat_in_result = [m for m in result if not _is_heartbeat(m)]
+        assert len(chat_in_result) == 25  # all chat preserved
+        # Check order: each chat should come before any later chat
+        for i in range(len(chat_in_result) - 1):
+            idx_a = result.index(chat_in_result[i])
+            idx_b = result.index(chat_in_result[i + 1])
+            assert idx_a < idx_b
+
+
+# ── 6.4 TestSaveCompact ─────────────────────────────────────────────
+
+
+class TestTokenBudgetWindowEdge:
+    """Edge cases for token-budget window in compressor."""
+
+    @pytest.mark.asyncio
+    async def test_last_message_exceeds_budget_still_kept(self):
+        """When the last message alone exceeds token_budget, it must still be kept verbatim."""
+        ctx = MagicMock()
+        compressor = SessionCompressor(ctx)
+        # Small messages + one huge trailing message
+        msgs = [{"role": "user", "content": f"msg-{i}"} for i in range(10)]
+        msgs.append({"role": "assistant", "content": "x" * 200_000})  # ~66K tokens alone
+
+        with patch.object(compressor, "_generate_summary", new_callable=AsyncMock) as mock_gen:
+            mock_gen.return_value = "Summary"
+            compressed, result = await compressor.maybe_compress(
+                msgs, token_budget=COMPACT_WINDOW_TOKENS,
+            )
+
+        assert compressed is True
+        # The huge last message must be in to_keep (verbatim), not summarized
+        assert any(len(m.get("content", "")) > 100_000 for m in result)
+
+    @pytest.mark.asyncio
+    async def test_single_message_exceeds_budget_no_compress(self):
+        """A single message that exceeds token_budget: nothing to compress, kept as-is."""
+        ctx = MagicMock()
+        compressor = SessionCompressor(ctx)
+        msgs = [{"role": "assistant", "content": "x" * 200_000}]
+
+        compressed, result = await compressor.maybe_compress(
+            msgs, token_budget=COMPACT_WINDOW_TOKENS,
+        )
+        # to_compress is empty → no compression
+        assert compressed is False
+        assert result is msgs
+
+
+class TestCompressHistory:
+    """Tests for the shared compress_history() entry point used by both save paths."""
+
+    @pytest.mark.asyncio
+    async def test_chat_below_budget_no_compact(self):
+        """Heartbeat tokens should NOT count toward compact decision."""
+        ctx = MagicMock()
+        compressor = SessionCompressor(ctx)
+        # Chat: ~10K tokens (30K chars)
+        chat_msgs = [{"role": "user", "content": "a" * 3000} for _ in range(10)]
+        # Heartbeat: ~5K tokens (15K chars) — should be excluded from budget
+        hb_msgs = [_heartbeat_msg(f"hb_{i}", "b" * 1500) for i in range(10)]
+        history = chat_msgs + hb_msgs
+
+        with patch.object(compressor, "_generate_summary", new_callable=AsyncMock) as mock_gen:
+            result = await compressor.compress_history(history)
+            mock_gen.assert_not_called()
+
+        assert result is history  # unchanged
+
+    @pytest.mark.asyncio
+    async def test_chat_above_budget_triggers_compact(self):
+        """When chat tokens > COMPACT_TOKEN_BUDGET, compact is triggered."""
+        ctx = MagicMock()
+        compressor = SessionCompressor(ctx)
+        # Chat: ~50K tokens (150K chars)
+        chat_msgs = [{"role": "user", "content": "a" * 3000} for _ in range(50)]
+        hb_msgs = [_heartbeat_msg(f"hb_{i}") for i in range(3)]
+        history = chat_msgs + hb_msgs
+
+        with patch.object(compressor, "_generate_summary", new_callable=AsyncMock) as mock_gen:
+            mock_gen.return_value = "Compressed summary"
+            result = await compressor.compress_history(history)
+
+        mock_gen.assert_called_once()
+        assert len(result) < len(history)
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_preserved_after_compact(self):
+        """After compact, heartbeat messages should still be in result."""
+        ctx = MagicMock()
+        compressor = SessionCompressor(ctx)
+        chat_msgs = [{"role": "user", "content": "a" * 3000} for _ in range(50)]
+        hb_msgs = [_heartbeat_msg(f"hb_{i}") for i in range(5)]
+        history = chat_msgs + hb_msgs
+
+        with patch.object(compressor, "_generate_summary", new_callable=AsyncMock) as mock_gen:
+            mock_gen.return_value = "Summary"
+            result = await compressor.compress_history(history)
+
+        hb_in_result = [m for m in result if _is_heartbeat(m)]
+        assert len(hb_in_result) == 5
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_appended_to_tail(self):
+        """Heartbeat messages should appear after compacted chat."""
+        ctx = MagicMock()
+        compressor = SessionCompressor(ctx)
+        chat_msgs = [{"role": "user", "content": "a" * 3000} for _ in range(50)]
+        hb_msgs = [_heartbeat_msg(f"hb_{i}") for i in range(3)]
+        history = chat_msgs + hb_msgs
+
+        with patch.object(compressor, "_generate_summary", new_callable=AsyncMock) as mock_gen:
+            mock_gen.return_value = "Summary"
+            result = await compressor.compress_history(history)
+
+        last_chat_idx = max(i for i, m in enumerate(result) if not _is_heartbeat(m))
+        for i, m in enumerate(result):
+            if _is_heartbeat(m):
+                assert i > last_chat_idx
+
+    @pytest.mark.asyncio
+    async def test_no_heartbeat_same_as_before(self):
+        """Without heartbeat, legacy maybe_compress path still works."""
+        ctx = MagicMock()
+        compressor = SessionCompressor(ctx)
+        # 100 messages > COMPRESS_THRESHOLD
+        msgs = []
+        for i in range(50):
+            msgs.append({"role": "user", "content": f"msg-{i}"})
+            msgs.append({"role": "assistant", "content": f"reply-{i}"})
+
+        with patch.object(compressor, "_generate_summary", new_callable=AsyncMock) as mock_gen:
+            mock_gen.return_value = "Summary"
+            compressed, result = await compressor.maybe_compress(msgs)
+
+        assert compressed is True
+        assert len(result) == 2 + WINDOW_SIZE
+
+
+# ── 6.5 TestRestoreFilter ───────────────────────────────────────────
+
+
+class TestRestoreFilter:
+    def test_heartbeat_removed(self):
+        history = [_user("hi"), *_heartbeat_turn("hb_1"), _user("bye")]
+        result = SessionPersistence._filter_heartbeat_messages(history)
+        assert len(result) == 2
+        assert all(not _is_heartbeat(m) for m in result)
+
+    def test_placeholder_removed_with_heartbeat(self):
+        history = _heartbeat_turn("hb_1")
+        result = SessionPersistence._filter_heartbeat_messages(history)
+        assert len(result) == 0
+
+    def test_legacy_placeholder_removed(self):
+        history = [
+            {"role": "assistant", "content": "(acknowledged)"},
+            {"role": "user", "content": "[Background notification follows]"},
+        ]
+        result = SessionPersistence._filter_heartbeat_messages(history)
+        assert len(result) == 0
+
+    def test_legacy_heartbeat_removed(self):
+        history = [_legacy_heartbeat("test")]
+        result = SessionPersistence._filter_heartbeat_messages(history)
+        assert len(result) == 0
+
+    def test_chat_preserved(self):
+        history = [_user("hi"), _assistant("hello"), *_heartbeat_turn("hb_1"), _user("q")]
+        result = SessionPersistence._filter_heartbeat_messages(history)
+        assert len(result) == 3
+        assert result[0]["content"] == "hi"
+        assert result[1]["content"] == "hello"
+        assert result[2]["content"] == "q"
+
+    def test_filter_preserves_valid_structure(self):
+        """Heartbeat filter must not corrupt chat message structure.
+
+        After filtering, remaining messages must all be valid dicts with a
+        'role' field — no orphaned fragments from partial heartbeat turns.
+        """
+        history = [
+            _user("hi"),
+            _assistant("hello"),
+            *_heartbeat_turn("hb_1"),
+            _user("follow-up"),
+            _assistant("sure"),
+        ]
+        result = SessionPersistence._filter_heartbeat_messages(history)
+        assert len(result) == 4
+        assert all(isinstance(m, dict) and "role" in m for m in result)
+        assert result[0]["content"] == "hi"
+        assert result[-1]["content"] == "sure"
+
+
+# ── 6.6 TestEndToEnd ────────────────────────────────────────────────
+
+
+class TestInjectionPathConsistency:
+    """Both heartbeat injection paths should produce metadata-only format (no content prefix)."""
+
+    @pytest.mark.asyncio
+    async def test_cron_delivery_no_prefix(self):
+        """CronDelivery.inject_to_history should NOT add content prefix."""
+        from src.everbot.core.runtime.cron_delivery import CronDelivery
+
+        cd = CronDelivery(
+            session_manager=MagicMock(),
+            primary_session_id="test",
+            heartbeat_session_id="hb_test",
+            agent_name="agent",
+        )
+        captured = {}
+
+        async def capture_inject(session_id, message, **kwargs):
+            captured.update(message)
+            return True
+
+        cd.session_manager.inject_history_message = AsyncMock(side_effect=capture_inject)
+
+        await cd.inject_to_history("检测正常", "run_123")
+        # Content should NOT have the legacy prefix
+        assert not captured["content"].startswith("[此消息由心跳系统自动执行例行任务生成]")
+        assert captured["content"] == "检测正常"
+        assert captured["metadata"]["source"] == "heartbeat"
+
+    def test_heartbeat_runner_no_prefix(self):
+        """HeartbeatRunner._inject_result_to_primary_history should NOT add content prefix."""
+        # Read the source to verify no prefix in the method
+        import inspect
+        from src.everbot.core.runtime.heartbeat import HeartbeatRunner
+
+        source = inspect.getsource(HeartbeatRunner._inject_result_to_primary_history)
+        assert "[此消息由心跳系统自动执行例行任务生成]" not in source
+
+
+class TestEndToEnd:
+    def test_inject_accumulation_then_evict(self):
+        """Simulate 30 heartbeat injections; eviction caps at 20."""
+        history = []
+        for i in range(30):
+            history.extend(_heartbeat_turn(f"hb_{i}"))
+            history = evict_oldest_heartbeat(history)
+
+        hb_count = sum(1 for m in history if _is_heartbeat(m))
+        assert hb_count == MAX_HEARTBEAT_MESSAGES
+
+    def test_metadata_roundtrip(self):
+        """Metadata survives serialization roundtrip."""
+        import json
+
+        hb = _heartbeat_msg("hb_test", "data")
+        serialized = json.dumps(hb)
+        loaded = json.loads(serialized)
+        assert _is_heartbeat(loaded) is True
+        assert loaded["metadata"]["run_id"] == "hb_test"
+
+    def test_backward_compatibility(self):
+        """Mixed legacy + new format: all correctly handled across full pipeline."""
+        history = []
+        # 15 new-format
+        for i in range(15):
+            history.extend(_heartbeat_turn(f"hb_{i}"))
+        # 10 legacy
+        for i in range(10):
+            history.append(_legacy_heartbeat(f"legacy_{i}"))
+        # 5 chat
+        for i in range(5):
+            history.append(_user(f"chat_{i}"))
+
+        # inject eviction
+        evicted = evict_oldest_heartbeat(history)
+        hb_count = sum(1 for m in evicted if _is_heartbeat(m))
+        assert hb_count == MAX_HEARTBEAT_MESSAGES
+
+        # restore filter
+        filtered = SessionPersistence._filter_heartbeat_messages(evicted)
+        assert all(not _is_heartbeat(m) for m in filtered)
+        assert all(not _is_placeholder(m) for m in filtered)
+        # Chat preserved
+        chat_msgs = [m for m in filtered if m.get("role") == "user"]
+        assert len(chat_msgs) == 5

--- a/tests/unit/test_session_manager_core.py
+++ b/tests/unit/test_session_manager_core.py
@@ -564,17 +564,21 @@ class TestSaveSessionLockAlreadyHeld:
 
 
 # ===========================================================================
-# 10. SessionManager.restore_to_agent history truncation
+# 10. SessionManager.restore_to_agent
 # ===========================================================================
 
-class TestRestoreToAgentTruncation:
+class TestRestoreToAgent:
 
     @pytest.mark.asyncio
-    async def test_history_truncated_when_exceeding_max(self, tmp_path: Path):
-        manager = SessionManager(tmp_path)
-        max_msgs = SessionPersistence.MAX_RESTORED_HISTORY_MESSAGES  # 120
+    async def test_history_passed_through_intact(self, tmp_path: Path):
+        """restore_to_agent must NOT truncate history by message count.
 
-        # Create a session with more than MAX_RESTORED_HISTORY_MESSAGES
+        Context-budget management is Dolphin's responsibility.  EverBot restore
+        only strips data-hygiene artifacts (empty assistant, heartbeat) and then
+        passes whatever save() persisted straight into import_portable_session.
+        """
+        manager = SessionManager(tmp_path)
+
         large_history = [{"role": "user", "content": f"msg {i}"} for i in range(200)]
         session_data = _make_session_data(
             session_id="web_session_test_agent",
@@ -582,20 +586,18 @@ class TestRestoreToAgentTruncation:
         )
 
         agent = _make_mock_agent()
-
         await manager.restore_to_agent(agent, session_data)
 
-        # Verify import_portable_session was called
         agent.snapshot.import_portable_session.assert_called_once()
         call_args = agent.snapshot.import_portable_session.call_args
         portable = call_args[0][0]
         restored_history = portable["history_messages"]
 
-        # Should be truncated to MAX_RESTORED_HISTORY_MESSAGES
-        assert len(restored_history) <= max_msgs
+        # All 200 messages must reach import_portable_session — no EverBot truncation.
+        assert len(restored_history) == 200
 
     @pytest.mark.asyncio
-    async def test_history_not_truncated_when_within_limit(self, tmp_path: Path):
+    async def test_history_small_session_passed_through(self, tmp_path: Path):
         manager = SessionManager(tmp_path)
 
         small_history = [{"role": "user", "content": f"msg {i}"} for i in range(10)]
@@ -605,7 +607,6 @@ class TestRestoreToAgentTruncation:
         )
 
         agent = _make_mock_agent()
-
         await manager.restore_to_agent(agent, session_data)
 
         agent.snapshot.import_portable_session.assert_called_once()


### PR DESCRIPTION
⏺ ## Background                                                                                                                                                                         
                                               
  Previously `restore_to_agent()` applied a hard 120-message truncation                                                                                                                 
  (`MAX_RESTORED_HISTORY_MESSAGES`) as a band-aid context guardrail. This
  created two problems:                                                                                                                                                                 
                                                                  
  1. **Responsibility confusion** — EverBot restore was doing context-budget
     management, which is Dolphin runtime's job (Dolphin enforces token limits
     before every LLM call).
  2. **Silent context loss** — `save()` already pays the cost to LLM-summarize
     history; the 120-message truncation at restore time was silently discarding
     that compressed-but-still-valuable context.

  ## Changes

  ### `persistence.py`

  - Remove `MAX_RESTORED_HISTORY_MESSAGES = 120` and the
    `compact_session_state(..., max_messages=120)` truncation from
    `restore_to_agent()`.
  - `restore_to_agent()` now handles **data hygiene only**: strip empty assistant
    messages, strip heartbeat/placeholder artifacts, filter non-restorable
    variables — then pass the result straight to `import_portable_session`. No
    message-count truncation.
  - Extend save-side compression from `session_type == "primary"` to
    `session_type in ("primary", "channel")`, and switch from the legacy
    count-based `maybe_compress()` to the token-budget `compress_history()`
    entry point.
  - Unify `_filter_heartbeat_messages` to use the shared `_is_heartbeat` /
    `_is_placeholder` helpers from `history_utils` (removes a duplicated inline
    impl).

  ### Responsibility boundary (now explicit in docstring)

  | Layer | Responsibility |
  |---|---|
  | `save()` | Token-budget LLM summary compression |
  | `restore_to_agent()` | Data hygiene (empty/heartbeat filter, variable filter) |
  | Dolphin runtime | Token guardrail before each LLM call |

  ## Tests

  - **`test_session_manager_core.py`** — `TestRestoreToAgentTruncation` →
    `TestRestoreToAgent`: assertion flipped from `<= 120` to `== 200` (all
    messages must reach Dolphin intact).
  - **`test_channel_session_compression.py`** — boundedness tests now use
    600-char messages that actually exceed the 40K-token budget, replacing the
    previously incorrect message-count bounds. E2E test rewritten to verify
    restore does not drop messages that save already compressed.
  - **`test_history_policy.py`** — `test_compact_still_works` replaced with
    `test_filter_preserves_valid_structure` (heartbeat filter correctness, no
    longer testing the removed code path).