### PR TITLE
fix(heartbeat): cron/routine 隔离任务 milkie-safe — 不再调 dolphin continue_chat (#44)

### DIFF
--- a/src/everbot/core/runtime/heartbeat.py
+++ b/src/everbot/core/runtime/heartbeat.py
@@ -1471,9 +1471,20 @@ If not, reply with `HEARTBEAT_OK`.
         message: str,
         system_prompt_override: str,
     ) -> str:
-        """Run direct continue_chat path for explicit system-prompt override cases."""
+        """Run an agent turn with an explicit system-prompt override (cron/routine
+        isolated tasks). Provider-aware:
+
+        - dolphin: in-process context honours a per-turn system_prompt → ``continue_chat``.
+        - milkie: ``serve`` drops per-turn system_prompt (milkie#136), so the override
+          (job persona + ``task.description``) is folded into the message and the turn
+          runs through the orchestrator (JOB_POLICY) — keeping tool support
+          (run_command / skills, which routines need) and the turn guards. The agent's
+          baked agent.md systemPrompt (persona + skills section) is retained.
+        """
+        from ..agent.provider import provider_for
+
+        provider = provider_for(agent)
         try:
-            result = ""
             ensure_continue_chat_compatibility()
 
             from .events import emit
@@ -1481,20 +1492,15 @@ If not, reply with `HEARTBEAT_OK`.
                             source_type="heartbeat", run_id=getattr(self, '_current_run_id', None))
             await emit(self.primary_session_id, {"type": "status", "content": "后台心跳检查中..."}, **_emit_kw)
             try:
-                async for event in agent.continue_chat(
-                    message=message,
-                    stream_mode="delta",
-                    system_prompt=system_prompt_override,
-                ):
-                    if "_progress" in event:
-                        for progress in event["_progress"]:
-                            if progress.get("stage") == "llm":
-                                answer = progress.get("answer", "")
-                                if answer:
-                                    result = answer
+                if provider.needs_history_restore():
+                    return await self._override_via_continue_chat(
+                        agent, message, system_prompt_override
+                    )
+                return await self._override_via_orchestrator(
+                    agent, message, system_prompt_override
+                )
             finally:
                 await emit(self.primary_session_id, {"type": "status", "content": ""}, **_emit_kw)
-            return result
         except Exception as e:
             logger.error(
                 "Heartbeat agent execution failed: type=%s detail=%s",
@@ -1503,6 +1509,51 @@ If not, reply with `HEARTBEAT_OK`.
             )
             logger.error("执行 Agent 失败: %s", e)
             raise
+
+    @staticmethod
+    async def _override_via_continue_chat(
+        agent: Any, message: str, system_prompt_override: str,
+    ) -> str:
+        """dolphin: per-turn system_prompt override via ``continue_chat``."""
+        result = ""
+        async for event in agent.continue_chat(
+            message=message,
+            stream_mode="delta",
+            system_prompt=system_prompt_override,
+        ):
+            if "_progress" in event:
+                for progress in event["_progress"]:
+                    if progress.get("stage") == "llm":
+                        answer = progress.get("answer", "")
+                        if answer:
+                            result = answer
+        return result
+
+    async def _override_via_orchestrator(
+        self, agent: Any, message: str, system_prompt_override: str,
+    ) -> str:
+        """milkie: fold the override into the message and run via the orchestrator
+        (JOB_POLICY) so the job keeps tool support and turn guards."""
+        from .turn_orchestrator import JOB_POLICY, TurnEventType, TurnOrchestrator
+
+        combined = (
+            f"{system_prompt_override}\n\n{message}"
+            if system_prompt_override
+            else message
+        )
+        orchestrator = TurnOrchestrator(JOB_POLICY)
+        answer = ""
+        deltas: list[str] = []
+        async for ev in orchestrator.run_turn(
+            agent, combined, system_prompt=system_prompt_override, stream_mode="delta",
+        ):
+            if ev.type == TurnEventType.LLM_DELTA and ev.content:
+                deltas.append(ev.content)
+            elif ev.type == TurnEventType.TURN_COMPLETE:
+                answer = ev.answer or answer
+            elif ev.type == TurnEventType.TURN_ERROR:
+                raise RuntimeError(ev.error)
+        return answer or "".join(deltas)
 
     async def run_once(self):
         """执行一次心跳（带前置检查）"""

--- a/tests/unit/test_heartbeat_runner_core.py
+++ b/tests/unit/test_heartbeat_runner_core.py
@@ -1487,3 +1487,84 @@ class TestRunHeartbeatTurnMilkieSafe:
 
         assert out == "RESULT"
         assert runner._runtime_workspace_instructions == "DOLPHIN WS"
+
+
+class TestRunAgentWithOverrideMilkieSafe:
+    """_run_agent_with_override(cron/routine 隔离任务路径)必须 milkie-safe。
+
+    回归:milkie 下它仍直调 agent.continue_chat(dolphin 专有)→ AttributeError,
+    使所有 cron/routine 隔离任务失败(如「每日论文报告生成」)。
+    milkie 应走 orchestrator run_turn(带工具支持),并把 override 折进 message
+    (serve 丢弃 per-turn system_prompt);dolphin 仍用 continue_chat(system_prompt)。
+    """
+
+    def _patch(self, monkeypatch, provider):
+        import importlib
+        provider_mod = importlib.import_module(
+            HeartbeatRunner.__module__.rsplit(".", 2)[0] + ".agent.provider"
+        )
+        # heartbeat._run_agent_with_override 与 orchestrator._run_attempt 都经
+        # provider_for(agent) 取 provider(均为函数内惰性 import)→ 改模块属性即生效。
+        monkeypatch.setattr(provider_mod, "provider_for", lambda agent: provider)
+        import src.everbot.core.runtime.heartbeat as hb
+        monkeypatch.setattr(hb, "ensure_continue_chat_compatibility", lambda: None)
+
+        async def _emit(*a, **k):
+            return None
+
+        import src.everbot.core.runtime.events as ev
+        monkeypatch.setattr(ev, "emit", _emit)
+
+    @pytest.mark.asyncio
+    async def test_milkie_routes_through_orchestrator_no_continue_chat(self, tmp_path, monkeypatch):
+        captured = {}
+
+        class _MilkieProvider:
+            def needs_history_restore(self):
+                return False
+
+            async def run_turn(self, agent, message, *, system_prompt="",
+                               is_first_turn=False, stream_mode="delta"):
+                captured["message"] = message
+                # 模型纯文本产出(单轮)
+                yield {"_progress": [{"stage": "llm", "delta": "今日", "answer": "", "id": "llm"}]}
+                yield {"_progress": [{"stage": "llm", "delta": "论文报告", "answer": "", "id": "llm"}]}
+
+        # milkie handle:故意没有 continue_chat —— 若仍走老路径会 AttributeError。
+        handle = SimpleNamespace(base_url="http://x", context_id="c1")
+        self._patch(monkeypatch, _MilkieProvider())
+        runner = _make_runner(workspace_path=tmp_path)
+
+        out = await runner._run_agent_with_override(
+            handle, "请生成今天的论文报告", "SYSPROMPT-PERSONA\n\nTASK-DESC-论文"
+        )
+
+        assert out == "今日论文报告"
+        # override(含 task.description)必须经 message 触达模型(serve 丢 system_prompt)。
+        assert "TASK-DESC-论文" in captured["message"]
+        assert "请生成今天的论文报告" in captured["message"]
+
+    @pytest.mark.asyncio
+    async def test_dolphin_still_uses_continue_chat_with_override(self, tmp_path, monkeypatch):
+        seen = {}
+
+        async def _continue_chat(*, message, stream_mode, system_prompt):
+            seen["system_prompt"] = system_prompt
+            seen["message"] = message
+            yield {"_progress": [{"stage": "llm", "answer": "dolphin-report"}]}
+
+        agent = SimpleNamespace(continue_chat=_continue_chat)
+
+        class _DolphinProvider:
+            def needs_history_restore(self):
+                return True
+
+        self._patch(monkeypatch, _DolphinProvider())
+        runner = _make_runner(workspace_path=tmp_path)
+
+        out = await runner._run_agent_with_override(agent, "msg", "OVERRIDE")
+
+        assert out == "dolphin-report"
+        # dolphin 把 override 作为 per-turn system_prompt(进程内 context 支持)。
+        assert seen["system_prompt"] == "OVERRIDE"
+        assert seen["message"] == "msg"


### PR DESCRIPTION
Closes #44

## 问题
心跳定时 routine(如「每日论文报告生成」)在 milkie 下失败:
`'MilkieAgentHandle' object has no attribute 'continue_chat'`

## 根因
cron 隔离任务链最终走 `_run_agent_with_override → agent.continue_chat(...)` —— #38 迁移漏改的 dolphin 路径(无 override 的 `_run_heartbeat_turn` 已改走 orchestrator,带 override 这条没改)。cron 隔离任务**永远带 override** → **milkie 下所有 cron/routine 隔离任务 100% 失败**。chat / 心跳自省早是 milkie 正确路径,故仅定时任务触发才暴露。

## 修复
`_run_agent_with_override` 改为 provider 感知:
- **dolphin** `_override_via_continue_chat`:保持 `continue_chat(system_prompt=override)` 不变。
- **milkie** `_override_via_orchestrator`:serve 丢弃 per-turn system_prompt(milkie#136),把 override(job 人设 + `task.description`)折进 message,经 orchestrator `run_turn`(JOB_POLICY)执行——保留工具支持(routine 要 run_command 跑 skill)+ turn 守护;agent.md 自身 systemPrompt 保留。

## TDD / 验证
- `TestRunAgentWithOverrideMilkieSafe`:milkie 风格 agent(无 continue_chat)先复现生产同款 `AttributeError`(红)→ 修后转绿;断言**不触达 continue_chat** 且 override 经 message 触达模型;dolphin 风格 agent 仍用 continue_chat(system_prompt=override)不变。
- **全量 1639 单测通过**。
- 待重启后实跑「每日论文报告生成」routine 验证 telegram 收到报告(#44 验收④)。

## 关联
同族迁移漏网:reflector、LLM delta 去重(18268aa)、EMPTY_OUTPUT_LOOP(99585b1)、milkie 错误透出(1065f69)。milkie per-turn system_prompt 限制:#136。

🤖 Generated with [Claude Code](https://claude.com/claude-code)