### PR TITLE
fix(memory): cap reinforce at 0.95 so review can evict bad entries

### DIFF
--- a/src/everbot/core/memory/merger.py
+++ b/src/everbot/core/memory/merger.py
@@ -36,6 +36,12 @@ _EVENT_HALF_LIFE_DAYS = 30.0
 # Dedup parameters
 _SIMILARITY_THRESHOLD = 0.35
 
+# Reinforce ceiling: caps the unbounded climb so a wrongly-reinforced
+# entry stays demotable by review (×0.3 from 0.95 lands at 0.285, below
+# the 0.5 injection threshold; without the cap, scores reach 0.99+ and
+# review's deprecate can no longer push them out of the active set).
+_REINFORCE_CEILING = 0.95
+
 
 def _tokenize(text: str) -> Set[str]:
     """Tokenize text for similarity comparison.
@@ -106,7 +112,8 @@ class MemoryMerger:
 
     def reinforce(self, entry: MemoryEntry) -> MemoryEntry:
         """Reinforce an existing entry: boost score with diminishing returns."""
-        entry.score = entry.score + (1.0 - entry.score) * 0.2
+        boosted = entry.score + (1.0 - entry.score) * 0.2
+        entry.score = min(_REINFORCE_CEILING, boosted)
         entry.activation_count += 1
         entry.last_activated = datetime.now(timezone.utc).isoformat()
         return entry

--- a/tests/unit/test_memory_merger.py
+++ b/tests/unit/test_memory_merger.py
@@ -72,6 +72,21 @@ class TestReinforce:
         # 0.2 + (1.0 - 0.2) * 0.2 = 0.2 + 0.16 = 0.36
         assert abs(entry.score - 0.36) < 0.001
 
+    def test_reinforce_caps_at_ceiling(self):
+        # Without a cap, 0.94 + (1-0.94)*0.2 = 0.952. The cap pulls it back
+        # to 0.95 so review's deprecate (×0.3) can still meaningfully demote
+        # an entry that was reinforced from a wrong extraction.
+        merger = MemoryMerger()
+        entry = _make_entry(score=0.94, activation_count=5)
+        merger.reinforce(entry)
+        assert abs(entry.score - 0.95) < 0.001
+
+    def test_reinforce_idempotent_at_ceiling(self):
+        merger = MemoryMerger()
+        entry = _make_entry(score=0.95, activation_count=5)
+        merger.reinforce(entry)
+        assert abs(entry.score - 0.95) < 0.001
+
 
 class TestDecay:
     """Time-based decay with 7-day protection."""


### PR DESCRIPTION
## Summary

- `MemoryMerger.reinforce` was unbounded — repeated calls push score asymptotically to 1.0
- Once an entry reached 0.95+, the 2h auto-review's `deprecate_ids` (×0.3) lands at 0.285+, and a single later reinforce restores it above the 0.5 injection threshold → the bad entry oscillates instead of being evicted
- This commit caps `reinforce` at 0.95 so deprecate-from-ceiling lands at 0.285 (below threshold) and requires multiple reinforces to climb back, giving review a real path to remove pollution from wrongly-extracted entries

## Why this is enough on its own

Auto-review (`memory_review.py`, scheduled every 2h via `inspector.py`'s builtin job) already provides the consolidation/eviction loop. It just couldn't make progress against entries pinned near 1.0. The cap is the missing piece.

Categorical decay rates and `activation_count`-aware decay were considered as follow-ups but no actual symptom yet justifies them — defer until observation shows fact-class drift or stale-decision retention.

## Test plan

- [x] `pytest tests/unit/test_memory_merger.py` — 35 passed (includes 2 new cases: `test_reinforce_caps_at_ceiling`, `test_reinforce_idempotent_at_ceiling`)
- [x] `pytest tests/unit/test_memory_*.py` — 71 passed (no regression in manager / events / dedup)
- [ ] After deploy: monitor `demo_agent`'s `e68edd` profile entry (currently score 0.98, a known hallucination case) — expect it to fall below the 0.5 injection threshold within 1–2 review cycles

🤖 Generated with [Claude Code](https://claude.com/claude-code)