### PR TITLE
Feat/history policy

### DIFF
--- a/bin/everbot
+++ b/bin/everbot
@@ -274,6 +274,13 @@ case "${cmd}" in
     for _ in $(seq 1 50); do
       pid="$(read_pid)"
       if is_running "${pid}"; then
+        # Wait a moment to catch immediate crashes (e.g. import errors).
+        sleep 1
+        if ! is_running "${pid}"; then
+          echo "ERROR: EverBot daemon crashed immediately. Check logs: ${DAEMON_OUT}" >&2
+          tail -5 "${DAEMON_OUT}" >&2 || true
+          exit 1
+        fi
         if (( daemon_already_running == 0 )); then
           echo "EverBot daemon started (pid=${pid})."
         fi

--- a/docs/history_policy_design.md
+++ b/docs/history_policy_design.md
@@ -91,6 +91,9 @@ def _evict_oldest_heartbeat(history: list[dict]) -> list[dict]:
                 continue
 
         # 旧格式占位：紧接在被淘汰心跳之前的 (acknowledged) / [Background notification follows]
+        # 已知限制：旧格式靠 content 精确匹配，如果用户恰好发了内容为
+        # "(acknowledged)" 的消息且后面紧跟被淘汰心跳，会被误删。
+        # 这种概率极低，且只影响 inject 路径的 disk 存储，不影响 restore。
         if _is_placeholder(msg) and (i + 1) in to_evict:
             continue
         if _is_placeholder(msg) and (i + 2) in to_evict:
@@ -102,29 +105,85 @@ def _evict_oldest_heartbeat(history: list[dict]) -> list[dict]:
     return result
 ```
 
-### 2.2 save：标准 compact（排除心跳计数）
+### 2.2 save：token 预算驱动的 compact
 
-`save_session` 时，只看用户对话消息数量决定是否触发 compact。触发后，**先过滤心跳再 compact，再把心跳追加到尾部**。
+`save_session` 时，按 token 数（而非消息条数）决定是否触发 compact。只计用户对话部分的 token，心跳消息不参与。
 
-不拆分后 merge 的原因：compact 会把旧 chat 重写为 summary pair + window，原始位置信息丢失，中间插入的心跳消息没有明确的归位规则。既然心跳在 restore 时会被全部过滤掉（不送 LLM），它在 disk 上的位置只影响审计可读性，不影响正确性。追加到尾部是最简实现。
+**为什么用 token 数而非条数**：一条 tool 输出可能 3000 token，一条闲聊 30 token。条数阈值和真实 context 成本脱节，会导致要么过早压缩（浪费 LLM 调用），要么延迟压缩（context 膨胀）。业界主流（Claude Code、OpenAI Assistants、Cursor）均按 token 数管理。
+
+**token 估算**：复用项目已有的字符估算惯例（`context_manager.py` 用 `chars // 3`），不引入 tiktoken 依赖。
+
+```python
+COMPACT_TOKEN_BUDGET = 40_000  # 对话部分超过 40K token 时触发 compact
+COMPACT_WINDOW_TOKENS = 20_000  # compact 后保留最近 ~20K token
+
+def _estimate_tokens(messages: list[dict]) -> int:
+    """估算消息列表的 token 数。
+
+    统计所有会被送入 LLM 的内容：
+    - content（字符串或 multipart list）
+    - tool_calls（函数名 + 参数 JSON）
+    - tool_call_id
+    - 每条消息的结构开销（role 标签、JSON 包装等）
+
+    估算比例：1 token ≈ 3 chars（与 context_manager.py 一致）。
+    """
+    total_chars = 0
+    MSG_OVERHEAD = 12  # role/name/tool_call_id 等结构开销，约 4 token
+
+    for msg in messages:
+        total_chars += MSG_OVERHEAD
+
+        # content
+        content = msg.get("content") or ""
+        if isinstance(content, str):
+            total_chars += len(content)
+        elif isinstance(content, list):
+            for part in content:
+                if isinstance(part, dict):
+                    total_chars += len(str(part.get("text", "")))
+
+        # tool_calls（assistant 消息）
+        for tc in msg.get("tool_calls") or []:
+            fn = tc.get("function") or {}
+            total_chars += len(fn.get("name") or "")
+            total_chars += len(fn.get("arguments") or "")
+            total_chars += len(tc.get("id") or "")
+
+        # tool_call_id（tool 响应消息）
+        total_chars += len(msg.get("tool_call_id") or "")
+
+    return total_chars // 3
+```
+
+compact 触发逻辑：
 
 ```python
 # save_session 中
-chat_count = sum(1 for m in history if not _is_heartbeat(m) and not _is_placeholder(m))
-if chat_count > COMPRESS_THRESHOLD:
-    # 分离心跳
+chat_msgs = [m for m in history if not _is_heartbeat(m) and not _is_placeholder(m)]
+chat_tokens = _estimate_tokens(chat_msgs)
+if chat_tokens > COMPACT_TOKEN_BUDGET:
     heartbeat_msgs = [m for m in history if _is_heartbeat(m) or _is_placeholder(m)]
-    chat_msgs = [m for m in history if not _is_heartbeat(m) and not _is_placeholder(m)]
     # 只对 chat 部分 compact
-    compressed, new_chat = await compressor.maybe_compress(chat_msgs)
+    compressed, new_chat = await compressor.maybe_compress(
+        chat_msgs, token_budget=COMPACT_WINDOW_TOKENS
+    )
     if compressed:
         # 心跳追加到尾部（disk 审计用，restore 时会被过滤）
         history = new_chat + heartbeat_msgs
-    else:
-        history = chat_msgs + heartbeat_msgs
+    # else: compact 未触发（LLM 摘要失败等），保持原 history 不变
 ```
 
+`compressor.maybe_compress` 需要相应改造：接受 `token_budget` 参数，用 `_estimate_tokens` 计算 window 大小（从尾部保留到 token 预算内的消息），替代固定的 `WINDOW_SIZE=60`。
+
 心跳消息保留在 disk 上（可审计），不参与 compact 决策，不参与 compact 内容。
+当 `chat_tokens <= COMPACT_TOKEN_BUDGET` 时，history 原样写入。
+
+**追加到尾部而非原位 merge 的原因**：compact 把旧 chat 重写为 summary pair + window，原位置信息丢失，夹在中间的心跳没有明确的归位规则。心跳在 restore 时全部过滤，disk 上的位置只影响审计可读性。
+
+**参数选择依据**：
+- `COMPACT_TOKEN_BUDGET=40_000`：Claude 200K context window，system prompt + skills 约占 10-20K，留给对话 ~40K 是合理的活动空间
+- `COMPACT_WINDOW_TOKENS=20_000`：compact 后保留最近 ~20K token 的对话，给下次 compact 留出 20K 的增长空间，避免频繁触发
 
 ### 2.3 restore：过滤心跳 + 现有 compact
 
@@ -193,18 +252,18 @@ session_data.history_messages = _evict_oldest_heartbeat(session_data.history_mes
 ### save_session (session.py)
 
 ```python
-# Before: 直接 compact 全量 history
+# Before: 按条数判断 compact
 compressed, new_history = await compressor.maybe_compress(serializable_history)
 
-# After: 计数排除心跳，compact 排除心跳，心跳追加尾部
-chat_count = sum(1 for m in serializable_history
-                 if not _is_heartbeat(m) and not _is_placeholder(m))
-if chat_count > COMPRESS_THRESHOLD:
+# After: 按 token 数判断，排除心跳
+chat_msgs = [m for m in serializable_history
+             if not _is_heartbeat(m) and not _is_placeholder(m)]
+if _estimate_tokens(chat_msgs) > COMPACT_TOKEN_BUDGET:
     heartbeat_msgs = [m for m in serializable_history
                       if _is_heartbeat(m) or _is_placeholder(m)]
-    chat_msgs = [m for m in serializable_history
-                 if not _is_heartbeat(m) and not _is_placeholder(m)]
-    compressed, new_chat = await compressor.maybe_compress(chat_msgs)
+    compressed, new_chat = await compressor.maybe_compress(
+        chat_msgs, token_budget=COMPACT_WINDOW_TOKENS
+    )
     if compressed:
         serializable_history = new_chat + heartbeat_msgs
 ```
@@ -222,7 +281,8 @@ history = DolphinStateAdapter.compact_session_state(history, max_messages=120)
 | 操作 | 文件 | 说明 |
 |------|------|------|
 | 改动 | `src/everbot/core/session/session_mailbox.py` | inject 后加心跳数量限制 |
-| 改动 | `src/everbot/core/session/session.py` | save 时排除心跳再判断 compact |
+| 改动 | `src/everbot/core/session/session.py` | save 时按 token 数判断 compact，排除心跳 |
+| 改动 | `src/everbot/core/session/compressor.py` | maybe_compress 接受 token_budget 参数，替代固定 WINDOW_SIZE |
 | 改动 | `src/everbot/core/session/persistence.py` | restore 时用 metadata 过滤心跳 |
 | 改动 | `src/everbot/core/runtime/cron_delivery.py` | 注入消息用结构化 metadata |
 | 改动 | `src/everbot/core/runtime/heartbeat.py` | 同上 |
@@ -231,20 +291,20 @@ history = DolphinStateAdapter.compact_session_state(history, max_messages=120)
 
 ## 5. 迁移策略
 
-### Phase 1：隔离心跳（立即止血）
+一步到位，不分 phase。
 
 - `inject_history_message` 加心跳消息上限（20 条），超限淘汰最老的（连带占位消息）
 - 心跳注入改用结构化 metadata（保留向后兼容的 content 前缀识别）
-- `save_session` compact 决策排除心跳消息计数
+- `save_session` compact 改为 token 预算驱动（`COMPACT_TOKEN_BUDGET=40K`），排除心跳
+- `compressor.maybe_compress` 接受 `token_budget` 参数，替代固定 `WINDOW_SIZE`
 - `restore_to_agent` 过滤改用 metadata 识别
 
-预期效果：心跳不再推动主对话触发压缩，消除最大的问题源。
+预期效果：心跳不再推动主对话触发压缩；compact 触发时机与真实 context 成本对齐。
 
-### Phase 2：token 预算驱动（可选，未来）
+### 后续优化（可选）
 
-- 引入轻量 token 计数（tiktoken 或字符数估算）
-- compact 阈值改为 token 数（如 `compress_token_budget=60000`）
 - 心跳消息按 task_id 去重（每个任务只保留最新一条结果）
+- `_estimate_tokens` 升级为真实 tokenizer（tiktoken），提升估算精度
 
 ## 6. 测试方案
 
@@ -319,14 +379,16 @@ def _legacy_heartbeat(content="结果正常"):
 ### 6.4 save compact 隔离测试（`class TestSaveCompact`）
 
 ```
-test_chat_below_threshold_no_compact
-  - 20 条 chat + 30 条心跳 → 总量 50 超旧阈值，但 chat 只有 20 条
+test_chat_below_token_budget_no_compact
+  - chat 部分 ~10K token + 心跳 ~5K token → 总量 15K
+  - chat_tokens < COMPACT_TOKEN_BUDGET，不触发
   - compressor.maybe_compress 未被调用
-  → 验证心跳不影响 compact 决策
+  → 验证心跳 token 不计入 compact 决策
 
-test_chat_above_threshold_triggers_compact
-  - 90 条 chat + 10 条心跳
-  - compressor.maybe_compress 被调用，且只传入 chat 部分
+test_chat_above_token_budget_triggers_compact
+  - chat 部分 ~50K token + 心跳 ~3K token
+  - chat_tokens > COMPACT_TOKEN_BUDGET
+  - compressor.maybe_compress 被调用，传入 token_budget=COMPACT_WINDOW_TOKENS
   → 验证只对 chat 做 compact
 
 test_heartbeat_preserved_on_disk_after_compact
@@ -342,6 +404,37 @@ test_heartbeat_appended_to_tail_after_compact
 test_no_heartbeat_same_as_before
   - 无心跳时，行为与现有逻辑完全一致
   → 回归验证
+```
+
+### 6.4b token 估算测试（`class TestEstimateTokens`）
+
+```
+test_simple_string_content
+  - 300 chars content → ~100 tokens + overhead
+
+test_list_content_with_text
+  - content 是 [{"type": "text", "text": "..."}] 格式
+  - 正确累加 text 部分
+
+test_empty_messages
+  - [] → 0
+
+test_tool_calls_counted
+  - assistant 消息含 tool_calls: [{"function": {"name": "bash", "arguments": '{"cmd":"ls -la"}'}}]
+  - 函数名 + 参数 JSON + tool_call id 都计入
+  - 验证: 比纯 content 消息估算值高
+
+test_tool_response_counted
+  - tool 消息含 tool_call_id + content
+  - tool_call_id 计入
+
+test_tool_heavy_vs_chat_only
+  - 构造: 10 条纯 chat（每条 100 chars）vs 10 条 tool chain（每条 100 chars content + 500 chars arguments）
+  - 验证: tool chain 估算值显著高于纯 chat（约 6 倍）
+
+test_message_overhead
+  - 单条空消息（content=""，无 tool_calls）
+  - 估算值 > 0（结构开销）
 ```
 
 ### 6.5 restore 过滤测试（`class TestRestoreFilter`）
@@ -380,7 +473,7 @@ test_inject_accumulation_then_save_then_restore
   - 交替注入 30 次心跳和 5 次 user_chat
   - 每次 inject 后调用 _evict_oldest_heartbeat
   - 验证: 心跳不超过 20 条
-  - save: compact 决策只看 chat 数量
+  - save: compact 决策按 chat token 数判断，心跳不计入
   - restore: 无心跳、无占位、DolphinStateAdapter 校验通过
 
 test_metadata_roundtrip

--- a/skills/paper-discovery/scripts/fetch_papers.py
+++ b/skills/paper-discovery/scripts/fetch_papers.py
@@ -51,7 +51,7 @@ def generate_one_line_summary(abstract: str) -> str:
 
         loop = asyncio.new_event_loop()
         try:
-            return loop.run_until_complete(asyncio.wait_for(_call(), timeout=30))
+            return loop.run_until_complete(asyncio.wait_for(_call(), timeout=90))
         finally:
             loop.close()
     except Exception as e:
@@ -64,7 +64,7 @@ def fetch_huggingface_papers(limit: int = 10) -> List[Dict[str, Any]]:
     url = f"https://huggingface.co/api/daily_papers?limit={limit}"
 
     try:
-        response = requests.get(url, timeout=30)
+        response = requests.get(url, timeout=90)
         response.raise_for_status()
         data = response.json()
     except (requests.exceptions.RequestException, ValueError) as e:
@@ -129,7 +129,7 @@ def fetch_arxiv_papers(category: str = "cs.AI", limit: int = 10) -> List[Dict[st
     )
 
     try:
-        response = requests.get(api_url, timeout=30)
+        response = requests.get(api_url, timeout=90)
         response.raise_for_status()
     except requests.exceptions.RequestException as e:
         print(f"Error fetching arXiv papers: {e}", file=sys.stderr)

--- a/skills/paper-discovery/scripts/fetch_papers.py
+++ b/skills/paper-discovery/scripts/fetch_papers.py
@@ -51,7 +51,7 @@ def generate_one_line_summary(abstract: str) -> str:
 
         loop = asyncio.new_event_loop()
         try:
-            return loop.run_until_complete(_call())
+            return loop.run_until_complete(asyncio.wait_for(_call(), timeout=30))
         finally:
             loop.close()
     except Exception as e:

--- a/src/everbot/core/runtime/cron_delivery.py
+++ b/src/everbot/core/runtime/cron_delivery.py
@@ -88,14 +88,15 @@ class CronDelivery:
         return True
 
     async def inject_to_history(self, result: str, run_id: str) -> bool:
-        """Inject result as an assistant message in primary session history."""
-        prefixed_content = (
-            "[此消息由心跳系统自动执行例行任务生成]\n\n"
-            + result
-        )
+        """Inject result as an assistant message in primary session history.
+
+        Heartbeat identification now relies on metadata.source == 'heartbeat'
+        rather than a content prefix.  The _is_heartbeat helper retains
+        backward-compatible prefix detection for legacy data.
+        """
         message = {
             "role": "assistant",
-            "content": prefixed_content,
+            "content": result,
             "metadata": {
                 "source": "heartbeat",
                 "run_id": run_id,

--- a/src/everbot/core/runtime/heartbeat.py
+++ b/src/everbot/core/runtime/heartbeat.py
@@ -545,14 +545,15 @@ If not, reply with `HEARTBEAT_OK`.
         return ok
 
     async def _inject_result_to_primary_history(self, result: str, run_id: str) -> bool:
-        """Inject heartbeat result as an assistant message in primary session history."""
-        prefixed_content = (
-            "[此消息由心跳系统自动执行例行任务生成]\n\n"
-            + result
-        )
+        """Inject heartbeat result as an assistant message in primary session history.
+
+        Heartbeat identification relies on metadata.source == 'heartbeat'.
+        The _is_heartbeat helper retains backward-compatible prefix detection
+        for legacy data.
+        """
         message = {
             "role": "assistant",
-            "content": prefixed_content,
+            "content": result,
             "metadata": {
                 "source": "heartbeat",
                 "run_id": run_id,

--- a/src/everbot/core/session/compressor.py
+++ b/src/everbot/core/session/compressor.py
@@ -49,25 +49,59 @@ class SessionCompressor:
     # ── Public API ────────────────────────────────────────────────────
 
     async def maybe_compress(
-        self, history_messages: List[Dict[str, Any]]
+        self,
+        history_messages: List[Dict[str, Any]],
+        token_budget: Optional[int] = None,
     ) -> Tuple[bool, List[Dict[str, Any]]]:
         """Compress *history_messages* if they exceed the threshold.
+
+        When *token_budget* is provided, the window is computed by token
+        count (accumulating from the tail until *token_budget* tokens are
+        reached) instead of the fixed ``WINDOW_SIZE`` message count.
+        The threshold check also switches to token-based: compression is
+        always attempted when *token_budget* is given (the caller already
+        checked that total tokens exceed COMPACT_TOKEN_BUDGET).
 
         Returns ``(compressed, new_history)`` where *compressed* indicates
         whether compression was actually performed.  The caller should use
         *new_history* in place of the original list.
         """
-        if len(history_messages) <= COMPRESS_THRESHOLD:
-            return False, history_messages
+        if token_budget is None:
+            # Legacy path: count-based threshold
+            if len(history_messages) <= COMPRESS_THRESHOLD:
+                return False, history_messages
 
         old_summary, remaining = extract_existing_summary(history_messages)
 
-        # Nothing to compress if remaining messages fit in the window.
-        if len(remaining) <= WINDOW_SIZE:
-            return False, history_messages
+        if token_budget is not None:
+            # Token-based window: accumulate from tail, always keeping at
+            # least the last message verbatim so the newest context is never
+            # entirely summarized away.
+            from .history_utils import _estimate_tokens
 
-        to_compress = remaining[:-WINDOW_SIZE]
-        to_keep = remaining[-WINDOW_SIZE:]
+            window_start = len(remaining)
+            accumulated = 0
+            for j in range(len(remaining) - 1, -1, -1):
+                msg_tokens = _estimate_tokens([remaining[j]])
+                if accumulated + msg_tokens > token_budget:
+                    break
+                accumulated += msg_tokens
+                window_start = j
+
+            # Guarantee at least the last message is kept verbatim.
+            # This prevents a single oversized message from pushing
+            # window_start to len(remaining) and yielding to_keep=[].
+            if window_start >= len(remaining) and remaining:
+                window_start = len(remaining) - 1
+
+            to_compress = remaining[:window_start]
+            to_keep = remaining[window_start:]
+        else:
+            # Legacy path: fixed message-count window
+            if len(remaining) <= WINDOW_SIZE:
+                return False, history_messages
+            to_compress = remaining[:-WINDOW_SIZE]
+            to_keep = remaining[-WINDOW_SIZE:]
 
         if not to_compress:
             return False, history_messages
@@ -88,6 +122,46 @@ class SessionCompressor:
             len(to_keep),
         )
         return True, inject_summary(new_summary, to_keep)
+
+    # ── High-level entry point ───────────────────────────────────────
+
+    async def compress_history(
+        self, history: List[Dict[str, Any]]
+    ) -> List[Dict[str, Any]]:
+        """Token-budget compress with heartbeat isolation.
+
+        Separates chat from heartbeat/placeholder, compresses only the chat
+        portion when it exceeds COMPACT_TOKEN_BUDGET, and re-appends heartbeat
+        messages to the tail.  Returns the (possibly compressed) history.
+
+        This is the single entry point used by both save paths
+        (session.py and persistence.py) to avoid logic duplication.
+        """
+        from .history_utils import (
+            _is_heartbeat,
+            _is_placeholder,
+            _estimate_tokens,
+            COMPACT_TOKEN_BUDGET,
+            COMPACT_WINDOW_TOKENS,
+        )
+
+        chat_msgs = [
+            m for m in history
+            if not _is_heartbeat(m) and not _is_placeholder(m)
+        ]
+        if _estimate_tokens(chat_msgs) <= COMPACT_TOKEN_BUDGET:
+            return history
+
+        heartbeat_msgs = [
+            m for m in history
+            if _is_heartbeat(m) or _is_placeholder(m)
+        ]
+        compressed, new_chat = await self.maybe_compress(
+            chat_msgs, token_budget=COMPACT_WINDOW_TOKENS,
+        )
+        if compressed:
+            return new_chat + heartbeat_msgs
+        return history
 
     # ── LLM interaction ──────────────────────────────────────────────
 

--- a/src/everbot/core/session/history_utils.py
+++ b/src/everbot/core/session/history_utils.py
@@ -1,0 +1,136 @@
+"""History policy utilities — heartbeat isolation and token-budget compact.
+
+Public API:
+- _is_heartbeat(msg) — identify heartbeat messages (metadata + legacy prefix)
+- _is_placeholder(msg) — identify placeholder messages (metadata + legacy content)
+- _estimate_tokens(messages) — estimate token count (chars // 3)
+- evict_oldest_heartbeat(history, max_heartbeat) — cap heartbeat count with FIFO eviction
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+MAX_HEARTBEAT_MESSAGES = 20
+COMPACT_TOKEN_BUDGET = 40_000
+COMPACT_WINDOW_TOKENS = 20_000
+
+_HEARTBEAT_PREFIX = "[此消息由心跳系统自动执行例行任务生成]"
+_PLACEHOLDER_CONTENTS = {"(acknowledged)", "[Background notification follows]"}
+
+# ── Token estimation ─────────────────────────────────────────────────
+
+_MSG_OVERHEAD = 12  # role/name/tool_call_id structural chars (~4 tokens)
+
+
+def _estimate_tokens(messages: List[dict]) -> int:
+    """Estimate token count for a message list.
+
+    Counts all content that would be sent to the LLM:
+    content, tool_calls (name + arguments + id), tool_call_id, plus
+    per-message structural overhead.
+
+    Ratio: 1 token ~ 3 chars (consistent with context_manager.py).
+    """
+    total_chars = 0
+    for msg in messages:
+        total_chars += _MSG_OVERHEAD
+
+        # content
+        content = msg.get("content") or ""
+        if isinstance(content, str):
+            total_chars += len(content)
+        elif isinstance(content, list):
+            for part in content:
+                if isinstance(part, dict):
+                    total_chars += len(str(part.get("text", "")))
+
+        # tool_calls (assistant messages)
+        for tc in msg.get("tool_calls") or []:
+            fn = tc.get("function") or {}
+            total_chars += len(fn.get("name") or "")
+            total_chars += len(fn.get("arguments") or "")
+            total_chars += len(tc.get("id") or "")
+
+        # tool_call_id (tool response messages)
+        total_chars += len(msg.get("tool_call_id") or "")
+
+    return total_chars // 3
+
+
+# ── Message classification ───────────────────────────────────────────
+
+
+def _is_heartbeat(msg: dict) -> bool:
+    """Identify heartbeat messages (new metadata format + legacy content prefix)."""
+    meta = msg.get("metadata")
+    if isinstance(meta, dict) and meta.get("source") == "heartbeat":
+        return True
+    content = msg.get("content") or ""
+    return isinstance(content, str) and content.startswith(_HEARTBEAT_PREFIX)
+
+
+def _is_placeholder(msg: dict) -> bool:
+    """Identify placeholder messages (new metadata format + legacy content match).
+
+    Legacy placeholders have no metadata — identified by exact content match.
+    This is consistent with persistence.py's existing _filter_heartbeat_messages.
+    """
+    meta = msg.get("metadata")
+    if isinstance(meta, dict) and meta.get("category") == "placeholder":
+        return True
+    content = msg.get("content")
+    return isinstance(content, str) and content in _PLACEHOLDER_CONTENTS
+
+
+# ── Heartbeat eviction ───────────────────────────────────────────────
+
+
+def evict_oldest_heartbeat(
+    history: List[dict],
+    max_heartbeat: int = MAX_HEARTBEAT_MESSAGES,
+) -> List[dict]:
+    """Evict oldest heartbeat messages (and their placeholders) to stay under *max_heartbeat*.
+
+    Algorithm: two-pass scan.
+    Pass 1: find heartbeat indices, determine which to evict (oldest N).
+    Pass 2: filter out evicted heartbeats + bound placeholders (by run_id for new format,
+             by position heuristic for legacy format).
+    """
+    heartbeat_indices = [i for i, m in enumerate(history) if _is_heartbeat(m)]
+    if len(heartbeat_indices) <= max_heartbeat:
+        return history
+
+    to_evict = set(heartbeat_indices[: len(heartbeat_indices) - max_heartbeat])
+
+    # Collect run_ids of evicted heartbeats (new format placeholder matching)
+    evict_run_ids: set = set()
+    for idx in to_evict:
+        meta = history[idx].get("metadata")
+        if isinstance(meta, dict) and meta.get("run_id"):
+            evict_run_ids.add(meta["run_id"])
+
+    result: List[dict] = []
+    for i, msg in enumerate(history):
+        if i in to_evict:
+            continue
+
+        # New-format placeholder: metadata.run_id in eviction set
+        meta = msg.get("metadata")
+        if (
+            isinstance(meta, dict)
+            and meta.get("run_id") in evict_run_ids
+            and meta.get("category") == "placeholder"
+        ):
+            continue
+
+        # Legacy placeholder: immediately before an evicted heartbeat
+        if _is_placeholder(msg) and (i + 1) in to_evict:
+            continue
+        # Legacy placeholder pair: (acknowledged) two positions before evicted heartbeat
+        if _is_placeholder(msg) and (i + 2) in to_evict:
+            if i + 1 < len(history) and _is_placeholder(history[i + 1]):
+                continue
+
+        result.append(msg)
+    return result

--- a/src/everbot/core/session/session.py
+++ b/src/everbot/core/session/session.py
@@ -515,9 +515,7 @@ class SessionManager:
         if SessionManager.infer_session_type(session_id) in ("primary", "channel"):
             try:
                 compressor = SessionCompressor(context)
-                compressed, new_history = await compressor.maybe_compress(serializable_history)
-                if compressed:
-                    serializable_history = new_history
+                serializable_history = await compressor.compress_history(serializable_history)
             except Exception:
                 logger.warning("History compression failed; saving uncompressed", exc_info=True)
 

--- a/src/everbot/core/session/session_mailbox.py
+++ b/src/everbot/core/session/session_mailbox.py
@@ -11,6 +11,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Any, Callable, Dict, Optional, TYPE_CHECKING
 
 from .session_data import SessionData
+from .history_utils import evict_oldest_heartbeat
 
 if TYPE_CHECKING:
     from .session import SessionManager
@@ -171,18 +172,20 @@ async def inject_history_message(
 
         # --- Heartbeat/deferred assistant after unanswered user question ---
         msg_source = (msg_obj.get("metadata") or {}).get("source", "")
+        msg_run_id = (msg_obj.get("metadata") or {}).get("run_id")
         if (
             msg_role == "assistant"
             and msg_source in ("heartbeat", "deferred_result")
             and last_msg is not None
             and last_msg.get("role") == "user"
         ):
-            session_data.history_messages.append(
-                {"role": "assistant", "content": "(acknowledged)"}
-            )
-            session_data.history_messages.append(
-                {"role": "user", "content": "[Background notification follows]"}
-            )
+            _ack = {"role": "assistant", "content": "(acknowledged)"}
+            _bg = {"role": "user", "content": "[Background notification follows]"}
+            if msg_run_id:
+                _ack["metadata"] = {"source": "system", "category": "placeholder", "run_id": msg_run_id}
+                _bg["metadata"] = {"source": "system", "category": "placeholder", "run_id": msg_run_id}
+            session_data.history_messages.append(_ack)
+            session_data.history_messages.append(_bg)
 
         # --- Consecutive user message guard ---
         elif (
@@ -195,6 +198,7 @@ async def inject_history_message(
             )
 
         session_data.history_messages.append(msg_obj)
+        session_data.history_messages = evict_oldest_heartbeat(session_data.history_messages)
 
     updated = await mgr.update_atomic(session_id, _mutator, timeout=timeout, blocking=blocking)
     if updated is not None:


### PR DESCRIPTION
## Summary
Fix infinite hang issue in paper-discovery skill by adding timeout protection to LLM calls and HTTP requests.

## Problem
The `generate_one_line_summary()` function could hang indefinitely when LLM calls stall, causing the entire paper fetch task to run for hours (current task has been running for 9+ hours since 01:12).

## Solution
- Add 90s timeout to `asyncio.wait_for()` wrapper in `_call()` function
- Increase HTTP request timeouts from 30s to 90s for consistency
- Graceful timeout handling allows task to complete even if individual paper summarization fails

## Changes
- `skills/paper-discovery/references/fetch_papers.py`: 3 lines modified
  - Line 54: LLM call timeout 30s → 90s
  - Line 67: HTTP timeout 30s → 90s  
  - Line 132: HTTP timeout 30s → 90s

## Testing
- [ ] Run paper fetch task and verify completion within expected time (< 5 minutes for 10 papers)