### PR TITLE
feat(inspector): enrich reflection with multi-dimensional context change detection

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ where = ["src"]
 testpaths = ["tests"]
 pythonpath = ["."]
 asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
 markers = [
     "slow: marks tests as slow",
 ]

--- a/src/everbot/core/runtime/heartbeat.py
+++ b/src/everbot/core/runtime/heartbeat.py
@@ -677,9 +677,12 @@ If not, reply with `HEARTBEAT_OK`.
                         self._write_heartbeat_event("reflect_skipped", reason="disabled")
                         self._record_timeline_event("turn_end", run_id, status="completed", result="HEARTBEAT_OK")
                         return "HEARTBEAT_OK"
-                    if self._inspector.should_skip():
-                        logger.info("[%s] Reflection skipped: files unchanged since last reflect", self.agent_name)
-                        self._write_heartbeat_event("reflect_skipped", reason="file_unchanged")
+                    if self._inspector.should_skip(
+                        session_manager=self.session_manager,
+                        primary_session_id=self.primary_session_id,
+                    ):
+                        logger.info("[%s] Reflection skipped: no context change since last reflect", self.agent_name)
+                        self._write_heartbeat_event("reflect_skipped", reason="no_context_change")
                         self._record_timeline_event("turn_end", run_id, status="completed", result="HEARTBEAT_OK")
                         self._record_runtime_metric("heartbeat_reflect_skipped")
                         return "HEARTBEAT_OK"
@@ -1245,6 +1248,16 @@ If not, reply with `HEARTBEAT_OK`.
 4. 若无可执行动作，回复 "HEARTBEAT_OK"
 {memory_section}
 当前 HEARTBEAT.md 内容：
+{heartbeat_content}
+"""
+
+            if mode == "reflect_json":
+                # heartbeat_content here is actually the enriched prompt
+                # built by Inspector._build_reflect_prompt(), passed through
+                # the inject_context(agent, reflect_prompt, mode="reflect_json") call.
+                return f"""
+{header}
+
 {heartbeat_content}
 """
 

--- a/src/everbot/core/runtime/inspector.py
+++ b/src/everbot/core/runtime/inspector.py
@@ -1,26 +1,31 @@
 """Inspector — heartbeat reflection observation engine.
 
-Observes session context, MEMORY.md, and task execution stats to discover
-and register new routine tasks. Does NOT execute any tasks — that is the
-Cron side of the heartbeat.
+Observes session context, MEMORY.md, task execution stats, and recent events to discover
+and register new routine tasks. Does NOT execute any tasks — that is the Cron side
+of the heartbeat.
 
 Wraps ReflectionManager internally and exposes a clean ``inspect()`` method
 that the Scheduler / HeartbeatRunner can call on a reflection tick.
 """
 
+import hashlib
 import json
 import logging
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
+from ...infra.user_data import get_user_data_manager
 from ..models.system_event import build_system_event
 from .reflection import ReflectionManager
 
 logger = logging.getLogger(__name__)
 
 SUMMARY_MAX_CHARS = 500
+
+# State file for tracking inspection context changes
+INSPECTOR_STATE_FILE = ".inspector_state.json"
 
 
 # ── Result types ─────────────────────────────────────────────
@@ -31,8 +36,10 @@ class InspectionContext:
     """Context provided to the reflection LLM call."""
 
     memory_content: Optional[str] = None
+    heartbeat_content: Optional[str] = None
     session_summary: Optional[str] = None
     task_execution_stats: Dict[str, Any] = field(default_factory=dict)
+    recent_events: List[Dict[str, Any]] = field(default_factory=list)
     existing_routines: List[Any] = field(default_factory=list)
 
 
@@ -40,6 +47,8 @@ class InspectionContext:
 class InspectionResult:
     """Outcome of one inspection cycle."""
 
+    heartbeat_ok: bool = True
+    push_message: Optional[str] = None
     proposals: List[dict] = field(default_factory=list)
     skipped: bool = False
     skip_reason: Optional[str] = None
@@ -76,203 +85,546 @@ class Inspector:
         self.workspace_path = Path(workspace_path)
         self.routine_manager = routine_manager
         self.auto_register_routines = auto_register_routines
+        self._force_interval = timedelta(hours=reflect_force_interval_hours)
 
         self._reflection = reflection_manager or ReflectionManager(
             workspace_path=self.workspace_path,
-            force_interval=timedelta(hours=reflect_force_interval_hours),
+            force_interval=self._force_interval,
         )
 
-    # ── Public API ────────────────────────────────────────────
+        self._state_path = self._resolve_state_path()
 
-    def should_skip(self) -> bool:
-        """Check whether inspection can be skipped (files unchanged + force interval not elapsed)."""
-        return self._reflection.should_skip_reflection()
+        # Restore ReflectionManager in-memory state from persisted state
+        # so that process restarts don't force an unnecessary LLM call.
+        persisted = self._load_state()
+        if persisted.get("last_run_at"):
+            try:
+                self._reflection.last_reflect_at = datetime.fromisoformat(
+                    persisted["last_run_at"]
+                )
+                self._reflection.last_reflect_file_hashes = (
+                    self._reflection.compute_file_hashes()
+                )
+            except (TypeError, ValueError):
+                pass
+
+    # ── State Management ───────────────────────────────────────
+
+    def _resolve_state_path(self) -> Path:
+        """Resolve persisted inspector state path outside the workspace root."""
+        try:
+            return (
+                get_user_data_manager().get_agent_tmp_dir(self.agent_name)
+                / INSPECTOR_STATE_FILE
+            )
+        except Exception as exc:
+            logger.debug("Failed to resolve inspector state path from user data: %s", exc)
+            return self.workspace_path / INSPECTOR_STATE_FILE
+
+    def _load_state(self) -> Dict[str, Any]:
+        """Load persisted inspector state."""
+        try:
+            if self._state_path.exists():
+                return json.loads(self._state_path.read_text(encoding="utf-8"))
+        except Exception as exc:
+            logger.debug("Failed to load inspector state: %s", exc)
+        return {}
+
+    def _persist_state(self, state: Dict[str, Any]) -> None:
+        """Persist inspector state."""
+        try:
+            self._state_path.parent.mkdir(parents=True, exist_ok=True)
+            self._state_path.write_text(
+                json.dumps(state, ensure_ascii=False, indent=2),
+                encoding="utf-8",
+            )
+        except Exception as exc:
+            logger.debug("Failed to persist inspector state: %s", exc)
+
+    def _compute_context_hashes(self, ctx: InspectionContext) -> Dict[str, str]:
+        """Compute hashes for all context components to detect changes."""
+        hashes: Dict[str, str] = {
+            "session_summary": hashlib.md5(
+                str(ctx.session_summary or "").encode("utf-8")
+            ).hexdigest(),
+            "task_stats": hashlib.md5(
+                json.dumps(ctx.task_execution_stats, sort_keys=True).encode("utf-8")
+            ).hexdigest(),
+            "events": hashlib.md5(
+                json.dumps(ctx.recent_events, sort_keys=True).encode("utf-8")
+            ).hexdigest(),
+            "memory": hashlib.md5(str(ctx.memory_content or "").encode("utf-8")).hexdigest(),
+            "heartbeat": hashlib.md5(
+                str(ctx.heartbeat_content or "").encode("utf-8")
+            ).hexdigest(),
+        }
+        return hashes
+
+    # ── Context Gathering ──────────────────────────────────────
+
+    def _gather_context(
+        self,
+        heartbeat_content: str,
+        session_manager: Optional[Any] = None,
+        primary_session_id: Optional[str] = None,
+    ) -> InspectionContext:
+        """Gather enriched context for reflection prompt."""
+        memory_path = self.workspace_path / "MEMORY.md"
+        memory_content = None
+        if memory_path.exists():
+            try:
+                memory_content = memory_path.read_text(encoding="utf-8")
+            except Exception as exc:
+                logger.debug("Failed to read MEMORY.md: %s", exc)
+
+        # Get session summary from primary session
+        session_summary = None
+        if session_manager and primary_session_id:
+            try:
+                summary = session_manager.get_session_summary(
+                    primary_session_id, max_chars=SUMMARY_MAX_CHARS
+                )
+                if isinstance(summary, str) and summary.strip():
+                    session_summary = summary
+            except Exception as exc:
+                logger.debug("Failed to get session summary: %s", exc)
+
+        # Get task execution stats
+        task_stats = self._gather_task_stats()
+
+        # Get recent events (last 24h)
+        recent_events = self._gather_recent_events()
+
+        # Get existing routines
+        existing_routines = []
+        if self.routine_manager:
+            try:
+                existing_routines = list(self.routine_manager.list_routines())
+            except Exception as exc:
+                logger.debug("Failed to list routines: %s", exc)
+
+        return InspectionContext(
+            memory_content=memory_content,
+            heartbeat_content=heartbeat_content,
+            session_summary=session_summary,
+            task_execution_stats=task_stats,
+            recent_events=recent_events,
+            existing_routines=existing_routines,
+        )
+
+    def _gather_task_stats(self) -> Dict[str, Any]:
+        """Gather task execution statistics."""
+        stats = {"total": 0, "failed": 0, "pending": 0, "last_24h": 0}
+        try:
+            if self.routine_manager and hasattr(self.routine_manager, "list_routines"):
+                tasks = list(self.routine_manager.list_routines())
+                stats["total"] = len(tasks)
+                now = datetime.now()
+                for task in tasks:
+                    task_state = None
+                    if isinstance(task, dict):
+                        task_state = task.get("state") or task.get("status")
+                        last_run_at = task.get("last_run_at")
+                    else:
+                        task_state = getattr(task, "state", None) or getattr(
+                            task, "status", None
+                        )
+                        last_run_at = getattr(task, "last_run_at", None)
+
+                    if task_state == "failed":
+                        stats["failed"] += 1
+                    elif task_state == "pending":
+                        stats["pending"] += 1
+
+                    if not last_run_at:
+                        continue
+                    try:
+                        last_run = datetime.fromisoformat(str(last_run_at))
+                    except (TypeError, ValueError):
+                        continue
+                    if last_run.tzinfo is not None:
+                        now_for_compare = datetime.now(last_run.tzinfo)
+                    else:
+                        now_for_compare = now
+                    if (now_for_compare - last_run).total_seconds() < 86400:
+                        stats["last_24h"] += 1
+        except Exception as exc:
+            logger.debug("Failed to gather task stats: %s", exc)
+        return stats
+
+    def _gather_recent_events(self, hours: int = 24) -> List[Dict[str, Any]]:
+        """Gather recent system events."""
+        events = []
+        try:
+            user_data = get_user_data_manager()
+            events_file = user_data.heartbeat_events_file
+            if events_file.exists():
+                cutoff = datetime.now() - timedelta(hours=hours)
+                with open(events_file, "r", encoding="utf-8") as f:
+                    for line in f:
+                        try:
+                            event = json.loads(line.strip())
+                            ts = event.get("timestamp")
+                            if ts:
+                                event_time = datetime.fromisoformat(ts)
+                                if event_time >= cutoff:
+                                    events.append(event)
+                        except Exception:
+                            continue
+        except Exception as exc:
+            logger.debug("Failed to gather recent events: %s", exc)
+        return events[-10:]  # Limit to 10 most recent
+
+    # ── Reflection entrypoint ──────────────────────────────────
+
+    # ── Skip / state logic ─────────────────────────────────────
+
+    def _should_inspect(self, ctx: InspectionContext) -> bool:
+        """Return True if inspection should proceed based on context changes.
+
+        Checks ReflectionManager's file-based logic first, then persisted
+        context hashes for enriched change detection.
+        """
+        # Check ReflectionManager's built-in file-change / force-interval logic
+        rm_decision = None
+        if hasattr(self._reflection, 'should_skip_reflection'):
+            try:
+                rm_skip = self._reflection.should_skip_reflection()
+                if not rm_skip:
+                    return True  # files changed or force interval elapsed
+                rm_decision = "skip"  # RM says skip (files unchanged)
+            except Exception:
+                pass
+
+        state = self._load_state()
+        last_hashes = state.get("context_hashes", {})
+        last_run_at = state.get("last_run_at")
+
+        # Check force interval from persisted state
+        if self._force_interval and last_run_at:
+            last_time = datetime.fromisoformat(last_run_at)
+            if datetime.now() - last_time >= self._force_interval:
+                return True
+
+        # If RM already checked and no persisted state exists, trust RM
+        if not last_hashes:
+            if rm_decision == "skip":
+                return False  # RM says files unchanged, no prior enriched state
+            return True  # first time ever
+
+        # Compare context hashes
+        current_hashes = self._compute_context_hashes(ctx)
+        for key, current_hash in current_hashes.items():
+            if last_hashes.get(key) != current_hash:
+                return True
+
+        return False
+
+    def should_skip(
+        self,
+        *,
+        session_manager: Optional[Any] = None,
+        primary_session_id: Optional[str] = None,
+    ) -> bool:
+        """Public API: check if inspection can be skipped (backward compat).
+
+        Gathers context internally and delegates to ``_should_inspect``.
+        """
+        heartbeat_path = self.workspace_path / "HEARTBEAT.md"
+        heartbeat_content = ""
+        if heartbeat_path.exists():
+            try:
+                heartbeat_content = heartbeat_path.read_text(encoding="utf-8")
+            except Exception:
+                pass
+
+        ctx = self._gather_context(
+            heartbeat_content,
+            session_manager=session_manager,
+            primary_session_id=primary_session_id,
+        )
+        return not self._should_inspect(ctx)
+
+    def update_state(
+        self,
+        ctx: Optional[InspectionContext] = None,
+        result: Optional[InspectionResult] = None,
+    ) -> None:
+        """Persist context hashes after a successful inspection.
+
+        Args:
+            ctx: pre-gathered context (gathered internally if omitted).
+            result: inspection result (unused, kept for API symmetry).
+        """
+        # Update ReflectionManager's state for backward compatibility
+        if hasattr(self._reflection, 'update_reflect_state'):
+            try:
+                self._reflection.update_reflect_state()
+            except Exception:
+                pass
+
+        if ctx is None:
+            heartbeat_path = self.workspace_path / "HEARTBEAT.md"
+            heartbeat_content = ""
+            if heartbeat_path.exists():
+                try:
+                    heartbeat_content = heartbeat_path.read_text(encoding="utf-8")
+                except Exception:
+                    pass
+            ctx = self._gather_context(heartbeat_content)
+
+        state = {
+            "last_run_at": datetime.now().isoformat(),
+            "context_hashes": self._compute_context_hashes(ctx),
+        }
+        self._persist_state(state)
 
     async def inspect(
         self,
         *,
-        run_agent: Callable,
-        inject_context: Callable,
+        run_agent: Callable[..., Any],
+        inject_context: Callable[..., Any],
         agent: Any,
         heartbeat_content: str,
         run_id: str,
-        session_manager: Any = None,
+        session_manager: Optional[Any] = None,
         primary_session_id: Optional[str] = None,
-        agent_name: Optional[str] = None,
     ) -> InspectionResult:
-        """Execute one inspection cycle.
+        """Run one inspection cycle.
 
-        Args:
-            run_agent: async callable ``(agent, user_message) -> str``
-            inject_context: async callable ``(agent, content, mode="reflect") -> str``
-            agent: the LLM agent instance
-            heartbeat_content: raw HEARTBEAT.md content
-            run_id: current heartbeat run id
-            session_manager: optional, needed for mailbox deposit when not auto-registering
-            primary_session_id: optional, needed for mailbox deposit
-            agent_name: override agent_name for logging (defaults to self.agent_name)
+        If ``auto_register_routines`` is True, new routines are auto-registered.
+        Otherwise, proposals are deposited to the primary session mailbox.
         """
-        effective_agent_name = agent_name or self.agent_name
+        # Gather enriched context once
+        ctx = self._gather_context(heartbeat_content, session_manager, primary_session_id)
 
-        # 1. Skip check
-        if self.should_skip():
-            logger.info(
-                "[%s] Inspection skipped: files unchanged since last reflect",
-                effective_agent_name,
-            )
-            self._write_event("inspect_skipped", reason="file_unchanged")
+        # Check if we should skip
+        if not self._should_inspect(ctx):
+            self._write_event("inspect_skipped", reason="no_context_change")
             return InspectionResult(
                 skipped=True,
-                skip_reason="file_unchanged",
+                skip_reason="no_context_change",
+                output="HEARTBEAT_OK",
             )
 
-        # 2. Inject reflection context and run LLM
-        user_message = await inject_context(agent, heartbeat_content, mode="reflect")
-        response = await run_agent(agent, user_message)
+        # Build enriched prompt and inject into agent
+        reflect_prompt = self._build_reflect_prompt(ctx)
+        user_message = await inject_context(agent, reflect_prompt, mode="reflect_json")
 
-        # 3. Record state after successful LLM call
-        self.update_state()
-
-        # 4. Extract proposals
-        proposals = self._reflection.extract_routine_proposals(response)
-
-        if not proposals:
-            logger.debug(
-                "[%s] Inspection produced no proposals, returning HEARTBEAT_OK",
-                effective_agent_name,
+        # Run LLM
+        try:
+            response = await run_agent(agent, user_message)
+        except Exception as exc:
+            logger.warning("LLM reflection failed: %s", exc)
+            return InspectionResult(
+                heartbeat_ok=False,
+                output=f"LLM_ERROR: {exc}",
             )
-            self._write_event("inspect", result="ok")
-            return InspectionResult(output="HEARTBEAT_OK")
 
-        # 5. Apply or deposit proposals
-        self._write_event("inspect", result="proposals", proposal_count=len(proposals))
+        # Parse response (unified format)
+        parsed = self._reflection.extract_unified_response(response)
 
-        if self.auto_register_routines:
-            return self._apply_proposals(proposals, run_id, effective_agent_name)
-        else:
-            return await self._deposit_proposals(
-                proposals,
-                run_id,
-                effective_agent_name,
+        # Update state after successful LLM call
+        self.update_state(ctx)
+
+        result = InspectionResult(
+            heartbeat_ok=parsed.heartbeat_ok,
+            push_message=parsed.push_message,
+            output="HEARTBEAT_OK" if parsed.heartbeat_ok else "HEARTBEAT_ERROR",
+        )
+
+        # Handle routine proposals
+        if parsed.routines:
+            result.proposals = parsed.routines
+            result.applied, result.deposited = await self._apply_proposals(
+                proposals=parsed.routines,
                 session_manager=session_manager,
                 primary_session_id=primary_session_id,
+                run_id=run_id,
             )
 
-    def update_state(self) -> None:
-        """Record state after a successful inspection (delegates to ReflectionManager)."""
-        self._reflection.update_reflect_state()
+        # Deliver push message if present
+        if result.push_message and session_manager and primary_session_id:
+            delivered = await self._deliver_push_message(
+                result=result,
+                session_manager=session_manager,
+                primary_session_id=primary_session_id,
+                run_id=run_id,
+            )
+            if delivered:
+                result.deposited += 1
 
-    # ── Internal ──────────────────────────────────────────────
-
-    def _apply_proposals(
-        self,
-        proposals: List[dict],
-        run_id: str,
-        agent_name: str,
-    ) -> InspectionResult:
-        """Auto-register proposals via RoutineManager."""
-        added: List[dict] = []
-        skipped_duplicates = 0
-        failed = 0
-
-        for raw in proposals:
-            normalized = self._reflection.normalize_routine(raw)
-            if normalized is None:
-                continue
-            try:
-                created = self.routine_manager.add_routine(**normalized)
-                added.append(created)
-            except ValueError as exc:
-                detail = str(exc)
-                if "duplicate routine" in detail or "task_id already exists" in detail:
-                    skipped_duplicates += 1
-                else:
-                    failed += 1
-                    logger.warning(
-                        "Inspector routine apply rejected: agent=%s run_id=%s title=%s reason=%s",
-                        agent_name, run_id,
-                        normalized.get("title", ""), detail,
-                    )
-            except Exception as exc:
-                failed += 1
-                logger.warning(
-                    "Inspector routine apply failed: agent=%s run_id=%s title=%s error=%s",
-                    agent_name, run_id,
-                    normalized.get("title", ""), str(exc),
-                )
-
-        lines = [f"Registered {len(added)} routine(s) from heartbeat inspection."]
-        for item in added[:5]:
-            title = str(item.get("title") or "")
-            schedule = str(item.get("schedule") or "manual")
-            lines.append(f"- {title} ({schedule})")
-        if skipped_duplicates > 0:
-            lines.append(f"Skipped duplicates: {skipped_duplicates}.")
-        if failed > 0:
-            lines.append(f"Failed to apply: {failed}.")
-
-        output = "\n".join(lines) if added else "HEARTBEAT_OK"
-
-        return InspectionResult(
-            proposals=proposals,
-            applied=len(added),
-            output=output,
+        self._write_event(
+            "inspection_complete",
+            heartbeat_ok=result.heartbeat_ok,
+            push_message=bool(result.push_message),
+            proposals_count=len(result.proposals),
+            applied=result.applied,
+            deposited=result.deposited,
+            run_id=run_id,
         )
 
-    async def _deposit_proposals(
+        return result
+
+    def _build_reflect_prompt(self, ctx: InspectionContext) -> str:
+        """Build reflection prompt with enriched context."""
+        sections = []
+
+        # Memory section
+        if ctx.memory_content:
+            sections.append(f"# MEMORY.md\n{ctx.memory_content[:2000]}")
+
+        # Heartbeat section
+        if ctx.heartbeat_content:
+            sections.append(f"# HEARTBEAT.md\n{ctx.heartbeat_content[:2000]}")
+
+        # Session summary section
+        if ctx.session_summary:
+            sections.append(f"# Recent Session Summary\n{ctx.session_summary}")
+
+        # Task stats section
+        if ctx.task_execution_stats:
+            stats_text = json.dumps(ctx.task_execution_stats, indent=2)
+            sections.append(f"# Task Execution Stats\n{stats_text}")
+
+        # Recent events section
+        if ctx.recent_events:
+            events_text = json.dumps(ctx.recent_events[:5], indent=2)
+            sections.append(f"# Recent Events (last 24h)\n{events_text}")
+
+        # Existing routines section
+        if ctx.existing_routines:
+            routines_text = "\n".join(
+                f"- {r.title if hasattr(r, 'title') else r.get('title', 'unknown')}"
+                for r in ctx.existing_routines[:10]
+            )
+            sections.append(f"# Existing Routines\n{routines_text}")
+
+        # Instructions
+        sections.append(
+            """# Reflection Instructions
+
+Analyze the above context and determine:
+1. Is the system healthy? (heartbeat_ok: true/false)
+2. Are there urgent issues requiring immediate user attention? (push_message)
+3. Should any new routine tasks be proposed? (routines)
+
+Respond in this exact JSON format:
+```json
+{
+  "heartbeat_ok": true,
+  "push_message": null,
+  "routines": []
+}
+```
+
+- heartbeat_ok: false indicates system issues needing attention
+- push_message: optional urgent notification for the user (delivered immediately)
+- routines: array of routine task proposals (same format as before)"""
+        )
+
+        return "\n\n".join(sections)
+
+    async def _apply_proposals(
         self,
         proposals: List[dict],
+        session_manager: Optional[Any],
+        primary_session_id: Optional[str],
         run_id: str,
-        agent_name: str,
-        *,
-        session_manager: Any = None,
-        primary_session_id: Optional[str] = None,
-    ) -> InspectionResult:
-        """Deposit proposals to the primary session mailbox for user review."""
-        lines = [f"Heartbeat inspection proposed {len(proposals)} routine(s) for review:"]
-        normalized_list: List[dict] = []
+    ) -> Tuple[int, int]:
+        """Apply routine proposals via auto-register or deposit to mailbox."""
+        applied = 0
+        deposited = 0
+
         for raw in proposals:
             normalized = self._reflection.normalize_routine(raw)
             if normalized is None:
                 continue
-            normalized_list.append(normalized)
-            title = normalized.get("title", "")
-            schedule = normalized.get("schedule") or "manual"
-            lines.append(f"- {title} ({schedule})")
 
-        summary = "\n".join(lines)
+            if self.auto_register_routines:
+                try:
+                    self.routine_manager.add_routine(**normalized)
+                    applied += 1
+                    self._write_event(
+                        "routine_auto_registered",
+                        title=normalized.get("title"),
+                        run_id=run_id,
+                    )
+                except ValueError as exc:
+                    detail = str(exc)
+                    if "duplicate routine" in detail or "task_id already exists" in detail:
+                        logger.debug("Skipping duplicate routine: %s", normalized.get("title"))
+                    else:
+                        logger.warning("Failed to auto-register routine: %s", exc)
+                except Exception as exc:
+                    logger.warning("Failed to auto-register routine: %s", exc)
+            else:
+                # Deposit to mailbox for user review
+                if session_manager and primary_session_id:
+                    try:
+                        event = build_system_event(
+                            event_type="routine_proposal",
+                            source_session_id=f"inspector:{self.agent_name}",
+                            summary=f"Routine proposal: {normalized.get('title', '')}",
+                            detail=normalized.get("description", ""),
+                            artifacts=[normalized],
+                            priority=1,
+                            suppress_if_stale=False,
+                            dedupe_key=f"routine_proposal:{self.agent_name}:{normalized.get('title')}:{run_id}",
+                        )
+                        await session_manager.deposit_mailbox_event(
+                            primary_session_id,
+                            event,
+                            timeout=5.0,
+                            blocking=True,
+                        )
+                        deposited += 1
+                        self._write_event(
+                            "routine_proposal_deposited",
+                            title=normalized.get("title"),
+                            run_id=run_id,
+                        )
+                    except Exception as exc:
+                        logger.warning("Failed to deposit proposal: %s", exc)
 
-        if session_manager is not None and primary_session_id is not None:
+        return applied, deposited
+
+    async def _deliver_push_message(
+        self,
+        result: InspectionResult,
+        session_manager: Optional[Any],
+        primary_session_id: Optional[str],
+        run_id: str,
+    ) -> bool:
+        """Deliver urgent push message to primary session."""
+        if not session_manager or not primary_session_id or not result.push_message:
+            return False
+
+        try:
             event = build_system_event(
-                event_type="routine_proposal",
-                source_session_id=f"inspector:{agent_name}",
-                summary=summary[:SUMMARY_MAX_CHARS],
-                detail=json.dumps(normalized_list, ensure_ascii=False, indent=2),
+                event_type="inspector_push",
+                source_session_id=f"inspector:{self.agent_name}",
+                summary=result.push_message[:SUMMARY_MAX_CHARS],
+                detail=result.push_message,
                 artifacts=[],
-                priority=0,
+                priority=1,
                 suppress_if_stale=False,
-                dedupe_key=f"routine_proposal:{agent_name}:{run_id}",
+                dedupe_key=f"inspector_push:{self.agent_name}:{run_id}",
             )
             await session_manager.deposit_mailbox_event(
-                primary_session_id, event, timeout=5.0, blocking=True,
+                primary_session_id,
+                event,
+                timeout=5.0,
+                blocking=True,
             )
-        else:
-            logger.warning(
-                "[%s] Cannot deposit proposals: session_manager or primary_session_id not provided",
-                agent_name,
-            )
-
-        return InspectionResult(
-            proposals=proposals,
-            deposited=len(normalized_list),
-            output=summary,
-        )
+            return True
+        except Exception as exc:
+            logger.warning("Failed to deliver push message: %s", exc)
+            return False
 
     def _write_event(self, event_type: str, **kwargs: Any) -> None:
         """Write a structured event to heartbeat_events.jsonl."""
         try:
-            from ...infra.user_data import get_user_data_manager
-
             user_data = get_user_data_manager()
             events_file = user_data.heartbeat_events_file
             events_file.parent.mkdir(parents=True, exist_ok=True)

--- a/src/everbot/core/runtime/reflection.py
+++ b/src/everbot/core/runtime/reflection.py
@@ -3,12 +3,35 @@
 import hashlib
 import json
 import re
+from dataclasses import dataclass
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Optional, Any, Dict
+from typing import Optional, Any, Dict, List
 import logging
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ParsedReflectionResponse:
+    """Parsed unified reflection response.
+
+    Expected LLM output format:
+    {
+        "heartbeat_ok": bool,
+        "push_message": str | null,
+        "routines": [...] | null
+    }
+    """
+
+    heartbeat_ok: bool = True
+    push_message: Optional[str] = None
+    routines: Optional[List[Dict[str, Any]]] = None
+    raw_response: str = ""
+
+    def __post_init__(self):
+        if self.routines is None:
+            self.routines = []
 
 
 class ReflectionManager:
@@ -61,8 +84,111 @@ class ReflectionManager:
         self.last_reflect_file_hashes = self.compute_file_hashes()
 
     @staticmethod
+    def _parse_heartbeat_ok(value: Any) -> bool:
+        """Parse heartbeat_ok with string compatibility for LLM JSON output."""
+        if isinstance(value, bool):
+            return value
+        if value is None:
+            return True
+        if isinstance(value, (int, float)):
+            return bool(value)
+        if isinstance(value, str):
+            normalized = value.strip().lower()
+            if normalized in {"true", "1", "yes", "y", "ok"}:
+                return True
+            if normalized in {"false", "0", "no", "n", "null", "none", ""}:
+                return False
+        return bool(value)
+
+    @staticmethod
+    def extract_unified_response(response: str) -> ParsedReflectionResponse:
+        """Parse unified reflection response format.
+
+        Expected format:
+        {
+            "heartbeat_ok": bool,
+            "push_message": str | null,
+            "routines": [...] | null
+        }
+
+        Backward compatible: if response contains only "routines" array
+        without the wrapper, it will be parsed as heartbeat_ok=true,
+        push_message=null, routines=[...]
+        """
+        result = ParsedReflectionResponse(raw_response=response)
+
+        if not isinstance(response, str) or not response.strip():
+            return result
+
+        json_text = None
+
+        # Try code blocks first
+        for match in re.finditer(r"```json\s*(\{.*?\})\s*```", response, re.DOTALL):
+            try:
+                json_text = match.group(1)
+                payload = json.loads(json_text)
+                # Check if this looks like unified format
+                if isinstance(payload, dict) and ("heartbeat_ok" in payload or "push_message" in payload):
+                    break
+                json_text = None  # Keep looking if not unified format
+            except Exception:
+                continue
+
+        # Try raw JSON if no unified format code block found
+        if json_text is None:
+            start = response.find("{")
+            end = response.rfind("}")
+            if start != -1 and end != -1 and end > start:
+                try:
+                    json_text = response[start : end + 1]
+                    payload = json.loads(json_text)
+                    if not isinstance(payload, dict):
+                        json_text = None
+                except Exception:
+                    json_text = None
+
+        if json_text is None:
+            # No valid JSON found
+            return result
+
+        try:
+            payload = json.loads(json_text)
+        except json.JSONDecodeError:
+            return result
+
+        if not isinstance(payload, dict):
+            return result
+
+        # Parse unified format fields
+        result.heartbeat_ok = ReflectionManager._parse_heartbeat_ok(
+            payload.get("heartbeat_ok", True)
+        )
+
+        push_msg = payload.get("push_message")
+        if push_msg and isinstance(push_msg, str):
+            push_msg = push_msg.strip()
+            if push_msg.lower() not in ("null", "none", ""):
+                result.push_message = push_msg
+
+        routines = payload.get("routines")
+        if isinstance(routines, list):
+            result.routines = [item for item in routines if isinstance(item, dict)]
+
+        return result
+
+    @staticmethod
     def extract_routine_proposals(response: str) -> list[dict[str, Any]]:
-        """Extract routine proposals from reflection response JSON payload."""
+        """Extract routine proposals from reflection response JSON payload.
+
+        Backward compatible: works with both old format (just routines array)
+        and new unified format.
+        """
+        # First try unified format
+        unified = ReflectionManager.extract_unified_response(response)
+        if unified.routines:
+            return unified.routines
+
+        # Fall back to legacy extraction
         if not isinstance(response, str) or not response.strip():
             return []
 

--- a/tests/integration/test_heartbeat_token_optimizations.py
+++ b/tests/integration/test_heartbeat_token_optimizations.py
@@ -19,6 +19,17 @@ from src.everbot.core.runtime.heartbeat import HeartbeatRunner
 from src.everbot.core.tasks.task_manager import Task, TaskList, TaskState
 
 
+class _StubUserDataManager:
+    """Test double that redirects inspector state into the workspace."""
+
+    def __init__(self, base_dir: Path):
+        self._base_dir = base_dir
+        self.heartbeat_events_file = base_dir / "heartbeat_events.jsonl"
+
+    def get_agent_tmp_dir(self, agent_name: str) -> Path:
+        return self._base_dir / agent_name / "tmp"
+
+
 def _make_runner(workspace_path: Path = Path("."), **overrides) -> HeartbeatRunner:
     from contextlib import contextmanager
 
@@ -58,7 +69,16 @@ def _make_runner(workspace_path: Path = Path("."), **overrides) -> HeartbeatRunn
         "on_result": None,
     }
     defaults.update(overrides)
-    return HeartbeatRunner(**defaults)
+    stub_udm = _StubUserDataManager(workspace_path / ".alfred")
+    patcher = patch(
+        "src.everbot.core.runtime.inspector.get_user_data_manager",
+        return_value=stub_udm,
+    )
+    patcher.start()
+    runner = HeartbeatRunner(**defaults)
+    # Keep patch active for the runner's lifetime (inspector calls get_user_data_manager at runtime)
+    runner._udm_patcher = patcher
+    return runner
 
 
 def _write_heartbeat_md(workspace: Path, tasks: list[dict] | None = None) -> None:
@@ -282,8 +302,9 @@ class TestAgentCreationSkip:
         _write_heartbeat_md(tmp_path)
         (tmp_path / "MEMORY.md").write_text("stable", encoding="utf-8")
 
-        # Simulate prior reflect
+        # Simulate prior reflect (both RM and Inspector state)
         runner._update_reflect_state()
+        runner._inspector.update_state()
 
         get_agent_mock = AsyncMock()
         monkeypatch.setattr(runner, "_get_or_create_agent", get_agent_mock)
@@ -310,8 +331,9 @@ class TestAgentCreationSkip:
         _write_heartbeat_md(tmp_path)
         (tmp_path / "MEMORY.md").write_text("stable", encoding="utf-8")
 
-        # Simulate prior reflect so subsequent cycles skip
+        # Simulate prior reflect so subsequent cycles skip (both RM and Inspector state)
         runner._update_reflect_state()
+        runner._inspector.update_state()
 
         get_agent_mock = AsyncMock()
         monkeypatch.setattr(runner, "_get_or_create_agent", get_agent_mock)
@@ -344,6 +366,7 @@ class TestAgentCreationSkip:
         (tmp_path / "MEMORY.md").write_text("v1", encoding="utf-8")
 
         runner._update_reflect_state()
+        runner._inspector.update_state()
 
         # Change MEMORY.md
         (tmp_path / "MEMORY.md").write_text("v2 — new intentions", encoding="utf-8")

--- a/tests/unit/test_inspector.py
+++ b/tests/unit/test_inspector.py
@@ -1,6 +1,5 @@
 """Unit tests for Inspector — heartbeat reflection observation engine."""
 
-import asyncio
 import json
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -8,9 +7,24 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from src.everbot.core.runtime.inspector import Inspector, InspectionResult
+from src.everbot.core.runtime.inspector import (
+    Inspector,
+    InspectionResult,
+    InspectionContext,
+    INSPECTOR_STATE_FILE,
+)
 from src.everbot.core.runtime.reflection import ReflectionManager
 from src.everbot.core.tasks.routine_manager import RoutineManager
+
+
+class _StubUserDataManager:
+    """Test double for user data paths."""
+
+    def __init__(self, base_dir: Path):
+        self._base_dir = base_dir
+
+    def get_agent_tmp_dir(self, agent_name: str) -> Path:
+        return self._base_dir / agent_name / "tmp"
 
 
 def _make_inspector(tmp_path: Path, **overrides) -> Inspector:
@@ -23,7 +37,11 @@ def _make_inspector(tmp_path: Path, **overrides) -> Inspector:
         reflect_force_interval_hours=24,
     )
     defaults.update(overrides)
-    return Inspector(**defaults)
+    with patch(
+        "src.everbot.core.runtime.inspector.get_user_data_manager",
+        return_value=_StubUserDataManager(tmp_path / ".alfred"),
+    ):
+        return Inspector(**defaults)
 
 
 def _make_reflection_response_with_proposals(proposals: list[dict]) -> str:
@@ -37,23 +55,35 @@ def _make_reflection_response_no_proposals() -> str:
     return "Everything looks good. No new routines needed."
 
 
+def _make_reflection_response_v2_format(
+    heartbeat_ok: bool = True,
+    push_message: str = None,
+    routines: list = None,
+) -> str:
+    """Build an LLM response with the unified JSON format."""
+    payload = {
+        "heartbeat_ok": heartbeat_ok,
+        "push_message": push_message,
+        "routines": routines or [],
+    }
+    return f"```json\n{json.dumps(payload, ensure_ascii=False, indent=2)}\n```"
+
+
+# ── should_skip / _should_inspect ────────────────────────────
+
+
 class TestShouldSkip:
     """Tests for Inspector.should_skip() — file hash + time interval logic."""
 
     def test_skip_when_files_unchanged(self, tmp_path):
         """After update_state, should_skip returns True if files haven't changed."""
-        # Seed MEMORY.md so hashes are stable
         (tmp_path / "MEMORY.md").write_text("some memory content")
         (tmp_path / "HEARTBEAT.md").write_text("some heartbeat content")
 
         inspector = _make_inspector(tmp_path)
-        # First call: never reflected before, should NOT skip
         assert inspector.should_skip() is False
 
-        # Record state (simulates having just reflected)
         inspector.update_state()
-
-        # Files unchanged → should skip
         assert inspector.should_skip() is True
 
     def test_no_skip_when_force_interval_elapsed(self, tmp_path):
@@ -64,9 +94,7 @@ class TestShouldSkip:
         inspector = _make_inspector(tmp_path, reflect_force_interval_hours=1)
         inspector.update_state()
 
-        # Simulate time passage beyond force interval
         inspector._reflection.last_reflect_at = datetime.now() - timedelta(hours=2)
-
         assert inspector.should_skip() is False
 
     def test_no_skip_when_files_changed(self, tmp_path):
@@ -77,15 +105,254 @@ class TestShouldSkip:
         inspector = _make_inspector(tmp_path)
         inspector.update_state()
 
-        # Modify a file
         (tmp_path / "MEMORY.md").write_text("v2 - updated")
+        assert inspector.should_skip() is False
 
+    def test_no_skip_when_context_file_deleted(self, tmp_path):
+        """Deleting a previously tracked context file should trigger inspection."""
+        (tmp_path / "MEMORY.md").write_text("v1")
+        (tmp_path / "HEARTBEAT.md").write_text("v1")
+
+        inspector = _make_inspector(tmp_path)
+        inspector.update_state()
+
+        (tmp_path / "MEMORY.md").unlink()
         assert inspector.should_skip() is False
 
     def test_no_skip_when_never_reflected(self, tmp_path):
         """First call should never skip."""
         inspector = _make_inspector(tmp_path)
         assert inspector.should_skip() is False
+
+    def test_should_skip_includes_session_context(self, tmp_path):
+        """should_skip should use session summary for precheck decisions."""
+        (tmp_path / "MEMORY.md").write_text("memory")
+        (tmp_path / "HEARTBEAT.md").write_text("heartbeat")
+
+        inspector = _make_inspector(tmp_path)
+        session_manager = MagicMock()
+        session_manager.get_session_summary = MagicMock(return_value="summary v1")
+
+        assert inspector.should_skip(
+            session_manager=session_manager,
+            primary_session_id="primary_1",
+        ) is False
+
+        ctx = inspector._gather_context(
+            "heartbeat",
+            session_manager=session_manager,
+            primary_session_id="primary_1",
+        )
+        inspector.update_state(ctx, InspectionResult())
+
+        session_manager.get_session_summary.return_value = "summary v2"
+
+        assert inspector.should_skip(
+            session_manager=session_manager,
+            primary_session_id="primary_1",
+        ) is False
+
+
+# ── _should_inspect with enriched context ─────────────────────
+
+
+class TestShouldInspect:
+    """Tests for _should_inspect() with session/task/events context hashes."""
+
+    def test_detects_session_change(self, tmp_path):
+        """_should_inspect returns True when session_summary changes."""
+        inspector = _make_inspector(tmp_path)
+        (tmp_path / "MEMORY.md").write_text("memory")
+        (tmp_path / "HEARTBEAT.md").write_text("heartbeat")
+
+        context1 = InspectionContext(
+            memory_content="memory",
+            heartbeat_content="heartbeat",
+            session_summary="User asked about Python",
+            task_execution_stats={},
+            recent_events=[],
+        )
+
+        assert inspector._should_inspect(context1) is True
+        inspector.update_state(context1, InspectionResult())
+        assert inspector._should_inspect(context1) is False
+
+        context2 = InspectionContext(
+            memory_content="memory",
+            heartbeat_content="heartbeat",
+            session_summary="User asked about JavaScript",
+            task_execution_stats={},
+            recent_events=[],
+        )
+        assert inspector._should_inspect(context2) is True
+
+    def test_detects_task_stats_change(self, tmp_path):
+        """_should_inspect returns True when task_execution_stats changes."""
+        inspector = _make_inspector(tmp_path)
+        (tmp_path / "MEMORY.md").write_text("memory")
+        (tmp_path / "HEARTBEAT.md").write_text("heartbeat")
+
+        context1 = InspectionContext(
+            memory_content="memory",
+            heartbeat_content="heartbeat",
+            task_execution_stats={"completed": 5, "failed": 0},
+            recent_events=[],
+        )
+
+        assert inspector._should_inspect(context1) is True
+        inspector.update_state(context1, InspectionResult())
+        assert inspector._should_inspect(context1) is False
+
+        context2 = InspectionContext(
+            memory_content="memory",
+            heartbeat_content="heartbeat",
+            task_execution_stats={"completed": 6, "failed": 1},
+            recent_events=[],
+        )
+        assert inspector._should_inspect(context2) is True
+
+    def test_detects_events_change(self, tmp_path):
+        """_should_inspect returns True when recent_events changes."""
+        inspector = _make_inspector(tmp_path)
+        (tmp_path / "MEMORY.md").write_text("memory")
+        (tmp_path / "HEARTBEAT.md").write_text("heartbeat")
+
+        context1 = InspectionContext(
+            memory_content="memory",
+            heartbeat_content="heartbeat",
+            recent_events=[{"type": "error", "msg": "Connection failed"}],
+        )
+
+        assert inspector._should_inspect(context1) is True
+        inspector.update_state(context1, InspectionResult())
+        assert inspector._should_inspect(context1) is False
+
+        context2 = InspectionContext(
+            memory_content="memory",
+            heartbeat_content="heartbeat",
+            recent_events=[
+                {"type": "error", "msg": "Connection failed"},
+                {"type": "error", "msg": "Timeout"},
+            ],
+        )
+        assert inspector._should_inspect(context2) is True
+
+    def test_respects_force_interval(self, tmp_path):
+        """_should_inspect returns True when force interval elapsed even if context unchanged."""
+        inspector = _make_inspector(tmp_path, reflect_force_interval_hours=1)
+        (tmp_path / "MEMORY.md").write_text("memory")
+        (tmp_path / "HEARTBEAT.md").write_text("heartbeat")
+
+        context = InspectionContext(
+            memory_content="memory",
+            heartbeat_content="heartbeat",
+        )
+
+        assert inspector._should_inspect(context) is True
+        inspector.update_state(context, InspectionResult())
+        assert inspector._should_inspect(context) is False
+
+        state = inspector._load_state()
+        state["last_run_at"] = (datetime.now() - timedelta(hours=2)).isoformat()
+        inspector._persist_state(state)
+        inspector._reflection.last_reflect_at = datetime.now() - timedelta(hours=2)
+
+        assert inspector._should_inspect(context) is True
+
+
+# ── Context gathering ─────────────────────────────────────────
+
+
+class TestContextGathering:
+    """Tests for _gather_context() — session, task stats, events collection."""
+
+    def test_with_session_manager(self, tmp_path):
+        """_gather_context collects session summary when session_manager provided."""
+        inspector = _make_inspector(tmp_path)
+
+        mock_session_manager = MagicMock()
+        mock_session_manager.get_session_summary = MagicMock(
+            return_value="User asked about Python debugging"
+        )
+
+        context = inspector._gather_context(
+            heartbeat_content="test heartbeat",
+            session_manager=mock_session_manager,
+            primary_session_id="telegram_123",
+        )
+
+        assert context.session_summary == "User asked about Python debugging"
+        assert context.heartbeat_content == "test heartbeat"
+        mock_session_manager.get_session_summary.assert_called_once()
+
+    def test_without_session_manager(self, tmp_path):
+        """_gather_context works without session_manager (graceful degradation)."""
+        inspector = _make_inspector(tmp_path)
+
+        context = inspector._gather_context(
+            heartbeat_content="test heartbeat",
+            session_manager=None,
+            primary_session_id=None,
+        )
+
+        assert context.session_summary is None
+        assert context.heartbeat_content == "test heartbeat"
+        assert isinstance(context.task_execution_stats, dict)
+        assert isinstance(context.recent_events, list)
+
+    def test_with_task_stats(self, tmp_path):
+        """_gather_context includes task execution statistics."""
+        inspector = _make_inspector(tmp_path)
+
+        mock_routine_manager = MagicMock()
+        mock_routine_manager.list_routines = MagicMock(return_value=[
+            {"id": "routine_1", "title": "Daily Check", "enabled": True},
+        ])
+        inspector.routine_manager = mock_routine_manager
+
+        context = inspector._gather_context(
+            heartbeat_content="test",
+            session_manager=None,
+            primary_session_id=None,
+        )
+
+        assert isinstance(context.task_execution_stats, dict)
+
+    def test_reads_task_stats_from_list_routines(self, tmp_path):
+        """Task stats should be derived from RoutineManager.list_routines()."""
+        inspector = _make_inspector(tmp_path)
+
+        now = datetime.now(timezone.utc)
+        mock_routine_manager = MagicMock()
+        mock_routine_manager.list_routines = MagicMock(
+            return_value=[
+                {
+                    "id": "routine_1",
+                    "title": "Pending job",
+                    "state": "pending",
+                    "last_run_at": now.isoformat(),
+                },
+                {
+                    "id": "routine_2",
+                    "title": "Failed job",
+                    "state": "failed",
+                    "last_run_at": (now - timedelta(days=2)).isoformat(),
+                },
+            ]
+        )
+        inspector.routine_manager = mock_routine_manager
+
+        context = inspector._gather_context("test")
+
+        assert context.task_execution_stats == {
+            "total": 2,
+            "failed": 1,
+            "pending": 1,
+            "last_24h": 1,
+        }
+
+
+# ── inspect() main cycle ──────────────────────────────────────
 
 
 class TestInspect:
@@ -98,7 +365,7 @@ class TestInspect:
         (tmp_path / "HEARTBEAT.md").write_text("content")
 
         inspector = _make_inspector(tmp_path)
-        inspector.update_state()  # Mark as just reflected, files unchanged
+        inspector.update_state()
 
         run_agent = AsyncMock()
         inject_context = AsyncMock()
@@ -113,7 +380,7 @@ class TestInspect:
             )
 
         assert result.skipped is True
-        assert result.skip_reason == "file_unchanged"
+        assert result.skip_reason == "no_context_change"
         assert result.output == "HEARTBEAT_OK"
         run_agent.assert_not_called()
         inject_context.assert_not_called()
@@ -139,6 +406,8 @@ class TestInspect:
         assert result.proposals == []
         assert result.output == "HEARTBEAT_OK"
         assert result.applied == 0
+        inject_context.assert_awaited_once()
+        assert inject_context.await_args.kwargs["mode"] == "reflect_json"
 
     @pytest.mark.asyncio
     async def test_proposals_auto_register(self, tmp_path):
@@ -169,8 +438,7 @@ class TestInspect:
         assert len(result.proposals) == 1
         assert result.applied == 1
         assert result.deposited == 0
-        assert "Registered 1 routine" in result.output
-        assert "Daily digest" in result.output
+        assert result.output == "HEARTBEAT_OK"
 
     @pytest.mark.asyncio
     async def test_proposals_deposit_to_mailbox(self, tmp_path):
@@ -183,7 +451,7 @@ class TestInspect:
         run_agent = AsyncMock(return_value=_make_reflection_response_with_proposals(proposals))
         inject_context = AsyncMock(return_value="reflected prompt")
 
-        session_manager = AsyncMock()
+        session_manager = MagicMock()
         session_manager.deposit_mailbox_event = AsyncMock(return_value=True)
 
         with patch.object(inspector, "_write_event"):
@@ -201,12 +469,12 @@ class TestInspect:
         assert len(result.proposals) == 1
         assert result.deposited == 1
         assert result.applied == 0
-        assert "proposed 1 routine" in result.output
+        assert result.output == "HEARTBEAT_OK"
         session_manager.deposit_mailbox_event.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_proposals_deposit_without_session_manager(self, tmp_path):
-        """When no session_manager is provided, deposit logs a warning but doesn't crash."""
+        """When no session_manager is provided, deposit doesn't crash."""
         inspector = _make_inspector(tmp_path, auto_register_routines=False)
 
         proposals = [
@@ -222,11 +490,9 @@ class TestInspect:
                 agent=MagicMock(),
                 heartbeat_content="hb content",
                 run_id="run_005",
-                # no session_manager or primary_session_id
             )
 
-        # Should still succeed — just can't deposit
-        assert result.deposited == 1
+        assert result.deposited == 0
         assert len(result.proposals) == 1
 
     @pytest.mark.asyncio
@@ -243,7 +509,6 @@ class TestInspect:
             {"title": "Daily digest", "schedule": "24h", "description": "Send daily digest"},
         ]
 
-        # First inspection — registers the routine
         run_agent = AsyncMock(return_value=_make_reflection_response_with_proposals(proposals))
         inject_context = AsyncMock(return_value="reflected prompt")
 
@@ -258,8 +523,6 @@ class TestInspect:
 
         assert result1.applied == 1
 
-        # Second inspection — same proposal, should be skipped as duplicate
-        # Reset the reflection state so it doesn't skip the inspection itself
         inspector._reflection.last_reflect_at = None
 
         with patch.object(inspector, "_write_event"):
@@ -279,6 +542,7 @@ class TestInspect:
         """update_state is called after LLM call to record file hashes."""
         inspector = _make_inspector(tmp_path)
         (tmp_path / "MEMORY.md").write_text("content")
+        (tmp_path / "HEARTBEAT.md").write_text("hb")
 
         run_agent = AsyncMock(return_value=_make_reflection_response_no_proposals())
         inject_context = AsyncMock(return_value="prompt")
@@ -292,5 +556,324 @@ class TestInspect:
                 run_id="run_008",
             )
 
-        # After inspect, should_skip should return True (files unchanged)
         assert inspector.should_skip() is True
+
+
+# ── New output format {heartbeat_ok, push_message, routines} ──
+
+
+class TestNewOutputFormat:
+    """Tests for unified LLM output format."""
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_ok_true_no_push(self, tmp_path):
+        """When heartbeat_ok=true and no push_message, result is HEARTBEAT_OK."""
+        inspector = _make_inspector(tmp_path)
+        (tmp_path / "MEMORY.md").write_text("content")
+
+        response = _make_reflection_response_v2_format(heartbeat_ok=True)
+
+        run_agent = AsyncMock(return_value=response)
+        inject_context = AsyncMock(return_value="prompt")
+
+        with patch.object(inspector, "_write_event"):
+            result = await inspector.inspect(
+                run_agent=run_agent,
+                inject_context=inject_context,
+                agent=MagicMock(),
+                heartbeat_content="hb",
+                run_id="run_v2_001",
+            )
+
+        assert result.heartbeat_ok is True
+        assert result.push_message is None
+        assert result.output == "HEARTBEAT_OK"
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_ok_false_with_push(self, tmp_path):
+        """When heartbeat_ok=false with push_message, result reflects that."""
+        inspector = _make_inspector(tmp_path)
+        (tmp_path / "MEMORY.md").write_text("content")
+
+        response = _make_reflection_response_v2_format(
+            heartbeat_ok=False,
+            push_message="Detected anomalous task failures",
+        )
+
+        run_agent = AsyncMock(return_value=response)
+        inject_context = AsyncMock(return_value="prompt")
+
+        with patch.object(inspector, "_write_event"):
+            result = await inspector.inspect(
+                run_agent=run_agent,
+                inject_context=inject_context,
+                agent=MagicMock(),
+                heartbeat_content="hb",
+                run_id="run_v2_002",
+            )
+
+        assert result.heartbeat_ok is False
+        assert result.push_message == "Detected anomalous task failures"
+        assert result.output == "HEARTBEAT_ERROR"
+
+    def test_string_false_heartbeat_ok_is_parsed_as_false(self):
+        """String false must not be treated as a truthy heartbeat result."""
+        response = _make_reflection_response_v2_format(
+            heartbeat_ok="false",
+            push_message="Need attention",
+        )
+        parsed = ReflectionManager.extract_unified_response(response)
+        assert parsed.heartbeat_ok is False
+
+    def test_string_true_heartbeat_ok_is_parsed_as_true(self):
+        """String true should still be treated as a healthy heartbeat result."""
+        response = _make_reflection_response_v2_format(
+            heartbeat_ok="true",
+        )
+        parsed = ReflectionManager.extract_unified_response(response)
+        assert parsed.heartbeat_ok is True
+
+    @pytest.mark.asyncio
+    async def test_push_message_extraction(self, tmp_path):
+        """Non-routine push_message is extracted and returned separately."""
+        inspector = _make_inspector(tmp_path)
+        (tmp_path / "MEMORY.md").write_text("content")
+
+        response = _make_reflection_response_v2_format(
+            heartbeat_ok=True,
+            push_message="User requested feature X - needs manual review",
+        )
+
+        run_agent = AsyncMock(return_value=response)
+        inject_context = AsyncMock(return_value="prompt")
+
+        mock_session_manager = MagicMock()
+        mock_session_manager.deposit_mailbox_event = AsyncMock(return_value=True)
+
+        with patch.object(inspector, "_write_event"):
+            result = await inspector.inspect(
+                run_agent=run_agent,
+                inject_context=inject_context,
+                agent=MagicMock(),
+                heartbeat_content="hb",
+                run_id="run_v2_003",
+                session_manager=mock_session_manager,
+                primary_session_id="telegram_123",
+            )
+
+        assert result.push_message == "User requested feature X - needs manual review"
+        assert result.proposals == []
+
+    @pytest.mark.asyncio
+    async def test_combined_routines_and_push(self, tmp_path):
+        """LLM can return both routines and push_message simultaneously."""
+        inspector = _make_inspector(tmp_path)
+        (tmp_path / "MEMORY.md").write_text("content")
+
+        response = _make_reflection_response_v2_format(
+            heartbeat_ok=True,
+            push_message="I've identified some improvements",
+            routines=[{
+                "title": "New Routine",
+                "schedule": "1h",
+                "description": "Test routine",
+            }],
+        )
+
+        run_agent = AsyncMock(return_value=response)
+        inject_context = AsyncMock(return_value="prompt")
+
+        with patch.object(inspector, "_write_event"):
+            result = await inspector.inspect(
+                run_agent=run_agent,
+                inject_context=inject_context,
+                agent=MagicMock(),
+                heartbeat_content="hb",
+                run_id="run_v2_004",
+            )
+
+        assert result.push_message == "I've identified some improvements"
+        assert len(result.proposals) == 1
+        assert result.proposals[0]["title"] == "New Routine"
+
+
+# ── Push message delivery ─────────────────────────────────────
+
+
+class TestPushMessageDelivery:
+    """Tests for push message delivery to primary session."""
+
+    @pytest.mark.asyncio
+    async def test_unhealthy_push_message_not_reused_as_result_output(self, tmp_path):
+        """Unhealthy push_message should be deposited once and not mirrored in output."""
+        inspector = _make_inspector(tmp_path)
+        (tmp_path / "MEMORY.md").write_text("content")
+
+        response = _make_reflection_response_v2_format(
+            heartbeat_ok=False,
+            push_message="Important notification",
+        )
+
+        run_agent = AsyncMock(return_value=response)
+        inject_context = AsyncMock(return_value="prompt")
+
+        mock_session_manager = MagicMock()
+        mock_session_manager.deposit_mailbox_event = AsyncMock(return_value=True)
+
+        with patch.object(inspector, "_write_event"):
+            result = await inspector.inspect(
+                run_agent=run_agent,
+                inject_context=inject_context,
+                agent=MagicMock(),
+                heartbeat_content="hb",
+                run_id="run_v2_004b",
+                session_manager=mock_session_manager,
+                primary_session_id="telegram_123",
+            )
+
+        assert result.output == "HEARTBEAT_ERROR"
+        assert result.push_message == "Important notification"
+        assert result.deposited == 1
+        mock_session_manager.deposit_mailbox_event.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_push_message_deposited_to_session(self, tmp_path):
+        """When push_message exists and session_manager provided, deposit event."""
+        inspector = _make_inspector(tmp_path)
+        (tmp_path / "MEMORY.md").write_text("content")
+
+        response = _make_reflection_response_v2_format(
+            heartbeat_ok=True,
+            push_message="Important notification",
+        )
+
+        run_agent = AsyncMock(return_value=response)
+        inject_context = AsyncMock(return_value="prompt")
+
+        mock_session_manager = MagicMock()
+        mock_session_manager.deposit_mailbox_event = AsyncMock(return_value=True)
+
+        with patch.object(inspector, "_write_event"):
+            result = await inspector.inspect(
+                run_agent=run_agent,
+                inject_context=inject_context,
+                agent=MagicMock(),
+                heartbeat_content="hb",
+                run_id="run_v2_005",
+                session_manager=mock_session_manager,
+                primary_session_id="telegram_123",
+            )
+
+        assert result.deposited == 1
+        mock_session_manager.deposit_mailbox_event.assert_called_once()
+        call_args = mock_session_manager.deposit_mailbox_event.call_args
+        assert call_args[0][0] == "telegram_123"
+
+    @pytest.mark.asyncio
+    async def test_no_deposit_without_session_manager(self, tmp_path):
+        """When no session_manager, push_message is set but not deposited."""
+        inspector = _make_inspector(tmp_path)
+        (tmp_path / "MEMORY.md").write_text("content")
+
+        response = _make_reflection_response_v2_format(
+            heartbeat_ok=True,
+            push_message="Important notification",
+        )
+
+        run_agent = AsyncMock(return_value=response)
+        inject_context = AsyncMock(return_value="prompt")
+
+        with patch.object(inspector, "_write_event"):
+            result = await inspector.inspect(
+                run_agent=run_agent,
+                inject_context=inject_context,
+                agent=MagicMock(),
+                heartbeat_content="hb",
+                run_id="run_v2_006",
+                session_manager=None,
+                primary_session_id=None,
+            )
+
+        assert result.push_message == "Important notification"
+        assert result.deposited == 0
+
+    @pytest.mark.asyncio
+    async def test_no_deposit_without_primary_session(self, tmp_path):
+        """When no primary_session_id, push_message is set but not deposited."""
+        inspector = _make_inspector(tmp_path)
+        (tmp_path / "MEMORY.md").write_text("content")
+
+        response = _make_reflection_response_v2_format(
+            heartbeat_ok=True,
+            push_message="Important notification",
+        )
+
+        run_agent = AsyncMock(return_value=response)
+        inject_context = AsyncMock(return_value="prompt")
+
+        mock_session_manager = MagicMock()
+
+        with patch.object(inspector, "_write_event"):
+            result = await inspector.inspect(
+                run_agent=run_agent,
+                inject_context=inject_context,
+                agent=MagicMock(),
+                heartbeat_content="hb",
+                run_id="run_v2_007",
+                session_manager=mock_session_manager,
+                primary_session_id=None,
+            )
+
+        assert result.push_message == "Important notification"
+        assert result.deposited == 0
+        mock_session_manager.deposit_mailbox_event.assert_not_called()
+
+
+# ── State persistence ─────────────────────────────────────────
+
+
+class TestStatePersistence:
+    """Tests for .inspector_state.json persistence."""
+
+    def test_state_file_created_after_inspect(self, tmp_path):
+        """State file is created in user data tmp after successful inspection."""
+        inspector = _make_inspector(tmp_path)
+        (tmp_path / "MEMORY.md").write_text("content")
+
+        context = InspectionContext(
+            memory_content="content",
+            session_summary="test session",
+        )
+        result = InspectionResult(heartbeat_ok=True)
+
+        inspector.update_state(context, result)
+
+        state_file = tmp_path / ".alfred" / "test_agent" / "tmp" / INSPECTOR_STATE_FILE
+        assert state_file.exists()
+        assert not (tmp_path / INSPECTOR_STATE_FILE).exists()
+
+        state = json.loads(state_file.read_text())
+        assert "context_hashes" in state
+        assert "last_run_at" in state
+        assert "session_summary" in state["context_hashes"]
+
+    def test_state_loaded_on_init(self, tmp_path):
+        """Existing state file is loaded when Inspector is created."""
+        state = {
+            "last_run_at": datetime.now().isoformat(),
+            "context_hashes": {
+                "memory": "abc123",
+                "heartbeat": "def456",
+                "session_summary": "session_hash",
+                "task_stats": "task_hash",
+                "events": "events_hash",
+            },
+        }
+        state_file = tmp_path / ".alfred" / "test_agent" / "tmp" / INSPECTOR_STATE_FILE
+        state_file.parent.mkdir(parents=True, exist_ok=True)
+        state_file.write_text(json.dumps(state))
+
+        inspector = _make_inspector(tmp_path)
+        loaded = inspector._load_state()
+
+        assert loaded["context_hashes"]["session_summary"] == "session_hash"


### PR DESCRIPTION
  ## Summary

  - Inspector 的 skip 判断从单纯文件哈希扩展为多维上下文变化检测（session summary、task execution stats、recent events、memory、heartbeat）
  - 新增统一 LLM 输出格式 `{heartbeat_ok, push_message, routines}`，支持 push message 即时投递到主会话 mailbox
  - Inspector 状态持久化至 user data 目录，进程重启后自动恢复，避免无谓 LLM 调用
  - 合并 `test_inspector_v2.py` 到 `test_inspector.py`，集成测试隔离全局状态

  ## Test plan

  - [x] 1098 tests passed, 0 failed
  - [x] Inspector unit tests 覆盖 skip logic / context gathering / inspect cycle / output format / push delivery / state persistence
  - [x] 集成测试通过 `_StubUserDataManager` 隔离，不依赖全局 `~/.alfred/` 状态