### PR TITLE
feat(skill): twitter-watch — 抓 X 用户最新推文 + claude code 深度分析 (#41)

### DIFF
--- a/skills/twitter-watch/SKILL.md
+++ b/skills/twitter-watch/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: twitter-watch
+description: Fetch a given X (Twitter) user's latest tweets and run a deep analysis with claude code. Use when the user wants to watch/track an X account or analyze someone's recent tweets.
+version: "1.0.0"
+tags: [twitter, x, social, analysis, claude, watch]
+---
+
+# Twitter Watch Skill
+
+抓取指定 X(Twitter)用户的最新推文,并用 **claude code**(`claude -p`)做**深度分析**,产出结构化中文报告。可手动调用,也可注册为每日定时任务。
+
+## When to Use
+
+- 用户想看某个 X 账号的最新动态 / 让你跟踪某人推特(如 "看下 Serenity 最近发了啥"、"分析下 @aleabitoreddit 的最新推文")
+- 每日定时推送某账号的推文分析
+
+默认目标账号:**@aleabitoreddit**(显示名 Serenity)。
+
+## 前置依赖(已就绪,无需安装)
+
+- 抓取复用同级 **`web`** 技能的 Playwright 浏览器(端口 9222)及其**已登录 X** 的持久化 profile。脚本会在 server 未起时自动 `web/server.sh &` 拉起。
+- 分析用 `claude` CLI(claude code),已在 PATH。
+
+## 用法
+
+两步:抓取 → 分析。用 `run_command` 执行(脚本用绝对路径)。
+
+```bash
+TW="$SKILL_DIR/scripts"
+
+# 1) 抓最新 3 条(默认 handle 见 config/.env;也可显式传 handle)
+python "$TW/fetch_tweets.py" aleabitoreddit --count 3 > /tmp/tweets.json
+
+# 2) 深度分析(claude code),输出中文报告
+python "$TW/analyze.py" --input /tmp/tweets.json
+
+# 或一行管道
+python "$TW/fetch_tweets.py" aleabitoreddit --count 3 | python "$TW/analyze.py"
+```
+
+把 `analyze.py` 的报告原样作为给用户的回复。
+
+## 脚本
+
+- `scripts/fetch_tweets.py <handle> [--count N]` — 抓最新 N 条非置顶推文,按时间倒序,输出 JSON(正文/时间/URL/互动数)。**未登录/cookie 失效时退出码 3 并提示去 `web` profile 重登,绝不伪造内容。**
+- `scripts/analyze.py [--input f] [--model M] [--timeout S]` — 读推文 JSON(默认 stdin),调 `claude -p` 产出逐条解读 / 投资信号与标的 / 整体主题 / 作者立场 的中文报告。
+
+## 已知限制
+
+- 时间线视图对长推文会截断(X 的 "Show more")。当前抓的是时间线可见文本,超长推文末尾可能 "原文中断";`analyze.py` 会标注而非编造。如需全文,后续可增强为逐条打开 status 链接抓取。
+- 抓取依赖 X 页面 DOM 结构;X 改版时 `fetch_tweets.py` 的选择器需跟进。
+- X 会话 cookie 会过期;过期后在 `web` 技能的持久化 profile 里重新登录一次即可。
+
+## 配置
+
+见 `config/.env.template`:默认 handle、抓取条数等(复制为 `.env` 后生效,可选)。

--- a/skills/twitter-watch/config/.env.template
+++ b/skills/twitter-watch/config/.env.template
@@ -1,0 +1,13 @@
+# twitter-watch 默认配置(复制为 .env 生效;均为可选,命令行参数优先)
+
+# 默认监控的 X 用户名(不含 @)
+TWITTER_WATCH_HANDLE=aleabitoreddit
+
+# 默认抓取最新条数
+TWITTER_WATCH_COUNT=3
+
+# claude 分析超时(秒)
+TWITTER_WATCH_CLAUDE_TIMEOUT=180
+
+# 可选:指定 claude 模型(留空用 claude 默认)
+TWITTER_WATCH_CLAUDE_MODEL=

--- a/skills/twitter-watch/scripts/analyze.py
+++ b/skills/twitter-watch/scripts/analyze.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""把抓到的推文喂给 claude code(``claude -p`` headless)做深度分析,产出中文报告。
+
+输入:fetch_tweets.py 的 JSON(从 stdin 读,或 --input 指定文件)。
+输出:claude 生成的结构化深度分析报告(stdout)。
+
+纯文本分析,不开 --dangerously-skip-permissions(claude 只读 prompt、不动文件)。
+
+用法:
+    python fetch_tweets.py aleabitoreddit --count 3 | python analyze.py
+    python analyze.py --input tweets.json
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+
+_PROMPT_TEMPLATE = """你是资深投资与科技分析师。下面是 X 用户 @{handle} 最新的 {n} 条推文(含互动数据 metrics)。请做**深度分析**,用**中文**输出结构化报告。要求基于推文内容分析,保留关键原文引用,**不要编造推文未提及的信息**。
+
+## 逐条解读
+对每条推文:核心观点(1-2 句)+ 涉及的标的/资产(如 $XXX)+ 信号类型(看多/看空/中性/纯信息)。
+
+## 投资信号与标的
+汇总提到的股票/资产,逐个给出:作者的多空倾向、其依据、潜在交易机会与风险点。
+
+## 整体主题与趋势
+这批推文的共同主题、叙事/观点变化、值得持续跟踪的线索。
+
+## 作者立场与情绪
+作者整体的观点倾向、确信度、可能的偏见或争议点。
+
+---
+推文数据(JSON):
+{tweets_json}
+"""
+
+
+def build_prompt(data: dict) -> str:
+    handle = data.get("handle", "?")
+    tweets = data.get("tweets", [])
+    return _PROMPT_TEMPLATE.format(
+        handle=handle,
+        n=len(tweets),
+        tweets_json=json.dumps(data, ensure_ascii=False, indent=2),
+    )
+
+
+def run_claude(prompt: str, model: str | None, timeout: int) -> str:
+    cmd = ["claude", "-p", prompt]
+    if model:
+        cmd += ["--model", model]
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    except FileNotFoundError:
+        sys.exit("[analyze] 未找到 claude CLI — 确认 claude code 已安装且在 PATH")
+    except subprocess.TimeoutExpired:
+        sys.exit(f"[analyze] claude 分析超时(>{timeout}s)")
+    if proc.returncode != 0:
+        sys.stderr.write(proc.stderr)
+        sys.exit(f"[analyze] claude 退出码 {proc.returncode}")
+    out = proc.stdout.strip()
+    if not out:
+        sys.exit("[analyze] claude 返回空报告")
+    return out
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="用 claude code 深度分析推文")
+    ap.add_argument("--input", help="推文 JSON 文件(默认从 stdin 读)")
+    ap.add_argument("--model", default=None, help="指定 claude 模型(默认用 claude 默认)")
+    ap.add_argument("--timeout", type=int, default=180, help="claude 超时秒数(默认 180)")
+    args = ap.parse_args()
+
+    raw = open(args.input, encoding="utf-8").read() if args.input else sys.stdin.read()
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as e:
+        sys.exit(f"[analyze] 输入不是合法 JSON: {e}")
+    if not data.get("tweets"):
+        sys.exit("[analyze] 输入无 tweets,无可分析内容")
+
+    report = run_claude(build_prompt(data), args.model, args.timeout)
+    print(report)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/twitter-watch/scripts/fetch_tweets.py
+++ b/skills/twitter-watch/scripts/fetch_tweets.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""抓取指定 X(Twitter)用户的最新推文。
+
+复用同级 ``web`` 技能的 Playwright 浏览器 server(端口 9222)及其**已登录 X** 的
+持久化 profile —— 不重造浏览器、不存第二份凭证。实现方式:把一段 Playwright
+``tsx`` 脚本经 stdin 喂给 ``web`` 技能目录下的 ``npx tsx``(cwd=web 技能目录,故
+``@/client.js`` 子路径导入可解析),抓到的推文以 JSON 打到 stdout。
+
+登录态保护:首屏若只见 "Sign in / Join today"(未登录/cookie 失效),直接以非零
+退出码报错,**绝不**伪造内容 —— 对齐 web 技能 SKILL.md 的 Rule 4。
+
+用法:
+    python fetch_tweets.py <handle> [--count N]
+    python fetch_tweets.py aleabitoreddit --count 3
+
+输出(stdout, JSON):
+    {"handle": "...", "count": 3, "tweets": [{"text","ts","url","is_pinned","metrics"}...]}
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import socket
+import subprocess
+import sys
+import time
+
+SKILL_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+# web 技能是同级技能:.../skills/web
+WEB_SKILL_DIR = os.path.normpath(os.path.join(SKILL_DIR, "..", "web"))
+SERVER_PORT = 9222
+
+
+def _port_open(port: int, host: str = "127.0.0.1") -> bool:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.settimeout(1.0)
+        return s.connect_ex((host, port)) == 0
+
+
+def _ensure_browser_server() -> None:
+    """确保 web 技能的浏览器 server 在 :9222 监听;不在则拉起并等待就绪。"""
+    if _port_open(SERVER_PORT):
+        return
+    server_sh = os.path.join(WEB_SKILL_DIR, "server.sh")
+    if not os.path.isfile(server_sh):
+        sys.exit(f"[fetch_tweets] web 技能 server.sh 不存在: {server_sh}")
+    log = open(os.path.join(WEB_SKILL_DIR, "server.log"), "ab")
+    subprocess.Popen(
+        ["bash", server_sh],
+        cwd=WEB_SKILL_DIR, stdout=log, stderr=log,
+        start_new_session=True,
+    )
+    for _ in range(60):  # 首次会装 chromium,放宽到 ~120s
+        if _port_open(SERVER_PORT):
+            time.sleep(1.0)  # 端口起来后给 HTTP API 一点初始化时间
+            return
+        time.sleep(2.0)
+    sys.exit("[fetch_tweets] 浏览器 server 启动超时(:9222 未就绪)")
+
+
+# 内联 Playwright 抓取脚本(经 stdin 喂给 cwd=web 技能目录的 npx tsx)。
+# handle/count 经环境变量注入,避免拼串注入风险。
+_TSX = r"""
+import { connect, waitForPageLoad } from "@/client.js";
+
+const handle = process.env.TW_HANDLE;
+const count = parseInt(process.env.TW_COUNT || "3", 10);
+
+const client = await connect();
+const page = await client.page("twitter-watch");
+await page.setViewportSize({ width: 1280, height: 2000 });
+await page.goto(`https://x.com/${handle}`, { waitUntil: "domcontentloaded" });
+await waitForPageLoad(page).catch(() => {});
+await page.waitForTimeout(5000);
+
+// 登录态保护:未登录时 X 只渲染登录墙。
+const loggedOut = await page
+  .locator('text=/Sign in to X|Sign up|Create account|Join today/')
+  .count()
+  .catch(() => 0);
+const handleVisible = await page
+  .locator(`text=/@${handle}/i`)
+  .count()
+  .catch(() => 0);
+if (loggedOut > 0 && handleVisible === 0) {
+  console.error(
+    "LOGIN_REQUIRED: x.com 显示登录墙 — web 技能 profile 未登录或 cookie 已失效," +
+    "请在该 profile 里重新登录 X 一次。"
+  );
+  await client.disconnect();
+  process.exit(3);
+}
+
+// 渐进滚动,触发懒加载,直到攒够 count 条或到达上限。
+const seen = new Map();
+for (let scroll = 0; scroll < 8 && seen.size < count; scroll++) {
+  const batch = await page.evaluate(() => {
+    const arts = Array.from(document.querySelectorAll('article[data-testid="tweet"]'));
+    return arts.map((a) => {
+      const textEl = a.querySelector('[data-testid="tweetText"]');
+      const timeEl = a.querySelector('time');
+      const linkEl = timeEl ? timeEl.closest('a') : null;
+      const social = a.querySelector('[role="group"]');
+      const pinned = !!Array.from(a.querySelectorAll('span'))
+        .find((e) => /^Pinned/i.test((e.textContent || "").trim()));
+      return {
+        text: textEl ? textEl.innerText : "",
+        ts: timeEl ? timeEl.getAttribute("datetime") : null,
+        url: linkEl ? linkEl.href : null,
+        is_pinned: pinned,
+        metrics: social ? (social.getAttribute("aria-label") || "") : "",
+      };
+    });
+  });
+  for (const t of batch) {
+    const key = t.url || t.ts || t.text.slice(0, 40);
+    if (key && !seen.has(key)) seen.set(key, t);
+  }
+  await page.evaluate(() => window.scrollBy(0, window.innerHeight * 1.5));
+  await page.waitForTimeout(1500);
+}
+
+// 置顶推文不计入"最新":按时间倒序取最新 count 条。
+let tweets = Array.from(seen.values());
+const nonPinned = tweets.filter((t) => !t.is_pinned && t.ts);
+nonPinned.sort((a, b) => (a.ts < b.ts ? 1 : -1));
+const out = nonPinned.slice(0, count);
+
+console.log(JSON.stringify({ handle, count: out.length, tweets: out }));
+await client.disconnect();
+"""
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="抓取指定 X 用户的最新推文")
+    ap.add_argument("handle", help="X 用户名(不含 @),如 aleabitoreddit")
+    ap.add_argument("--count", type=int, default=3, help="抓取最新条数(默认 3)")
+    args = ap.parse_args()
+
+    handle = args.handle.lstrip("@")
+    _ensure_browser_server()
+
+    env = dict(os.environ, TW_HANDLE=handle, TW_COUNT=str(args.count))
+    proc = subprocess.run(
+        ["npx", "tsx"],  # 无文件参数 → tsx 从 stdin 读脚本(ESM,同 web 技能用法)
+        cwd=WEB_SKILL_DIR, input=_TSX, env=env,
+        capture_output=True, text=True, timeout=180,
+    )
+    if proc.returncode != 0:
+        sys.stderr.write(proc.stderr)
+        sys.exit(f"[fetch_tweets] 抓取失败 (exit {proc.returncode})")
+
+    # tsx 的 stdout 末行才是 JSON(前面可能有 npx/loader 噪音)。
+    line = next(
+        (l for l in reversed(proc.stdout.splitlines()) if l.strip().startswith("{")),
+        "",
+    )
+    if not line:
+        sys.stderr.write(proc.stdout)
+        sys.exit("[fetch_tweets] 未拿到 JSON 输出")
+    data = json.loads(line)
+    if not data.get("tweets"):
+        sys.exit(f"[fetch_tweets] @{handle} 未抓到推文(账号不存在/受保护/页面结构变化?)")
+    print(json.dumps(data, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #41

## 做了什么
新增 skill `skills/twitter-watch/`,抓取指定 X 用户最新推文并用 claude code 深度分析。

- `scripts/fetch_tweets.py <handle> [--count N]` — 复用同级 `web` 技能的 Playwright 浏览器(:9222)+ **已登录 X** 持久化 profile,抓最新 N 条非置顶推文(按时间倒序,正文/时间/URL/互动数 JSON)。未登录/cookie 失效 → 退出码 3 提示重登,**绝不伪造**(对齐 web 技能 Rule 4)。
- `scripts/analyze.py` — 推文 JSON 喂 `claude -p`(headless)产出中文深度报告(逐条解读 / 投资信号与标的 / 整体主题 / 作者立场)。纯文本分析,不开 skip-permissions。
- `SKILL.md` / `config/.env.template` — 用法、默认 handle(aleabitoreddit)、已知限制。

## 验证(已实测)
- ✅ `fetch_tweets.py aleabitoreddit --count 3` → 3 条最新推文 JSON(正文/时间/URL/互动数)
- ✅ `… | analyze.py` → claude 产出结构化中文深度报告(含投资信号表、原文引用、风险提示;正确标注被 X 截断的原文而非编造)
- ✅ alfred 技能发现可识别 twitter-watch
- ✅ milkie 零改动(经内建 run_command 调用)

## 范围 / 后续
- 本 PR 只做 skill 本体。**每日定时任务注册**(#41 验收④)按用户要求"先手动验证再做",留待后续。
- 已知限制:时间线长推文会被 X 截断("Show more");X 改版需跟进选择器;cookie 过期需在 web profile 重登。详见 SKILL.md。

🤖 Generated with [Claude Code](https://claude.com/claude-code)