### PR TITLE
Feat/refactor coding master

### DIFF
--- a/skills/coding-master/SKILL.md
+++ b/skills/coding-master/SKILL.md
@@ -1,66 +1,66 @@
 ---
 name: coding-master
-description: "Code review, analysis, development, and ops for registered repos — review uncommitted changes, check git status, search code, run tests, fix bugs, develop features, and submit PRs"
-version: "0.1.0"
+description: "Code review, development, and ops for registered repos"
+version: "0.2.0"
 tags: [coding, review, development, bugfix, pr, automation]
 ---
 
 # Coding Master Skill
 
-All commands use: `$D = python $SKILL_DIR/scripts/dispatch.py`
+`$D = python $SKILL_DIR/scripts/dispatch.py`
 
-All commands return JSON: `{"ok": true, "data": {...}}` or `{"ok": false, "error": "...", "error_code": "..."}`. Always check `ok`. On error, check `error_code` and `hint` field for actionable recovery.
+All commands return JSON `{"ok": true, "data": {...}}` or `{"ok": false, "error_code": "...", "hint": "..."}`.
+On failure, follow `hint` to recover.
 
-## Available Operations
+## Core Commands
 
-根据用户意图自主选择操作并组合执行，不强制走预定义流程。参数不确定时先跑 `$D <command> --help`。
+| Command | Description | timeout |
+|---------|-------------|---------|
+| `$D status --repos <name>` | git status / diff overview | default |
+| `$D find --repos <name> --query <pattern>` | Search code | default |
+| `$D analyze --repos <name> --task "<desc>"` | Engine deep analysis | 600 |
+| `$D auto-dev --repos <name> --task "<desc>"` | Develop + test (one step) | 600 |
+| `$D submit --repos <name> --title "<title>"` | Commit + push + create PR (auto-releases workspace) | default |
+| `$D release --workspace <ws>` | Release workspace lock | default |
 
-### 只读操作（无需 workspace lock）
+> Commands without explicit timeout use 120s default.
 
-| 命令 | 说明 |
-|------|------|
-| `$D quick-status --repos <name>` | git 状态/diff |
-| `$D quick-test --repos <name> [--path PATH] [--lint]` | 跑测试 |
-| `$D quick-find --repos <name> --query <pattern> [--glob GLOB]` | 搜索代码 |
-| `$D analyze --repos <name> --task "<desc>" [--engine ENGINE]` | 引擎深度分析（timeout=600） |
+### auto-dev Options
 
-### 写入操作（需要 workspace lock）
+- `--branch <name>` — specify branch name (auto-generated if omitted)
+- `--engine <claude|codex>` — specify engine (default from config)
+- `--feature next` — develop next task from feature plan
+- `--workspace <name>` — use existing workspace (required for feature mode)
+- `--repo <name>` — target repo in multi-repo workspace
+- `--plan "<desc>"` — specify implementation plan
+- `--allow-complex` — skip complexity check, force single auto-dev
+- `--reset-worktree` — clean uncommitted changes before developing
 
-流程：`workspace-check` → 写入操作 → `release`。workspace-check 返回的 `data.snapshot.workspace.name` 即 `<ws>`。
+### auto-dev Behavior
 
-| 命令 | 说明 |
-|------|------|
-| `$D workspace-check --repos <name> --task "<desc>" [--engine ENGINE]` | 获取锁，返回 workspace |
-| `$D develop --workspace <ws> --task "<desc>" [--engine ENGINE]` | 引擎写代码（timeout=600） |
-| `$D test --workspace <ws>` | 工作区内跑测试 |
-| `$D submit-pr --workspace <ws> [--repo <name>] --title "<title>" [--body "<body>"]` | 提交 PR（多 repo workspace 须指定 `--repo`） |
-| `$D release --workspace <ws>` | 释放锁（必须） |
+- Execution unit is a **single target repo**
+- `--repos <name>` only supports single repo; multiple repos → `TASK_TOO_COMPLEX`
+- Multi-repo workspace requires explicit `--repo <name>`; otherwise → `NEED_EXPLICIT_REPO`
+- Engine develops code, runs tests, and fixes until tests pass (internal loop)
+- Dispatch runs final verification independently after engine completes
 
-### 复杂度判断
+### Submitting PRs
 
-**直接组合操作**（多数场景）：单步或明确指令，直接组合上面的命令
-- "提交 pr" → workspace-check + submit-pr + release
-- "跑下测试" → quick-test --repos
-- "看看有什么问题" → analyze --repos
+auto-dev does NOT auto-submit PRs. After tests pass:
 
-**启动 workflow**（复杂任务）：需要 research→plan→implement→verify 闭环、预计超 20 次工具调用、多文件修改+测试验证 → 加载 SOP 后按流程执行
+- repo mode: `$D submit --repos <name> --title "<title>"`
+- workspace / feature mode: `$D submit --workspace <ws> --title "<title>"`
 
-### 参考文档（复杂任务时加载）
+`submit` auto-releases workspace on success. Add `--keep-lock` to keep working.
 
-| 文档 | 加载命令 |
-|------|---------|
-| sop-quick-queries.md | `_load_skill_resource("coding-master", "references/sop-quick-queries.md")` |
-| sop-deep-review.md | `_load_skill_resource("coding-master", "references/sop-deep-review.md")` |
-| sop-bugfix-workflow.md | `_load_skill_resource("coding-master", "references/sop-bugfix-workflow.md")` |
-| sop-feature-dev.md | `_load_skill_resource("coding-master", "references/sop-feature-dev.md")` |
+## Rules
 
-## Common Rules
+- **All code operations must go through $D commands** — never use bare `_bash` for repo operations
+- Engine commands (analyze, auto-dev) need `timeout=600`
+- On failure, check `error_code` + `hint` and follow instructions
+- After `auto-dev` / `submit`, release workspace if not continuing development
+- Never push to main/master. Never force push. Never auto-merge PRs.
 
-- **禁止裸 bash 执行开发/测试操作**: 所有测试、搜索、开发操作**必须**通过 `$D` 命令执行（`$D test`, `$D quick-test --repos`, `$D quick-find` 等）。**严禁**直接用 `_bash` 拼写 `cd ... && pytest`、`pip install`、`python -m pytest` 等命令。dispatch 会自动处理正确的 Python 解释器、venv 路径、依赖和 workspace 上下文。
-- **`--workspace` 可省略**: 当只有一个活跃 workspace 时，`test`、`develop`、`submit-pr` 等命令会自动检测，无需手动指定 `--workspace`。
-- **Review uses `--repos`**: Review/analysis is read-only — use `analyze --repos <name>` directly. No `workspace-check` or `release` needed. Only bugfix and feature-dev flows require workspace lock.
-- **Engine commands need long timeout**: `analyze` and `develop` take 2-5 minutes. Always use `_bash(cmd="...", timeout=600)` for engine commands. If timeout returns a `command_id`, continue waiting with `_bash(command_id="...", timeout=300)` — do NOT cancel.
-- **Engine fallback**: If `ENGINE_ERROR`, retry with the other engine (`codex`↔`claude`). If both fail, do it yourself, but `test`, `submit-pr`, `release` **must** go through `$D`.
-- **Error handling**: Always check `error_code` + `hint`. `PATH_NOT_FOUND` → run `config-list` for correct names. `WORKSPACE_LOCKED` → use `--repos` for read-only fallback.
-- **Safety**: Never push to main/master. Never force push. Never auto-merge PRs. Always release workspace when done.
-- **User confirmation**: WAIT for user at workspace-check, plan confirmation, test results, and PR submission.
+> More commands (workspace management, feature splitting, env probing, etc.):
+> `_load_skill_resource("coding-master", "references/full-command-reference.md")`
+> or `$D --help`

--- a/skills/coding-master/references/full-command-reference.md
+++ b/skills/coding-master/references/full-command-reference.md
@@ -1,0 +1,102 @@
+# Coding Master — Full Command Reference
+
+`$D = python $SKILL_DIR/scripts/dispatch.py`
+
+## Read-Only Operations (no workspace lock needed)
+
+| Command | Description |
+|---------|-------------|
+| `$D status --repos <name>` | git status/diff (alias: `quick-status`) |
+| `$D find --repos <name> --query <pattern> [--glob GLOB]` | Search code (alias: `quick-find`) |
+| `$D quick-test --repos <name> [--path PATH] [--lint]` | Run tests |
+| `$D quick-env --env <name> [--commands CMD...]` | Probe remote env |
+| `$D analyze --repos <name> --task "<desc>" [--engine ENGINE]` | Deep analysis (timeout=600) |
+
+All read-only commands also accept `--workspace <ws>` to operate on a locked workspace.
+
+## One-Step Development
+
+| Command | Description |
+|---------|-------------|
+| `$D auto-dev --repos <name> --task "<desc>"` | Develop + test in one step (timeout=600) |
+| `$D submit --repos <name> --title "<title>"` | Commit + push + PR + auto-release |
+
+### auto-dev Options
+
+- `--branch <name>` — branch name
+- `--engine <claude|codex>` — engine override
+- `--feature next` — next feature from plan (requires `--workspace`)
+- `--workspace <name>` — use existing workspace
+- `--repo <name>` — target repo in multi-repo workspace
+- `--plan "<desc>"` — implementation plan override
+- `--allow-complex` — skip complexity heuristic
+- `--reset-worktree` — git reset + clean before developing
+
+### submit Options
+
+- `--workspace <ws>` — explicit workspace
+- `--repos <name>` — find active workspace by repo name
+- `--repo <name>` — repo within workspace
+- `--body "<body>"` — PR body
+- `--keep-lock` — don't auto-release after submit
+
+## Write Operations (require workspace lock)
+
+### Workspace Lifecycle
+
+| Command | Description |
+|---------|-------------|
+| `$D workspace-check --repos <name> --task "<desc>" [--engine ENGINE]` | Acquire workspace lock |
+| `$D workspace-check --workspace <ws> --task "<desc>" [--engine ENGINE]` | Direct workspace mode |
+| `$D release --workspace <ws>` | Release workspace lock |
+| `$D release --all` | Release all workspace locks |
+| `$D renew-lease --workspace <ws>` | Extend workspace lease |
+
+### Development Commands (require active workspace)
+
+| Command | Description |
+|---------|-------------|
+| `$D develop --workspace <ws> --task "<desc>" [--engine ENGINE] [--plan PLAN] [--branch BRANCH]` | Engine writes code (timeout=600) |
+| `$D test --workspace <ws>` | Run lint + tests in workspace |
+| `$D submit-pr --workspace <ws> [--repo <name>] --title "<title>" [--body "<body>"]` | Commit + push + create PR |
+
+### Environment Probing (require active workspace)
+
+| Command | Description |
+|---------|-------------|
+| `$D env-probe --workspace <ws> --env <name> [--commands CMD...]` | Probe runtime environment |
+| `$D env-verify --workspace <ws> --env <name>` | Verify fix in deployment env |
+
+### Feature Management (require active workspace)
+
+| Command | Description |
+|---------|-------------|
+| `$D feature-plan --workspace <ws> --task "<task>" --features '<json>'` | Create feature split plan |
+| `$D feature-next --workspace <ws>` | Get next executable feature |
+| `$D feature-done --workspace <ws> --index N [--branch B] [--pr URL] [--force]` | Mark feature done |
+| `$D feature-list --workspace <ws>` | List all features and status |
+| `$D feature-update --workspace <ws> --index N [--status S] [--title T] [--task-desc D]` | Update feature |
+| `$D feature-criteria --workspace <ws> --index N --action view\|append [--criteria JSON]` | Manage acceptance criteria |
+| `$D feature-verify --workspace <ws> --index N [--engine E]` | Run acceptance criteria verification |
+
+## Configuration
+
+| Command | Description |
+|---------|-------------|
+| `$D config-list` | List all config |
+| `$D config-add <kind> <name> <value>` | Add repo/workspace/env |
+| `$D config-set <kind> <name> <key> <value>` | Set field on repo/workspace/env |
+| `$D config-remove <kind> <name>` | Remove repo/workspace/env |
+
+## Error Codes
+
+| Code | Meaning | Recovery |
+|------|---------|----------|
+| `TASK_TOO_COMPLEX` | Task needs splitting | Use `analyze` first, then feature plan |
+| `NEED_EXPLICIT_REPO` | Multi-repo workspace, repo ambiguous | Add `--repo <name>` |
+| `FINAL_TEST_FAILED` | Engine completed but tests failed | Retry `auto-dev` or fix manually |
+| `ENGINE_ERROR` | Engine failed | Try other engine: `--engine codex` / `--engine claude` |
+| `WORKSPACE_LOCKED` | Workspace busy | Use `release` or wait |
+| `LEASE_EXPIRED` | Lock expired | Run `workspace-check` again |
+| `PATH_NOT_FOUND` | Config name not found | Run `config-list` |
+| `NO_SESSION` | No workspace-check done | Run `workspace-check` first |

--- a/skills/coding-master/scripts/dispatch.py
+++ b/skills/coding-master/scripts/dispatch.py
@@ -74,12 +74,16 @@ DEVELOP_PROMPT = """\
 {plan}
 
 ## Task
-Implement the fix based on the diagnosis report above.
+Implement the fix/feature based on the diagnosis report above.
 Task: {task}
+
+## Test Command
+{test_command}
 
 Rules:
 - Only modify files within this repository
-- Do NOT run tests — that will be done separately
+- After implementing, run the test command to verify
+- If tests fail, fix the code and re-run until tests pass
 - Do NOT commit — that will be done separately
 - Keep changes minimal and focused
 """
@@ -253,6 +257,95 @@ def _load_artifact(ws_path: str, filename: str) -> str:
     if p.exists():
         return p.read_text()
     return "(not available)"
+
+
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+#  auto-dev helpers
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+def _looks_complex(task: str) -> bool:
+    """Heuristic: does the task description suggest multi-feature complexity?"""
+    complex_signals = ["重构", "refactor", "redesign", "整个", "所有", "全部",
+                       "多模块", "cross-cutting", "新子系统", "new subsystem"]
+    task_lower = task.lower()
+    return sum(1 for s in complex_signals if s in task_lower) >= 2
+
+
+
+
+def _clean_workspace_repos(ws_path: str, workspace_snapshot: str) -> dict:
+    """Reset tracked/untracked changes for repos inside the workspace snapshot."""
+    try:
+        snapshot = json.loads(workspace_snapshot)
+    except Exception:
+        return {
+            "ok": False,
+            "error": "workspace snapshot unavailable for reset",
+            "error_code": "NO_SNAPSHOT",
+            "hint": "先运行 workspace-check，或手动清理 workspace 后重试",
+        }
+
+    repos = snapshot.get("repos", [])
+    if not repos:
+        # Single-repo workspace — clean the root
+        result = GitOps.force_clean(ws_path)
+        if not result.get("ok"):
+            return {
+                "ok": False,
+                "error": result.get("error", f"failed to clean: {ws_path}"),
+                "error_code": "GIT_ERROR",
+            }
+        return {"ok": True}
+
+    for repo in repos:
+        repo_path = repo.get("path")
+        if not repo_path:
+            continue
+        result = GitOps.force_clean(repo_path)
+        if not result.get("ok"):
+            return {
+                "ok": False,
+                "error": result.get("error", f"failed to clean repo: {repo_path}"),
+                "error_code": "GIT_ERROR",
+                "hint": f"手动检查仓库后重试: {repo_path}",
+            }
+
+    return {"ok": True}
+
+
+def _suggest_next(args, feature_mode: bool, tests_passed: bool) -> str:
+    workspace_mode = bool(getattr(args, "workspace", None)) and not feature_mode
+
+    if feature_mode:
+        if tests_passed:
+            return (
+                f"当前 feature 完成。继续下一个 feature: "
+                f"$D auto-dev --workspace {args.workspace} --feature next"
+            )
+        return (
+            f"当前 feature 验证失败。两个选择:\n"
+            f"1. 继续修复: $D auto-dev --workspace {args.workspace} --feature next\n"
+            f"2. 清空改动后重试: $D auto-dev --workspace {args.workspace} --feature next --reset-worktree"
+        )
+
+    if workspace_mode:
+        if tests_passed:
+            return f"测试通过。提交 PR: $D submit --workspace {args.workspace} --title \"<title>\""
+        return (
+            f"测试未全部通过。两个选择:\n"
+            f"1. 继续修复: $D auto-dev --workspace {args.workspace} --task \"fix failing tests\"\n"
+            f"2. 清空改动后重试: $D auto-dev --workspace {args.workspace} --task \"{getattr(args, 'task', '')}\" --reset-worktree"
+        )
+
+    repos = getattr(args, "repos", "")
+    if tests_passed:
+        return f"测试通过。提交 PR: $D submit --repos {repos} --title \"<title>\""
+
+    return (
+        f"测试未全部通过。两个选择:\n"
+        f"1. 继续修复: $D auto-dev --repos {repos} --task \"fix failing tests\"\n"
+        f"2. 清空改动后重试: $D auto-dev --repos {repos} --task \"{getattr(args, 'task', '')}\" --reset-worktree"
+    )
 
 
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -758,6 +851,7 @@ def cmd_develop(args) -> dict:
             analysis=analysis,
             plan=args.plan or "(proceed with recommended approach)",
             task=args.task,
+            test_command="(no test command available)",
         )
 
         result = engine.run(ws_path, prompt, max_turns=max_turns)
@@ -862,6 +956,283 @@ def cmd_env_verify(args) -> dict:
         return result
 
     return with_lock_update(ws_path, "env-verified", do_verify)
+
+
+def cmd_auto_dev(args) -> dict:
+    """One-step development: workspace-check → develop (with test loop) → final test → report.
+
+    All repo resolution goes through repo_target.resolve_repo_target().
+    All execution uses the resolved RepoTarget — never raw workspace paths.
+    """
+    from repo_target import (
+        resolve_repo_target, resolve_repo_target_for_feature,
+        run_final_test, RepoTargetBinding,
+    )
+
+    config = ConfigManager()
+    mgr = WorkspaceManager(config)
+
+    # ── 0. Feature mode ──
+    feature_mode = getattr(args, "feature", None) == "next"
+    current_feature = None
+
+    if feature_mode:
+        ws_name = getattr(args, "workspace", None)
+        if not ws_name:
+            return {
+                "ok": False,
+                "error": "--feature next requires --workspace",
+                "error_code": "MISSING_WORKSPACE",
+                "hint": "用 analyze 返回的 workspace 名称: $D auto-dev --workspace env0 --feature next",
+            }
+        ws = config.get_workspace(ws_name)
+        if ws is None:
+            return {"ok": False, "error": f"workspace '{ws_name}' not found",
+                    "error_code": "NO_WORKSPACE"}
+
+        fm = FeatureManager(ws["path"])
+        feat = fm.next_feature()
+        if not feat.get("ok"):
+            _sync_coding_stats()
+            return feat
+
+        feat_data = feat.get("data", {})
+        current_feature = feat_data.get("feature")
+        if current_feature is None:
+            status = feat_data.get("status", "unknown")
+            if status == "all_complete":
+                return {
+                    "ok": True,
+                    "data": {"status": "all_complete", "progress": feat_data.get("progress")},
+                    "next_step": f"所有 feature 已完成。提交 PR: $D submit --workspace {ws_name} --title \"<title>\"",
+                }
+            return {"ok": False, "error": "no executable feature available",
+                    "error_code": "NO_FEATURE",
+                    "hint": "运行 $D feature-list 查看当前 plan 状态"}
+
+    # ── 1. Task + complexity check ──
+    task = current_feature["task"] if current_feature else getattr(args, "task", "")
+    if not task:
+        return {"ok": False, "error": "--task is required", "error_code": "INVALID_ARGS"}
+
+    if not getattr(args, "allow_complex", False) and _looks_complex(task):
+        repos_hint = getattr(args, "repos", "") or ""
+        return {
+            "ok": False,
+            "error_code": "TASK_TOO_COMPLEX",
+            "hint": f"建议先分析: $D analyze --repos {repos_hint} --task \"{task}\"",
+        }
+
+    # ── 2. Engine ──
+    engine_name = getattr(args, "engine", None) or config.get_default_engine()
+    engine = _get_engine(engine_name)
+    if engine is None:
+        return {"ok": False, "error": f"unknown engine: {engine_name}",
+                "error_code": "ENGINE_ERROR"}
+
+    # ── 3. Resolve repo target (unified) ──
+    if feature_mode:
+        binding = resolve_repo_target_for_feature(
+            config=config,
+            workspace_arg=getattr(args, "workspace", None),
+            repo_arg=getattr(args, "repo", None),
+            feature=current_feature,
+        )
+    else:
+        binding = resolve_repo_target(
+            config=config,
+            repos_arg=getattr(args, "repos", None),
+            workspace_arg=getattr(args, "workspace", None),
+            repo_arg=getattr(args, "repo", None),
+        )
+
+    # Handle NEEDS_WORKSPACE_ACQUISITION — acquire workspace then re-resolve
+    if isinstance(binding, dict) and binding.get("error_code") == "NEEDS_WORKSPACE_ACQUISITION":
+        repo_names = binding["data"]["repo_names"]
+        resolved_repo_name = binding["data"]["repo_name"]
+        ws_result = mgr.check_and_acquire_for_repos(repo_names, task, engine_name)
+        if not ws_result.get("ok"):
+            return ws_result
+        # Re-resolve with acquired workspace
+        acquired_ws_name = ws_result["data"]["snapshot"]["workspace"]["name"]
+        binding = resolve_repo_target(
+            config=config,
+            workspace_arg=acquired_ws_name,
+            repo_arg=getattr(args, "repo", None) or resolved_repo_name,
+        )
+
+    if isinstance(binding, dict):
+        return binding  # error
+
+    ws_ctx = binding.workspace
+    target = binding.target
+
+    # ── 3.5. Reset worktree if requested ──
+    if getattr(args, "reset_worktree", False):
+        snapshot_text = _load_artifact(ws_ctx.path, "workspace_snapshot.json")
+        clean_result = _clean_workspace_repos(ws_ctx.path, snapshot_text)
+        if not clean_result.get("ok"):
+            return clean_result
+
+    # ── 4. Build prompt + run engine (uses only RepoTarget) ──
+    ws_snapshot = _load_artifact(ws_ctx.path, "workspace_snapshot.json")
+    analysis = _load_artifact(ws_ctx.path, "phase2_analysis.md")
+
+    prompt = DEVELOP_PROMPT.format(
+        workspace_snapshot=ws_snapshot,
+        analysis=analysis,
+        plan=current_feature.get("plan", "") if current_feature else getattr(args, "plan", None) or "(proceed with recommended approach)",
+        task=task,
+        test_command=target.test_command or "(no test command available)",
+    )
+
+    max_turns = config.get_max_turns()
+
+    def do_dev():
+        # Branch
+        branch = getattr(args, "branch", None)
+        if branch:
+            git = GitOps(target.git_root)
+            br_result = git.create_branch(branch)
+            if not br_result.get("ok"):
+                return br_result
+            lock = LockFile(ws_ctx.path)
+            if lock.exists():
+                lock.load()
+                lock.data["branch"] = branch
+                lock.save()
+
+        # Engine runs on RepoTarget.repo_path
+        result = engine.run(target.repo_path, prompt, max_turns=max_turns)
+        if not result.success:
+            return {
+                "ok": False,
+                "error": result.error or "engine failed",
+                "error_code": "ENGINE_ERROR",
+                "hint": "引擎失败，可换引擎重试: --engine codex 或 --engine claude",
+            }
+
+        # ── Final test (uses RepoTarget) ──
+        test_status = run_final_test(target, config)
+
+        if test_status.status == "failed":
+            return {
+                "ok": False,
+                "error": "final verification failed after engine completed development",
+                "error_code": "FINAL_TEST_FAILED",
+                "data": {
+                    "summary": result.summary,
+                    "files_changed": result.files_changed,
+                    "test_status": test_status.status,
+                    "test_reason": test_status.reason,
+                    "test_report": test_status.report,
+                },
+                "hint": "查看失败报告后重试 auto-dev，或手动运行 $D test / $D analyze",
+            }
+
+        # Feature done
+        if feature_mode and current_feature is not None:
+            fm = FeatureManager(ws_ctx.path)
+            fm.mark_done(index=current_feature["index"], force=False)
+
+        return {
+            "ok": True,
+            "data": {
+                "summary": result.summary,
+                "files_changed": result.files_changed,
+                "test_status": test_status.status,
+                "test_reason": test_status.reason,
+                "test_report": test_status.report,
+            },
+            "next_step": _suggest_next(args, feature_mode=feature_mode, tests_passed=test_status.passed),
+        }
+
+    result = with_lock_update(ws_ctx.path, "developing", do_dev)
+    _sync_coding_stats()
+    return result
+
+
+def cmd_submit(args) -> dict:
+    """Simplified submit: supports both --repos and --workspace. Auto-releases on success.
+
+    All repo resolution goes through repo_target module.
+    """
+    from repo_target import (
+        resolve_repo_target, find_active_workspaces_by_repos, RepoTargetBinding,
+    )
+
+    config = ConfigManager()
+
+    # ── Resolve target (unified) ──
+    repos_arg = getattr(args, "repos", None)
+    workspace_arg = getattr(args, "workspace", None)
+    repo_arg = getattr(args, "repo", None)
+
+    if not workspace_arg and repos_arg:
+        # Use formal repo→workspace finder
+        repo_names = [r.strip() for r in repos_arg.split(",") if r.strip()]
+        matches = find_active_workspaces_by_repos(config, repo_names)
+
+        if len(matches) == 0:
+            return {
+                "ok": False,
+                "error": f"no active workspace found for repos: {repos_arg}",
+                "error_code": "NO_WORKSPACE",
+                "hint": "先运行 auto-dev 创建 workspace，或用 --workspace 指定",
+            }
+        if len(matches) > 1:
+            return {
+                "ok": False,
+                "error": "multiple active workspaces found",
+                "error_code": "AMBIGUOUS_WORKSPACE",
+                "hint": "请显式传 --workspace，避免提交到错误分支",
+            }
+        workspace_arg = matches[0]["name"]
+        if len(repo_names) == 1 and not repo_arg:
+            repo_arg = repo_names[0]
+
+    if not workspace_arg:
+        return {"ok": False, "error": "either --workspace or --repos is required",
+                "error_code": "INVALID_ARGS"}
+
+    binding = resolve_repo_target(
+        config=config,
+        workspace_arg=workspace_arg,
+        repo_arg=repo_arg,
+    )
+    if isinstance(binding, dict):
+        return binding  # error
+
+    ws_ctx = binding.workspace
+    target = binding.target
+
+    # ── Submit PR using RepoTarget ──
+    git = GitOps(target.git_root)
+
+    def do_submit():
+        result = git.submit_pr(
+            title=args.title,
+            body=getattr(args, "body", "") or "",
+            commit_message=args.title,
+        )
+        if result.get("ok"):
+            lock = LockFile(ws_ctx.path)
+            if lock.exists():
+                lock.load()
+                lock.data["pushed_to_remote"] = True
+                lock.save()
+        return result
+
+    result = with_lock_update(ws_ctx.path, "submitted", do_submit)
+
+    # Auto-release on success unless --keep-lock
+    if result.get("ok") and not getattr(args, "keep_lock", False):
+        import argparse as _ap
+        release_args = _ap.Namespace(workspace=workspace_arg, **{"all": False}, cleanup=False)
+        cmd_release(release_args)
+
+    _sync_coding_stats()
+    return result
 
 
 def cmd_release(args) -> dict:
@@ -1015,6 +1386,37 @@ def _build_parser() -> argparse.ArgumentParser:
     qe.add_argument("--env", required=True)
     qe.add_argument("--commands", nargs="*", default=None)
 
+    # ── Aliases for simplified interface ─────────────────────
+    sub.add_parser("status", help="Alias for quick-status").add_argument("--workspace", default=None)
+    sub._name_parser_map["status"].add_argument("--repos", default=None)
+
+    sub.add_parser("find", help="Alias for quick-find").add_argument("--workspace", default=None)
+    sub._name_parser_map["find"].add_argument("--repos", default=None)
+    sub._name_parser_map["find"].add_argument("--query", required=True)
+    sub._name_parser_map["find"].add_argument("--glob", default=None)
+
+    # ── auto-dev ──────────────────────────────────────────
+    ad = sub.add_parser("auto-dev", help="One-step development: workspace-check + develop + test")
+    ad.add_argument("--repos", default=None, help="Comma-separated repo names (single repo only)")
+    ad.add_argument("--workspace", default=None, help="Use existing workspace")
+    ad.add_argument("--task", default=None, help="Task description")
+    ad.add_argument("--branch", default=None, help="Branch name (auto-generated if omitted)")
+    ad.add_argument("--engine", default=None, help="Engine: claude or codex")
+    ad.add_argument("--feature", default=None, help="'next' to develop next feature from plan")
+    ad.add_argument("--repo", default=None, help="Target repo in multi-repo workspace")
+    ad.add_argument("--plan", default=None, help="Implementation plan")
+    ad.add_argument("--allow-complex", action="store_true", help="Skip complexity check")
+    ad.add_argument("--reset-worktree", action="store_true", help="Clean uncommitted changes before developing")
+
+    # ── submit ────────────────────────────────────────────
+    sm = sub.add_parser("submit", help="Commit, push, create PR (auto-releases workspace)")
+    sm.add_argument("--workspace", default=None, help="Workspace name")
+    sm.add_argument("--repos", default=None, help="Comma-separated repo names")
+    sm.add_argument("--repo", default=None, help="Repo name within workspace")
+    sm.add_argument("--title", required=True, help="PR title")
+    sm.add_argument("--body", default="", help="PR body")
+    sm.add_argument("--keep-lock", action="store_true", help="Don't auto-release workspace after submit")
+
     # ── Workflow ────────────────────────────────────────────
     wc = sub.add_parser("workspace-check", help="Check and acquire workspace")
     wc.add_argument("--workspace", default=None, help="Workspace name (required in direct mode, optional with --repos)")
@@ -1109,10 +1511,18 @@ COMMANDS = {
     "config-add": cmd_config_add,
     "config-set": cmd_config_set,
     "config-remove": cmd_config_remove,
+    # Simplified aliases
+    "status": cmd_quick_status,
+    "find": cmd_quick_find,
+    # Original names (kept for backward compatibility)
     "quick-status": cmd_quick_status,
     "quick-test": cmd_quick_test,
     "quick-find": cmd_quick_find,
     "quick-env": cmd_quick_env,
+    # New commands
+    "auto-dev": cmd_auto_dev,
+    "submit": cmd_submit,
+    # Workflow
     "workspace-check": cmd_workspace_check,
     "env-probe": cmd_env_probe,
     "analyze": cmd_analyze,
@@ -1122,6 +1532,7 @@ COMMANDS = {
     "env-verify": cmd_env_verify,
     "release": cmd_release,
     "renew-lease": cmd_renew_lease,
+    # Feature management
     "feature-plan": cmd_feature_plan,
     "feature-next": cmd_feature_next,
     "feature-done": cmd_feature_done,
@@ -1211,12 +1622,16 @@ def _sync_coding_stats() -> None:
         lines.append("")
         lines.append(
             "- **所有代码开发、测试、搜索操作必须通过 coding-master skill 的 dispatch 命令执行**"
-            "（`$D test`, `$D quick-test`, `$D quick-find` 等），"
+            "（`$D auto-dev`, `$D test`, `$D status`, `$D find` 等），"
             "**禁止**直接用 `_bash` 拼 `cd ... && pytest/pip install/python -m pytest` 命令。"
         )
         lines.append(
             "- dispatch 会自动处理正确的 Python 解释器、pytest 路径、"
             "依赖安装和 workspace 上下文，裸 bash 无法保证这些。"
+        )
+        lines.append(
+            "- 标准开发流程: `$D auto-dev --repos <name> --task \"...\"` 一步完成开发+测试。"
+            "测试通过后: `$D submit --repos <name> --title \"...\"`。"
         )
         lines.append("")
 
@@ -1237,7 +1652,7 @@ def _append_workspace_details(lines: list[str], ws: dict) -> None:
 
     # Enrich from artifacts if available
     ws_path = ws["path"]
-    test_report = _load_artifact(ws_path, "test_report.json")
+    test_report = _load_artifact_or_none(ws_path, "test_report.json")
     if test_report:
         try:
             report = json.loads(test_report)
@@ -1290,7 +1705,7 @@ def _collect_expired_workspace_status() -> list[dict]:
     return expired
 
 
-def _load_artifact(ws_path: str, filename: str) -> str | None:
+def _load_artifact_or_none(ws_path: str, filename: str) -> str | None:
     """Read an artifact file from .coding-master/ dir, return content or None."""
     art = Path(ws_path) / ARTIFACT_DIR / filename
     if art.is_file():

--- a/skills/coding-master/scripts/repo_target.py
+++ b/skills/coding-master/scripts/repo_target.py
@@ -1,0 +1,418 @@
+#!/usr/bin/env python3
+"""Two-layer model: WorkspaceContext (lifecycle) + RepoTarget (execution).
+
+Any git / test / engine action receives a RepoTarget, never a raw workspace path.
+All resolution logic lives in resolve_repo_target() — commands never do local inference.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from config_manager import ConfigManager
+from workspace import WorkspaceManager, LockFile, ARTIFACT_DIR
+from test_runner import _resolve_pytest_command
+
+
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+#  Data structures
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+
+@dataclass
+class RepoTarget:
+    """Concrete execution target — the only thing git/test/engine see."""
+    repo_name: str
+    repo_path: str
+    test_command: str | None
+    git_root: str  # directory containing .git (usually == repo_path)
+
+
+@dataclass
+class WorkspaceContext:
+    """Lifecycle container: lock, snapshot, task state."""
+    name: str
+    path: str
+    snapshot: dict | None = None
+
+
+@dataclass
+class RepoTargetBinding:
+    """Resolved binding returned by resolve_repo_target()."""
+    workspace: WorkspaceContext
+    target: RepoTarget
+
+
+@dataclass
+class TestStatus:
+    """Explicit test outcome — never silently 'passed' when no command exists."""
+    status: str   # "passed" | "failed" | "skipped"
+    reason: str   # "success" | "command_missing" | "command_failed"
+    report: dict = field(default_factory=dict)
+
+    @property
+    def passed(self) -> bool:
+        return self.status == "passed"
+
+    @property
+    def skipped(self) -> bool:
+        return self.status == "skipped"
+
+
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+#  Unified resolver
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+
+def resolve_repo_target(
+    *,
+    config: ConfigManager,
+    repos_arg: str | None = None,
+    workspace_arg: str | None = None,
+    repo_arg: str | None = None,
+) -> RepoTargetBinding | dict:
+    """Single entry point for resolving the execution target.
+
+    Accepts the raw CLI args and returns either:
+    - RepoTargetBinding on success
+    - error dict {"ok": False, ...} on failure
+
+    Resolution priority:
+    1. --workspace + --repo  → explicit workspace + explicit repo
+    2. --workspace (no repo) → workspace + auto-detect single repo
+    3. --repos               → find/acquire workspace, resolve single repo
+    """
+    if workspace_arg:
+        return _resolve_from_workspace(config, workspace_arg, repo_arg)
+
+    if repos_arg:
+        return _resolve_from_repos_arg(config, repos_arg)
+
+    return {
+        "ok": False,
+        "error": "--repos or --workspace is required",
+        "error_code": "INVALID_ARGS",
+    }
+
+
+def resolve_repo_target_for_feature(
+    *,
+    config: ConfigManager,
+    workspace_arg: str,
+    repo_arg: str | None = None,
+    feature: dict,
+) -> RepoTargetBinding | dict:
+    """Resolve target for feature mode — workspace must already exist."""
+    return _resolve_from_workspace(config, workspace_arg, repo_arg)
+
+
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+#  Workspace → repo lookup helpers
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+
+def find_active_workspaces_by_repos(
+    config: ConfigManager,
+    repo_names: list[str],
+) -> list[dict]:
+    """Find active (locked, non-expired) workspaces whose snapshot contains ALL given repos.
+
+    Returns list of {name, path, task, ...} dicts.
+    Rules:
+    - 0 matches → caller returns NO_WORKSPACE
+    - 1 match  → caller proceeds
+    - N matches → caller returns AMBIGUOUS_WORKSPACE
+    """
+    all_ws = config._section().get("workspaces", {})
+    matches = []
+
+    for ws_name in all_ws:
+        ws = config.get_workspace(ws_name)
+        if ws is None:
+            continue
+
+        ws_path = ws["path"]
+        lock = LockFile(ws_path)
+        if not lock.exists():
+            continue
+        try:
+            lock.load()
+        except Exception:
+            continue
+        if lock.is_expired():
+            continue
+
+        # Check if this workspace contains the requested repos
+        snapshot = _load_workspace_snapshot(ws_path)
+        if snapshot is None:
+            continue
+
+        snapshot_repo_names = {r.get("name") for r in snapshot.get("repos", [])}
+        if all(rn in snapshot_repo_names for rn in repo_names):
+            matches.append({
+                "name": ws_name,
+                "path": ws_path,
+                "task": lock.data.get("task", ""),
+                "phase": lock.data.get("phase", ""),
+            })
+
+    return matches
+
+
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+#  Test command resolution
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+
+def resolve_test_command(
+    repo_path: str,
+    repo_name: str,
+    config: ConfigManager,
+    ws_name: str,
+) -> str | None:
+    """Determine the test command for a repo target.
+
+    Priority:
+    1. Explicit config on workspace.repos.<name>.test_command
+    2. Global repo config on repos.<name>.test_command
+    3. Auto-detect from pyproject.toml
+    """
+    ws = config.get_workspace(ws_name)
+    if ws and isinstance(ws, dict):
+        repos_cfg = ws.get("repos", {})
+        if isinstance(repos_cfg, dict):
+            repo_cfg = repos_cfg.get(repo_name, {})
+            if isinstance(repo_cfg, dict) and repo_cfg.get("test_command"):
+                return repo_cfg["test_command"]
+
+    repo_cfg = config.get_repo(repo_name)
+    if isinstance(repo_cfg, dict) and repo_cfg.get("test_command"):
+        return repo_cfg["test_command"]
+
+    p = Path(repo_path)
+    if (p / "pyproject.toml").exists():
+        return _resolve_pytest_command(p)
+    return None
+
+
+def run_final_test(target: RepoTarget, config: ConfigManager) -> TestStatus:
+    """Run final verification on a RepoTarget. Returns explicit TestStatus."""
+    if not target.test_command:
+        return TestStatus(status="skipped", reason="command_missing")
+
+    from test_runner import TestRunner as TR, _exec, _parse_pytest_output
+
+    stdout, stderr, rc = _exec(target.repo_path, target.test_command)
+    total, passed_count, failed_count = _parse_pytest_output(stdout + stderr)
+
+    from test_runner import _truncate, OUTPUT_MAX
+    output = _truncate(stdout + stderr, OUTPUT_MAX)
+
+    if rc == 0:
+        return TestStatus(
+            status="passed",
+            reason="success",
+            report={
+                "passed_count": passed_count,
+                "failed_count": failed_count,
+                "total": total,
+                "output": output,
+            },
+        )
+    return TestStatus(
+        status="failed",
+        reason="command_failed",
+        report={
+            "passed_count": passed_count,
+            "failed_count": failed_count,
+            "total": total,
+            "output": output,
+        },
+    )
+
+
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+#  Internal helpers
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+
+def _resolve_from_workspace(
+    config: ConfigManager,
+    ws_name: str,
+    repo_arg: str | None,
+) -> RepoTargetBinding | dict:
+    """Resolve from an explicit workspace name."""
+    ws = config.get_workspace(ws_name)
+    if ws is None:
+        return {
+            "ok": False,
+            "error": f"workspace '{ws_name}' not found",
+            "error_code": "PATH_NOT_FOUND",
+        }
+
+    ws_path = ws["path"]
+
+    # Ensure session exists
+    session_path = Path(ws_path) / ARTIFACT_DIR / "session.json"
+    if not session_path.exists():
+        return {
+            "ok": False,
+            "error": "run workspace-check first to start a session",
+            "error_code": "NO_SESSION",
+        }
+
+    snapshot = _load_workspace_snapshot(ws_path)
+    ws_ctx = WorkspaceContext(name=ws_name, path=ws_path, snapshot=snapshot)
+
+    # Resolve repo within workspace
+    target_result = _resolve_single_repo(ws_path, ws_name, snapshot, repo_arg)
+    if isinstance(target_result, dict):
+        return target_result  # error
+
+    repo_name, repo_path = target_result
+
+    test_cmd = resolve_test_command(repo_path, repo_name, config, ws_name)
+
+    return RepoTargetBinding(
+        workspace=ws_ctx,
+        target=RepoTarget(
+            repo_name=repo_name,
+            repo_path=repo_path,
+            test_command=test_cmd,
+            git_root=repo_path,
+        ),
+    )
+
+
+def _resolve_from_repos_arg(
+    config: ConfigManager,
+    repos_arg: str,
+) -> RepoTargetBinding | dict:
+    """Resolve from --repos arg: acquire workspace, then resolve single repo."""
+    repo_names = [r.strip() for r in repos_arg.split(",") if r.strip()]
+    if not repo_names:
+        return {
+            "ok": False,
+            "error": "--repos value is empty",
+            "error_code": "INVALID_ARGS",
+        }
+    if len(repo_names) != 1:
+        return {
+            "ok": False,
+            "error": "auto-dev/submit only supports a single repo target",
+            "error_code": "TASK_TOO_COMPLEX",
+            "hint": "先运行 analyze 拆分任务，或改为单 repo 调用",
+        }
+
+    repo_name = repo_names[0]
+
+    # First check if there's already an active workspace for this repo
+    active = find_active_workspaces_by_repos(config, repo_names)
+    if len(active) == 1:
+        ws_name = active[0]["name"]
+        ws_path = active[0]["path"]
+    elif len(active) > 1:
+        return {
+            "ok": False,
+            "error": f"multiple active workspaces found for repo '{repo_name}'",
+            "error_code": "AMBIGUOUS_WORKSPACE",
+            "hint": "请显式传 --workspace，避免操作到错误分支",
+        }
+    else:
+        ws_name = None
+        ws_path = None
+
+    if ws_path:
+        snapshot = _load_workspace_snapshot(ws_path)
+        ws_ctx = WorkspaceContext(name=ws_name, path=ws_path, snapshot=snapshot)
+
+        # Find repo path within workspace
+        repo_path = _find_repo_path_in_snapshot(snapshot, repo_name)
+        if not repo_path:
+            repo_path = str(Path(ws_path) / repo_name)
+            if not Path(repo_path).is_dir():
+                repo_path = ws_path
+
+        test_cmd = resolve_test_command(repo_path, repo_name, config, ws_name)
+
+        return RepoTargetBinding(
+            workspace=ws_ctx,
+            target=RepoTarget(
+                repo_name=repo_name,
+                repo_path=repo_path,
+                test_command=test_cmd,
+                git_root=repo_path,
+            ),
+        )
+
+    # No active workspace — return partial binding (workspace needs acquisition)
+    # The caller (auto-dev) will need to acquire workspace first
+    return {
+        "ok": False,
+        "error_code": "NEEDS_WORKSPACE_ACQUISITION",
+        "data": {"repo_names": repo_names, "repo_name": repo_name},
+    }
+
+
+def _resolve_single_repo(
+    ws_path: str,
+    ws_name: str,
+    snapshot: dict | None,
+    repo_arg: str | None,
+) -> tuple[str, str] | dict:
+    """Resolve a single repo within a workspace. Returns (repo_name, repo_path) or error dict."""
+    if not snapshot:
+        # No snapshot — workspace is the repo itself
+        return (Path(ws_path).name, ws_path)
+
+    repos = snapshot.get("repos", [])
+
+    if not repos:
+        # Single-repo workspace (direct workspace mode)
+        return (Path(ws_path).name, ws_path)
+
+    if len(repos) == 1:
+        only = repos[0]
+        return (only["name"], only["path"])
+
+    # Multi-repo workspace — must have explicit --repo
+    if repo_arg:
+        for repo in repos:
+            if repo["name"] == repo_arg:
+                return (repo["name"], repo["path"])
+        return {
+            "ok": False,
+            "error": f"repo '{repo_arg}' not found in workspace",
+            "error_code": "PATH_NOT_FOUND",
+        }
+
+    return {
+        "ok": False,
+        "error": "multi-repo workspace requires explicit --repo",
+        "error_code": "NEED_EXPLICIT_REPO",
+        "hint": f"示例: --workspace {ws_name} --repo <name>",
+    }
+
+
+def _load_workspace_snapshot(ws_path: str) -> dict | None:
+    """Load workspace_snapshot.json, return parsed dict or None."""
+    snap_path = Path(ws_path) / ARTIFACT_DIR / "workspace_snapshot.json"
+    if not snap_path.is_file():
+        return None
+    try:
+        return json.loads(snap_path.read_text())
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+def _find_repo_path_in_snapshot(snapshot: dict | None, repo_name: str) -> str | None:
+    """Find a repo's path within a workspace snapshot."""
+    if not snapshot:
+        return None
+    for repo in snapshot.get("repos", []):
+        if repo.get("name") == repo_name:
+            return repo.get("path")
+    return None

--- a/skills/coding-master/tests/unit/test_auto_dev.py
+++ b/skills/coding-master/tests/unit/test_auto_dev.py
@@ -1,0 +1,317 @@
+"""Tests for auto-dev, submit, and related helpers."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from repo_target import RepoTarget, RepoTargetBinding, WorkspaceContext
+from dispatch import (
+    _looks_complex,
+    _suggest_next,
+    _clean_workspace_repos,
+    cmd_auto_dev,
+    cmd_submit,
+    COMMANDS,
+    _build_parser,
+    ARTIFACT_DIR,
+)
+
+
+# ── _looks_complex ──────────────────────────────────────
+
+
+class TestLooksComplex:
+    def test_simple_task(self):
+        assert _looks_complex("fix the login button") is False
+
+    def test_single_signal(self):
+        assert _looks_complex("refactor the auth module") is False
+
+    def test_two_signals_triggers(self):
+        assert _looks_complex("重构整个 inspector 模块") is True
+
+    def test_mixed_lang_signals(self):
+        assert _looks_complex("refactor redesign the system") is True
+
+    def test_case_insensitive(self):
+        assert _looks_complex("Refactor and Redesign") is True
+
+    def test_empty(self):
+        assert _looks_complex("") is False
+
+
+# ── _suggest_next ───────────────────────────────────────
+
+
+class TestSuggestNext:
+    def test_feature_mode_success(self):
+        args = SimpleNamespace(workspace="env0", repos=None)
+        hint = _suggest_next(args, feature_mode=True, tests_passed=True)
+        assert "feature next" in hint
+
+    def test_feature_mode_failure(self):
+        args = SimpleNamespace(workspace="env0", repos=None)
+        hint = _suggest_next(args, feature_mode=True, tests_passed=False)
+        assert "reset-worktree" in hint
+
+    def test_workspace_mode_success(self):
+        args = SimpleNamespace(workspace="env0", repos=None)
+        hint = _suggest_next(args, feature_mode=False, tests_passed=True)
+        assert "submit" in hint
+
+    def test_repo_mode_success(self):
+        args = SimpleNamespace(workspace=None, repos="myrepo")
+        hint = _suggest_next(args, feature_mode=False, tests_passed=True)
+        assert "submit" in hint
+        assert "myrepo" in hint
+
+
+# ── _clean_workspace_repos ──────────────────────────────
+
+
+class TestCleanWorkspaceRepos:
+    def test_invalid_json(self):
+        result = _clean_workspace_repos("/ws", "not json")
+        assert result["ok"] is False
+        assert result["error_code"] == "NO_SNAPSHOT"
+
+    @patch("dispatch.GitOps.force_clean", return_value={"ok": True})
+    def test_no_repos_cleans_root(self, mock_clean):
+        result = _clean_workspace_repos("/ws", '{"workspace": {}}')
+        assert result["ok"] is True
+        mock_clean.assert_called_once_with("/ws")
+
+    @patch("dispatch.GitOps.force_clean", return_value={"ok": True})
+    def test_with_repos(self, mock_clean):
+        snapshot = json.dumps({"repos": [
+            {"name": "a", "path": "/ws/a"},
+            {"name": "b", "path": "/ws/b"},
+        ]})
+        result = _clean_workspace_repos("/ws", snapshot)
+        assert result["ok"] is True
+        assert mock_clean.call_count == 2
+
+
+# ── Parser registration ────────────────────────────────
+
+
+class TestNewCommandRegistration:
+    def test_auto_dev_registered(self):
+        assert "auto-dev" in COMMANDS
+
+    def test_submit_registered(self):
+        assert "submit" in COMMANDS
+
+    def test_aliases_registered(self):
+        assert "status" in COMMANDS
+        assert "find" in COMMANDS
+
+    def test_auto_dev_parses(self):
+        parser = _build_parser()
+        args = parser.parse_args([
+            "auto-dev", "--repos", "myrepo", "--task", "fix bug"
+        ])
+        assert args.command == "auto-dev"
+        assert args.repos == "myrepo"
+        assert args.task == "fix bug"
+        assert args.allow_complex is False
+
+    def test_auto_dev_feature_mode_parses(self):
+        parser = _build_parser()
+        args = parser.parse_args([
+            "auto-dev", "--workspace", "env0", "--feature", "next"
+        ])
+        assert args.feature == "next"
+        assert args.workspace == "env0"
+
+    def test_submit_parses(self):
+        parser = _build_parser()
+        args = parser.parse_args([
+            "submit", "--repos", "myrepo", "--title", "my PR"
+        ])
+        assert args.command == "submit"
+        assert args.title == "my PR"
+
+    def test_submit_keep_lock(self):
+        parser = _build_parser()
+        args = parser.parse_args([
+            "submit", "--workspace", "env0", "--title", "PR", "--keep-lock"
+        ])
+        assert args.keep_lock is True
+
+
+# ── cmd_auto_dev error paths ────────────────────────────
+
+
+class TestCmdAutoDevErrors:
+    def test_no_repos_no_workspace(self):
+        args = SimpleNamespace(
+            repos=None, workspace=None, task="fix", feature=None,
+            engine=None, allow_complex=False, reset_worktree=False,
+            branch=None, repo=None, plan=None,
+        )
+        result = cmd_auto_dev(args)
+        assert result["ok"] is False
+
+    def test_no_task(self):
+        args = SimpleNamespace(
+            repos="myrepo", workspace=None, task=None, feature=None,
+            engine=None, allow_complex=False, reset_worktree=False,
+            branch=None, repo=None, plan=None,
+        )
+        result = cmd_auto_dev(args)
+        assert result["ok"] is False
+        assert result["error_code"] == "INVALID_ARGS"
+
+    def test_complex_task_blocked(self):
+        args = SimpleNamespace(
+            repos="myrepo", workspace=None, task="重构整个系统", feature=None,
+            engine=None, allow_complex=False, reset_worktree=False,
+            branch=None, repo=None, plan=None,
+        )
+        result = cmd_auto_dev(args)
+        assert result["ok"] is False
+        assert result["error_code"] == "TASK_TOO_COMPLEX"
+
+    @patch("dispatch.ConfigManager")
+    def test_feature_mode_no_workspace(self, MockCM):
+        args = SimpleNamespace(
+            repos=None, workspace=None, task=None, feature="next",
+            engine=None, allow_complex=False, reset_worktree=False,
+            branch=None, repo=None, plan=None,
+        )
+        result = cmd_auto_dev(args)
+        assert result["ok"] is False
+        assert result["error_code"] == "MISSING_WORKSPACE"
+
+    @patch("dispatch.ConfigManager")
+    def test_unknown_engine(self, MockCM):
+        MockCM.return_value.get_default_engine.return_value = "unknown-llm"
+        args = SimpleNamespace(
+            repos="myrepo", workspace=None, task="fix bug", feature=None,
+            engine="unknown-llm", allow_complex=False, reset_worktree=False,
+            branch=None, repo=None, plan=None,
+        )
+        result = cmd_auto_dev(args)
+        assert result["ok"] is False
+        assert result["error_code"] == "ENGINE_ERROR"
+
+    @patch("dispatch._sync_coding_stats")
+    @patch("dispatch.with_lock_update", side_effect=lambda path, phase, fn: fn())
+    @patch("dispatch._get_engine")
+    @patch("dispatch.WorkspaceManager")
+    @patch("dispatch.ConfigManager")
+    @patch("repo_target.run_final_test")
+    @patch("repo_target.resolve_repo_target")
+    def test_acquired_workspace_preserves_repo_arg(
+        self,
+        mock_resolve_repo_target,
+        mock_run_final_test,
+        MockCM,
+        MockWorkspaceManager,
+        mock_get_engine,
+        _mock_with_lock_update,
+        _mock_sync,
+    ):
+        args = SimpleNamespace(
+            repos="myrepo", workspace=None, task="fix bug", feature=None,
+            engine=None, allow_complex=False, reset_worktree=False,
+            branch=None, repo=None, plan=None,
+        )
+        config = MockCM.return_value
+        config.get_default_engine.return_value = "codex"
+        config.get_max_turns.return_value = 5
+
+        engine = mock_get_engine.return_value
+        engine.run.return_value = SimpleNamespace(success=True, summary="ok", files_changed=[])
+
+        mgr = MockWorkspaceManager.return_value
+        mgr.check_and_acquire_for_repos.return_value = {
+            "ok": True,
+            "data": {"snapshot": {"workspace": {"name": "env0"}}},
+        }
+
+        mock_resolve_repo_target.side_effect = [
+            {
+                "ok": False,
+                "error_code": "NEEDS_WORKSPACE_ACQUISITION",
+                "data": {"repo_names": ["myrepo"], "repo_name": "myrepo"},
+            },
+            RepoTargetBinding(
+                workspace=WorkspaceContext(name="env0", path="/tmp/env0", snapshot={}),
+                target=RepoTarget(
+                    repo_name="myrepo",
+                    repo_path="/tmp/env0/myrepo",
+                    test_command="pytest",
+                    git_root="/tmp/env0/myrepo",
+                ),
+            ),
+        ]
+        mock_run_final_test.return_value = SimpleNamespace(
+            status="passed",
+            reason="success",
+            report={},
+            passed=True,
+        )
+
+        with patch("dispatch._load_artifact", return_value=""):
+            result = cmd_auto_dev(args)
+
+        assert result["ok"] is True
+        assert mock_resolve_repo_target.call_args_list[1].kwargs["repo_arg"] == "myrepo"
+
+
+# ── cmd_submit error paths ──────────────────────────────
+
+
+class TestCmdSubmitErrors:
+    def test_no_workspace_no_repos(self):
+        args = SimpleNamespace(
+            workspace=None, repos=None, repo=None,
+            title="PR", body="", keep_lock=False,
+        )
+        result = cmd_submit(args)
+        assert result["ok"] is False
+        assert result["error_code"] == "INVALID_ARGS"
+
+    @patch("dispatch._sync_coding_stats")
+    @patch("dispatch.cmd_release")
+    @patch("dispatch.with_lock_update", side_effect=lambda path, phase, fn: fn())
+    @patch("dispatch.ConfigManager")
+    @patch("repo_target.resolve_repo_target")
+    @patch("repo_target.find_active_workspaces_by_repos")
+    def test_submit_repos_preserves_repo_arg(
+        self,
+        mock_find_active_workspaces,
+        mock_resolve_repo_target,
+        MockCM,
+        _mock_with_lock_update,
+        _mock_release,
+        _mock_sync,
+    ):
+        args = SimpleNamespace(
+            workspace=None, repos="myrepo", repo=None,
+            title="PR", body="", keep_lock=False,
+        )
+        mock_find_active_workspaces.return_value = [{"name": "env0", "path": "/tmp/env0"}]
+        mock_resolve_repo_target.return_value = RepoTargetBinding(
+            workspace=WorkspaceContext(name="env0", path="/tmp/env0", snapshot={}),
+            target=RepoTarget(
+                repo_name="myrepo",
+                repo_path="/tmp/env0/myrepo",
+                test_command="pytest",
+                git_root="/tmp/env0/myrepo",
+            ),
+        )
+
+        submit_result = {"ok": True, "data": {"pr_url": "https://example.test/pr/1"}}
+        with patch("dispatch.GitOps.submit_pr", return_value=submit_result):
+            result = cmd_submit(args)
+
+        assert result["ok"] is True
+        assert mock_resolve_repo_target.call_args.kwargs["repo_arg"] == "myrepo"

--- a/skills/coding-master/tests/unit/test_dispatch.py
+++ b/skills/coding-master/tests/unit/test_dispatch.py
@@ -11,7 +11,9 @@ class TestCommandRegistry:
         # All keys in COMMANDS should be valid subcommands
         expected = {
             "config-list", "config-add", "config-set", "config-remove",
+            "status", "find",  # simplified aliases
             "quick-status", "quick-test", "quick-find", "quick-env",
+            "auto-dev", "submit",  # new commands
             "workspace-check", "env-probe", "analyze", "develop",
             "test", "submit-pr", "env-verify", "release", "renew-lease",
             "feature-plan", "feature-next", "feature-done",

--- a/skills/coding-master/tests/unit/test_repo_target.py
+++ b/skills/coding-master/tests/unit/test_repo_target.py
@@ -1,0 +1,271 @@
+"""Tests for repo_target.py — two-layer model and unified resolver."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from repo_target import (
+    RepoTarget,
+    WorkspaceContext,
+    RepoTargetBinding,
+    TestStatus,
+    resolve_repo_target,
+    resolve_repo_target_for_feature,
+    find_active_workspaces_by_repos,
+    resolve_test_command,
+    run_final_test,
+    _resolve_single_repo,
+    _load_workspace_snapshot,
+)
+from workspace import ARTIFACT_DIR
+
+
+# ── TestStatus ──────────────────────────────────────────
+
+
+class TestTestStatus:
+    def test_passed(self):
+        ts = TestStatus(status="passed", reason="success")
+        assert ts.passed is True
+        assert ts.skipped is False
+
+    def test_failed(self):
+        ts = TestStatus(status="failed", reason="command_failed")
+        assert ts.passed is False
+        assert ts.skipped is False
+
+    def test_skipped(self):
+        ts = TestStatus(status="skipped", reason="command_missing")
+        assert ts.passed is False
+        assert ts.skipped is True
+
+
+# ── _resolve_single_repo ────────────────────────────────
+
+
+class TestResolveSingleRepo:
+    def test_no_snapshot_uses_ws_root(self, tmp_path):
+        name, path = _resolve_single_repo(str(tmp_path), "ws0", None, None)
+        assert path == str(tmp_path)
+
+    def test_empty_repos_uses_ws_root(self, tmp_path):
+        name, path = _resolve_single_repo(str(tmp_path), "ws0", {"repos": []}, None)
+        assert path == str(tmp_path)
+
+    def test_single_repo(self, tmp_path):
+        snapshot = {"repos": [{"name": "only", "path": str(tmp_path / "only")}]}
+        name, path = _resolve_single_repo(str(tmp_path), "ws0", snapshot, None)
+        assert name == "only"
+
+    def test_multi_repo_no_arg(self, tmp_path):
+        snapshot = {"repos": [
+            {"name": "a", "path": "/a"},
+            {"name": "b", "path": "/b"},
+        ]}
+        result = _resolve_single_repo(str(tmp_path), "ws0", snapshot, None)
+        assert isinstance(result, dict)
+        assert result["error_code"] == "NEED_EXPLICIT_REPO"
+
+    def test_multi_repo_with_arg(self, tmp_path):
+        snapshot = {"repos": [
+            {"name": "a", "path": "/a"},
+            {"name": "b", "path": "/b"},
+        ]}
+        name, path = _resolve_single_repo(str(tmp_path), "ws0", snapshot, "b")
+        assert name == "b"
+        assert path == "/b"
+
+    def test_multi_repo_wrong_arg(self, tmp_path):
+        snapshot = {"repos": [
+            {"name": "a", "path": "/a"},
+            {"name": "b", "path": "/b"},
+        ]}
+        result = _resolve_single_repo(str(tmp_path), "ws0", snapshot, "nonexistent")
+        assert isinstance(result, dict)
+        assert result["error_code"] == "PATH_NOT_FOUND"
+
+
+# ── _load_workspace_snapshot ────────────────────────────
+
+
+class TestLoadWorkspaceSnapshot:
+    def test_missing(self, tmp_path):
+        assert _load_workspace_snapshot(str(tmp_path)) is None
+
+    def test_valid(self, tmp_path):
+        art_dir = tmp_path / ARTIFACT_DIR
+        art_dir.mkdir()
+        snapshot = {"repos": [{"name": "x", "path": "/x"}]}
+        (art_dir / "workspace_snapshot.json").write_text(json.dumps(snapshot))
+        result = _load_workspace_snapshot(str(tmp_path))
+        assert result["repos"][0]["name"] == "x"
+
+    def test_invalid_json(self, tmp_path):
+        art_dir = tmp_path / ARTIFACT_DIR
+        art_dir.mkdir()
+        (art_dir / "workspace_snapshot.json").write_text("not json")
+        assert _load_workspace_snapshot(str(tmp_path)) is None
+
+
+# ── resolve_repo_target ─────────────────────────────────
+
+
+class TestResolveRepoTarget:
+    def test_no_args(self):
+        from config_manager import ConfigManager
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as td:
+            cm = ConfigManager(config_path=Path(td) / "cfg.yaml")
+            result = resolve_repo_target(config=cm)
+            assert isinstance(result, dict)
+            assert result["error_code"] == "INVALID_ARGS"
+
+    def test_multi_repo_rejected(self):
+        from config_manager import ConfigManager
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as td:
+            cm = ConfigManager(config_path=Path(td) / "cfg.yaml")
+            result = resolve_repo_target(config=cm, repos_arg="a,b")
+            assert isinstance(result, dict)
+            assert result["error_code"] == "TASK_TOO_COMPLEX"
+
+    def test_workspace_not_found(self):
+        from config_manager import ConfigManager
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as td:
+            cm = ConfigManager(config_path=Path(td) / "cfg.yaml")
+            result = resolve_repo_target(config=cm, workspace_arg="nonexistent")
+            assert isinstance(result, dict)
+            assert result["error_code"] == "PATH_NOT_FOUND"
+
+    def test_workspace_with_session(self, tmp_path):
+        """Full resolution from workspace with session + snapshot."""
+        from config_manager import ConfigManager
+        import yaml
+
+        ws_path = tmp_path / "ws"
+        ws_path.mkdir()
+        art_dir = ws_path / ARTIFACT_DIR
+        art_dir.mkdir()
+
+        # Session
+        session = {"ws_path": str(ws_path), "workspace_name": "test-ws",
+                   "task": "t", "engine": "e", "created_at": ""}
+        (art_dir / "session.json").write_text(json.dumps(session))
+
+        # Snapshot (single repo)
+        repo_path = str(ws_path / "myrepo")
+        Path(repo_path).mkdir()
+        snapshot = {"repos": [{"name": "myrepo", "path": repo_path}]}
+        (art_dir / "workspace_snapshot.json").write_text(json.dumps(snapshot))
+
+        # Config
+        cfg_path = tmp_path / "cfg.yaml"
+        cfg_data = {"coding_master": {"workspaces": {"test-ws": str(ws_path)}}}
+        cfg_path.write_text(yaml.dump(cfg_data))
+        cm = ConfigManager(config_path=cfg_path)
+
+        binding = resolve_repo_target(config=cm, workspace_arg="test-ws")
+        assert isinstance(binding, RepoTargetBinding)
+        assert binding.workspace.name == "test-ws"
+        assert binding.target.repo_name == "myrepo"
+        assert binding.target.repo_path == repo_path
+
+
+# ── resolve_test_command ────────────────────────────────
+
+
+class TestResolveTestCommand:
+    def test_no_pyproject(self, tmp_path):
+        from config_manager import ConfigManager
+        cm = ConfigManager(config_path=tmp_path / "cfg.yaml")
+        result = resolve_test_command(str(tmp_path), "myrepo", cm, "ws0")
+        assert result is None
+
+    def test_repo_config_fallback(self, tmp_path):
+        from config_manager import ConfigManager
+        import yaml
+
+        cfg_path = tmp_path / "cfg.yaml"
+        cfg_path.write_text(yaml.dump({
+            "coding_master": {
+                "repos": {
+                    "myrepo": {
+                        "url": str(tmp_path),
+                        "test_command": "make test",
+                    }
+                }
+            }
+        }))
+        cm = ConfigManager(config_path=cfg_path)
+        result = resolve_test_command(str(tmp_path), "myrepo", cm, "ws0")
+        assert result == "make test"
+
+    def test_pyproject_exists(self, tmp_path):
+        (tmp_path / "pyproject.toml").write_text("[project]\nname = \"x\"\n")
+        from config_manager import ConfigManager
+        cm = ConfigManager(config_path=tmp_path / "cfg.yaml")
+        result = resolve_test_command(str(tmp_path), "myrepo", cm, "ws0")
+        assert result is not None  # Should detect pytest
+
+
+# ── run_final_test ──────────────────────────────────────
+
+
+class TestRunFinalTest:
+    def test_no_test_command(self):
+        target = RepoTarget(
+            repo_name="x", repo_path="/x",
+            test_command=None, git_root="/x",
+        )
+        from config_manager import ConfigManager
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            cm = ConfigManager(config_path=Path(td) / "cfg.yaml")
+            status = run_final_test(target, cm)
+            assert status.status == "skipped"
+            assert status.reason == "command_missing"
+
+    def test_command_fails(self, tmp_path):
+        target = RepoTarget(
+            repo_name="x", repo_path=str(tmp_path),
+            test_command="false",  # always exits 1
+            git_root=str(tmp_path),
+        )
+        from config_manager import ConfigManager
+        cm = ConfigManager(config_path=tmp_path / "cfg.yaml")
+        status = run_final_test(target, cm)
+        assert status.status == "failed"
+        assert status.reason == "command_failed"
+
+    def test_command_passes(self, tmp_path):
+        target = RepoTarget(
+            repo_name="x", repo_path=str(tmp_path),
+            test_command="true",  # always exits 0
+            git_root=str(tmp_path),
+        )
+        from config_manager import ConfigManager
+        cm = ConfigManager(config_path=tmp_path / "cfg.yaml")
+        status = run_final_test(target, cm)
+        assert status.status == "passed"
+        assert status.reason == "success"
+
+
+# ── find_active_workspaces_by_repos ─────────────────────
+
+
+class TestFindActiveWorkspacesByRepos:
+    def test_no_workspaces(self):
+        from config_manager import ConfigManager
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            cm = ConfigManager(config_path=Path(td) / "cfg.yaml")
+            result = find_active_workspaces_by_repos(cm, ["myrepo"])
+            assert result == []

--- a/src/everbot/core/session/history_utils.py
+++ b/src/everbot/core/session/history_utils.py
@@ -5,6 +5,7 @@ Public API:
 - _is_placeholder(msg) — identify placeholder messages (metadata + legacy content)
 - _estimate_tokens(messages) — estimate token count (chars // 3)
 - evict_oldest_heartbeat(history, max_heartbeat) — cap heartbeat count with FIFO eviction
+- prepare_for_restore(messages) — strip placeholders and normalize heartbeat results for LLM context
 """
 
 from __future__ import annotations
@@ -132,5 +133,57 @@ def evict_oldest_heartbeat(
             if i + 1 < len(history) and _is_placeholder(history[i + 1]):
                 continue
 
+        result.append(msg)
+    return result
+
+
+# ── Restore preparation ─────────────────────────────────────────────
+
+
+def _normalize_heartbeat(msg: dict) -> dict:
+    """Convert a heartbeat message to a normal assistant message for LLM context.
+
+    Strips heartbeat-specific markers (metadata.source, content prefix) so the
+    message becomes a regular assistant message that the LLM can reference in
+    follow-up turns.  Traceability fields (run_id, injected_at) are preserved.
+    """
+    msg = dict(msg)
+
+    # Strip legacy content prefix
+    content = msg.get("content") or ""
+    if isinstance(content, str) and content.startswith(_HEARTBEAT_PREFIX):
+        content = content[len(_HEARTBEAT_PREFIX):].lstrip("\n")
+        msg["content"] = content
+
+    # Remove heartbeat source marker; keep other metadata intact
+    meta = msg.get("metadata")
+    if isinstance(meta, dict):
+        meta = {k: v for k, v in meta.items() if k != "source"}
+        msg["metadata"] = meta if meta else None
+
+    return msg
+
+
+def prepare_for_restore(messages: List[dict]) -> List[dict]:
+    """Prepare history messages for LLM context restoration.
+
+    Two concerns separated:
+    - **Placeholders** (structural role-alternation artifacts) → removed
+    - **Heartbeat results** (content-bearing async task output) → normalized
+      to regular assistant messages so the LLM can reference them in follow-ups
+
+    After normalization, heartbeat results lose their source marker and become
+    indistinguishable from normal assistant messages.  This is intentional:
+    once restored, they follow normal context-budget management.  The write-path
+    eviction (evict_oldest_heartbeat) operates on raw disk data and is unaffected.
+    """
+    result: List[dict] = []
+    for msg in messages:
+        if not isinstance(msg, dict):
+            continue
+        if _is_placeholder(msg):
+            continue
+        if _is_heartbeat(msg):
+            msg = _normalize_heartbeat(msg)
         result.append(msg)
     return result

--- a/src/everbot/core/session/persistence.py
+++ b/src/everbot/core/session/persistence.py
@@ -14,7 +14,7 @@ import logging
 
 from ...infra.dolphin_state_adapter import DolphinStateAdapter
 from .compressor import SessionCompressor
-from .history_utils import _is_heartbeat, _is_placeholder
+from .history_utils import _is_heartbeat, _is_placeholder, prepare_for_restore
 from .session_data import SessionData
 from . import session_ids as _sid
 
@@ -457,10 +457,11 @@ class SessionPersistence:
                 session_data.history_messages or []
             )
 
-            # 0b. Strip heartbeat-injected messages and placeholder artifacts.
-            #     Heartbeat results are for async notification only; they must not
-            #     be restored into the LLM conversation context.
-            history = self._filter_heartbeat_messages(history)
+            # 0b. Strip structural placeholders and normalize heartbeat results.
+            #     Placeholders (role-alternation artifacts) are removed.
+            #     Heartbeat results are preserved as normal assistant messages
+            #     so the LLM can reference them in follow-up turns.
+            history = prepare_for_restore(history)
 
             # 1. Build portable state, filtering non-restorable variables.
             #    workspace_instructions is re-injected at runtime; _history is

--- a/tests/unit/test_history_policy.py
+++ b/tests/unit/test_history_policy.py
@@ -10,7 +10,9 @@ from src.everbot.core.session.history_utils import (
     _is_heartbeat,
     _is_placeholder,
     _estimate_tokens,
+    _normalize_heartbeat,
     evict_oldest_heartbeat,
+    prepare_for_restore,
 )
 from src.everbot.core.session.compressor import (
     SessionCompressor,
@@ -408,44 +410,52 @@ class TestCompressHistory:
 
 
 class TestRestoreFilter:
-    def test_heartbeat_removed(self):
-        history = [_user("hi"), *_heartbeat_turn("hb_1"), _user("bye")]
-        result = SessionPersistence._filter_heartbeat_messages(history)
-        assert len(result) == 2
-        assert all(not _is_heartbeat(m) for m in result)
+    """Tests for prepare_for_restore: placeholders stripped, heartbeat content preserved."""
 
-    def test_placeholder_removed_with_heartbeat(self):
+    def test_heartbeat_content_preserved(self):
+        history = [_user("hi"), *_heartbeat_turn("hb_1"), _user("bye")]
+        result = prepare_for_restore(history)
+        # user("hi") + heartbeat_result(normalized) + user("bye") = 3
+        assert len(result) == 3
+        assert result[1]["role"] == "assistant"
+        assert result[1]["content"] == "检测正常"
+        assert not _is_heartbeat(result[1])  # no longer tagged as heartbeat
+
+    def test_placeholder_removed_heartbeat_kept(self):
         history = _heartbeat_turn("hb_1")
-        result = SessionPersistence._filter_heartbeat_messages(history)
-        assert len(result) == 0
+        result = prepare_for_restore(history)
+        # 2 placeholders removed, 1 heartbeat result kept
+        assert len(result) == 1
+        assert result[0]["content"] == "检测正常"
+        assert not _is_heartbeat(result[0])
 
     def test_legacy_placeholder_removed(self):
         history = [
             {"role": "assistant", "content": "(acknowledged)"},
             {"role": "user", "content": "[Background notification follows]"},
         ]
-        result = SessionPersistence._filter_heartbeat_messages(history)
+        result = prepare_for_restore(history)
         assert len(result) == 0
 
-    def test_legacy_heartbeat_removed(self):
+    def test_legacy_heartbeat_normalized(self):
         history = [_legacy_heartbeat("test")]
-        result = SessionPersistence._filter_heartbeat_messages(history)
-        assert len(result) == 0
+        result = prepare_for_restore(history)
+        assert len(result) == 1
+        assert result[0]["content"] == "test"  # prefix stripped
+        assert not _is_heartbeat(result[0])
 
-    def test_chat_preserved(self):
+    def test_chat_preserved_with_heartbeat(self):
         history = [_user("hi"), _assistant("hello"), *_heartbeat_turn("hb_1"), _user("q")]
-        result = SessionPersistence._filter_heartbeat_messages(history)
-        assert len(result) == 3
+        result = prepare_for_restore(history)
+        # user("hi") + assistant("hello") + heartbeat(normalized) + user("q") = 4
+        assert len(result) == 4
         assert result[0]["content"] == "hi"
         assert result[1]["content"] == "hello"
-        assert result[2]["content"] == "q"
+        assert result[2]["content"] == "检测正常"
+        assert result[3]["content"] == "q"
 
-    def test_filter_preserves_valid_structure(self):
-        """Heartbeat filter must not corrupt chat message structure.
-
-        After filtering, remaining messages must all be valid dicts with a
-        'role' field — no orphaned fragments from partial heartbeat turns.
-        """
+    def test_preserves_valid_structure(self):
+        """After prepare_for_restore, all messages are valid dicts with role."""
         history = [
             _user("hi"),
             _assistant("hello"),
@@ -453,11 +463,31 @@ class TestRestoreFilter:
             _user("follow-up"),
             _assistant("sure"),
         ]
-        result = SessionPersistence._filter_heartbeat_messages(history)
-        assert len(result) == 4
+        result = prepare_for_restore(history)
+        assert len(result) == 5
         assert all(isinstance(m, dict) and "role" in m for m in result)
         assert result[0]["content"] == "hi"
         assert result[-1]["content"] == "sure"
+
+    def test_normalize_preserves_traceability(self):
+        """run_id and injected_at survive normalization for debugging."""
+        hb = _heartbeat_msg("run_42", "paper report")
+        normalized = _normalize_heartbeat(hb)
+        assert normalized["metadata"]["run_id"] == "run_42"
+        assert "source" not in normalized["metadata"]
+
+    def test_normalize_strips_legacy_prefix(self):
+        legacy = _legacy_heartbeat("actual content")
+        normalized = _normalize_heartbeat(legacy)
+        assert normalized["content"] == "actual content"
+        assert "metadata" not in normalized or normalized.get("metadata") is None
+
+    def test_old_filter_still_works(self):
+        """_filter_heartbeat_messages still strips all heartbeat messages (backward compat)."""
+        history = [_user("hi"), *_heartbeat_turn("hb_1"), _user("bye")]
+        result = SessionPersistence._filter_heartbeat_messages(history)
+        assert len(result) == 2
+        assert all(not _is_heartbeat(m) for m in result)
 
 
 # ── 6.6 TestEndToEnd ────────────────────────────────────────────────
@@ -540,10 +570,13 @@ class TestEndToEnd:
         hb_count = sum(1 for m in evicted if _is_heartbeat(m))
         assert hb_count == MAX_HEARTBEAT_MESSAGES
 
-        # restore filter
-        filtered = SessionPersistence._filter_heartbeat_messages(evicted)
-        assert all(not _is_heartbeat(m) for m in filtered)
-        assert all(not _is_placeholder(m) for m in filtered)
+        # restore: placeholders stripped, heartbeat content preserved
+        restored = prepare_for_restore(evicted)
+        assert all(not _is_heartbeat(m) for m in restored)
+        assert all(not _is_placeholder(m) for m in restored)
         # Chat preserved
-        chat_msgs = [m for m in filtered if m.get("role") == "user"]
+        chat_msgs = [m for m in restored if m.get("role") == "user"]
         assert len(chat_msgs) == 5
+        # Heartbeat content preserved (normalized) — count matches post-eviction cap
+        hb_restored = [m for m in restored if m.get("role") == "assistant"]
+        assert len(hb_restored) == MAX_HEARTBEAT_MESSAGES

--- a/tests/unit/test_session_manager_core.py
+++ b/tests/unit/test_session_manager_core.py
@@ -1195,38 +1195,32 @@ class TestHeartbeatResponseDoesNotPollutePrimaryConversation:
 # ===========================================================================
 
 class TestIsolatedJobResultNotRestoredToLLMContext:
-    """Production bug: isolated routine results (heartbeat-injected assistant
-    messages) are persisted in primary session's history_messages. When
-    restore_to_agent loads the session for the next chat turn, these heartbeat
-    messages appear in the LLM context as if they were normal conversation
-    messages.
+    """Heartbeat-injected messages are normalized during restore_to_agent:
 
-    Example from production history_messages:
+    - Placeholders ((acknowledged), [Background notification follows]) are stripped
+    - Heartbeat results are preserved as normal assistant messages (source marker
+      and content prefix removed) so the LLM can reference them in follow-up turns
+
+    Example from production history_messages after restore:
         [0] user: "你好"
-        [1] assistant: "[此消息由心跳系统自动执行例行任务生成] MicroStrategy 吸引子分析..."
-        [2] user: "帮我搜索 Anthropic 新闻"
-        [3] assistant: "[此消息由心跳系统自动执行例行任务生成] 会话轨迹健康检测..."
-
-    The LLM sees these heartbeat results as part of the conversation, which:
-    - Confuses the model about what the user is asking
-    - Wastes context window with irrelevant heartbeat output
-    - Can cause the model to reference heartbeat analysis in unrelated replies
+        [1] assistant: "你好！有什么可以帮助你的？"
+        [2] assistant: "MicroStrategy 吸引子分析：当前价格..."   ← heartbeat, normalized
+        [3] user: "帮我搜索 Anthropic 新闻"
+        [4] assistant: "会话轨迹健康检测结果..."               ← heartbeat, normalized
     """
 
     @pytest.mark.asyncio
-    async def test_heartbeat_messages_filtered_during_restore(self, tmp_path: Path):
-        """restore_to_agent should filter out heartbeat-injected messages so
-        the LLM only sees real user-assistant conversation turns."""
+    async def test_heartbeat_messages_normalized_during_restore(self, tmp_path: Path):
+        """restore_to_agent should normalize heartbeat messages: strip source marker
+        and content prefix, but preserve the actual content for follow-up context."""
         manager = SessionManager(tmp_path)
         session_id = "web_session_test_agent"
 
-        # Build a session with heartbeat messages mixed into conversation
         session_data = _make_session_data(
             session_id=session_id,
             history_messages=[
                 {"role": "user", "content": "你好"},
                 {"role": "assistant", "content": "你好！有什么可以帮助你的？"},
-                # Heartbeat result injected by _inject_result_to_primary_history
                 {"role": "assistant", "content": "(acknowledged)"},
                 {"role": "user", "content": "[Background notification follows]"},
                 {
@@ -1234,9 +1228,7 @@ class TestIsolatedJobResultNotRestoredToLLMContext:
                     "content": "[此消息由心跳系统自动执行例行任务生成]\n\nMicroStrategy 吸引子分析：当前价格...",
                     "metadata": {"source": "heartbeat", "run_id": "hb_001"},
                 },
-                # Another real conversation turn
                 {"role": "user", "content": "帮我搜索 Anthropic 最新的新闻"},
-                # Another heartbeat injection
                 {"role": "assistant", "content": "(acknowledged)"},
                 {"role": "user", "content": "[Background notification follows]"},
                 {
@@ -1251,12 +1243,11 @@ class TestIsolatedJobResultNotRestoredToLLMContext:
         agent = _make_mock_agent()
         await manager.restore_to_agent(agent, session_data)
 
-        # Check what was passed to import_portable_session
         call_args = agent.snapshot.import_portable_session.call_args
         portable = call_args[0][0]
         restored_history = portable["history_messages"]
 
-        # Heartbeat messages should NOT be in the restored context
+        # Heartbeat source marker should be stripped (normalized to normal messages)
         heartbeat_messages = [
             m for m in restored_history
             if isinstance(m, dict)
@@ -1264,10 +1255,17 @@ class TestIsolatedJobResultNotRestoredToLLMContext:
             and m["metadata"].get("source") == "heartbeat"
         ]
         assert len(heartbeat_messages) == 0, (
-            f"Found {len(heartbeat_messages)} heartbeat message(s) in restored history. "
-            "Heartbeat-injected messages should be filtered during restore_to_agent "
-            "to prevent isolated job results from polluting the LLM conversation context."
+            "Heartbeat source markers should be stripped during restore"
         )
+
+        # But heartbeat content should be preserved (prefix stripped)
+        contents = [m.get("content") for m in restored_history]
+        assert "MicroStrategy 吸引子分析：当前价格..." in contents
+        assert "会话轨迹健康检测结果..." in contents
+
+        # Placeholders should be gone
+        assert "(acknowledged)" not in contents
+        assert "[Background notification follows]" not in contents
 
     @pytest.mark.asyncio
     async def test_heartbeat_placeholder_messages_filtered_during_restore(self, tmp_path: Path):
@@ -1351,7 +1349,11 @@ class TestIsolatedJobResultNotRestoredToLLMContext:
             isinstance(m, dict) and m.get("content") == multimodal_content
             for m in restored_history
         ), "Multimodal message with list content should be preserved after filtering"
-        # Heartbeat and placeholders should still be filtered
-        assert len(restored_history) == 2, (
-            f"Expected 2 messages (multimodal user + assistant reply), got {len(restored_history)}"
+        # Placeholders stripped, heartbeat content preserved (normalized)
+        assert len(restored_history) == 3, (
+            f"Expected 3 messages (multimodal user + assistant reply + heartbeat result), got {len(restored_history)}"
         )
+        # Heartbeat result normalized: prefix stripped, no longer tagged
+        hb_msg = restored_history[2]
+        assert hb_msg["content"] == "结果..."
+        assert hb_msg.get("metadata", {}).get("source") is None


### PR DESCRIPTION
## Summary

  - **coding-master auto-dev/submit**: 新增两层 repo target 模型，支持 `auto-dev` 自动开发和 `submit` 提交命令，skill 可以自动解析目标仓库并在其中执行开发工作流
  - **heartbeat 上下文修复**: `restore_to_agent` 恢复会话时错误地剥离了所有 heartbeat 消息（含论文报告等异步任务结果），导致用户追问时 LLM 完全丢失上下文。拆分 restore
  过滤逻辑：placeholder（结构性填充）剥离，heartbeat 结果归化为普通 assistant 消息保留

  ## Changes

  ### coding-master skill
  - 新增 `auto-dev` / `submit` 子命令（`dispatch.py`）
  - 新增 `repo_target.py`：两层仓库目标解析（explicit → workspace inference）
  - 更新 SKILL.md 命令文档，新增 full-command-reference.md
  - 单元测试覆盖 auto-dev 流程和 repo target 解析

  ### session restore fix
  - `history_utils.py`: 新增 `prepare_for_restore()` 和 `_normalize_heartbeat()`，分离写入路径（eviction 用 heartbeat 标记）和读取路径（归化为普通消息）
  - `persistence.py`: `restore_to_agent` 中 `_filter_heartbeat_messages` → `prepare_for_restore`
  - 更新相关测试断言：heartbeat 内容保留、placeholder 剥离、legacy 格式兼容

  ## Test plan

  - [x] `python -m pytest tests/ -v` — 1101 passed, 0 failed