### PR TITLE
fix(heartbeat): skill 任务脱离失效阿里 key + LLM 恢复改静默

### DIFF
--- a/src/everbot/core/runtime/heartbeat.py
+++ b/src/everbot/core/runtime/heartbeat.py
@@ -793,11 +793,15 @@ If not, reply with `HEARTBEAT_OK`.
                             return "HEARTBEAT_OK"
 
                 # LLM recovery check
+                # Recovery is logged only, NOT pushed to the user. Mac sleep/wake
+                # cycles make the LLM probe fail (no network while asleep) and then
+                # succeed on wake, so pushing a recovery notice spams the user with
+                # "LLM 已恢复" every time the laptop wakes. The outage notice
+                # (returned above) is the actionable signal; recovery is not.
                 if self._llm_unavailable_since is not None:
                     self._llm_unavailable_since = None
                     self._llm_unavailable_last_notified_at = None
-                    logger.info("[%s] LLM recovered", self.agent_name)
-                    await self._delivery.deliver_result("LLM 已恢复, 心跳任务恢复正常", run_id)
+                    logger.info("[%s] LLM recovered (silent, not delivered)", self.agent_name)
 
                 # Recover tasks stuck in 'running' (crash/timeout) before
                 # mode dispatch. Without this, stuck tasks cause reflect mode

--- a/tests/unit/test_heartbeat_runner_core.py
+++ b/tests/unit/test_heartbeat_runner_core.py
@@ -1362,8 +1362,13 @@ async def test_execute_once_cooldown_suppresses_repeated_notification(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_execute_once_recovery_notification(tmp_path):
-    """When LLM recovers after being unavailable, notify recovery."""
+async def test_execute_once_recovery_is_silent(tmp_path):
+    """When LLM recovers after being unavailable, clear state silently.
+
+    Recovery must NOT push a notification to the user: Mac sleep/wake cycles
+    repeatedly toggle probe failure→success, and pushing "LLM 已恢复" on every
+    wake spams the user. State is cleared but no deliver_result is called.
+    """
     runner = _setup_runner_for_execute_once(tmp_path, probe_return=False)
     # First: probe fails
     await runner._execute_once()
@@ -1383,10 +1388,9 @@ async def test_execute_once_recovery_notification(tmp_path):
     await runner._execute_once()
     # Recovery state cleared
     assert runner._llm_unavailable_since is None
-    # Recovery notification sent
-    runner._delivery.deliver_result.assert_called_once()
-    call_args = runner._delivery.deliver_result.call_args
-    assert "LLM 已恢复" in call_args[0][0]
+    assert runner._llm_unavailable_last_notified_at is None
+    # Recovery notification must NOT be pushed to the user (silent recovery)
+    runner._delivery.deliver_result.assert_not_called()
 
 
 class TestRunHeartbeatTurnMilkieSafe:

--- a/tests/unit/test_model_config.py
+++ b/tests/unit/test_model_config.py
@@ -100,3 +100,21 @@ def test_legacy_default_model_key_still_works(tmp_path):
                  "clouds:\n  c:\n    api: http://x\n    api_key: k\n", encoding="utf-8")
     mc = load_model_config(p)
     assert mc.default_model == "m" and mc.fast_model == "m"
+
+
+def test_repo_fast_tier_does_not_route_to_aliyun(monkeypatch):
+    """Regression guard (#45): the shipped config/dolphin.yaml `fast` tier must
+    not point at aliyun/dashscope. Background skill jobs (skill-evaluate Judge,
+    reflection) resolve their model via cron.py:_resolve_skill_model() ->
+    fast_model. An expired aliyun key there made every skill evaluation fail
+    with 403 access_denied while normal chat (volcengine) kept working.
+    """
+    repo_config = Path(__file__).resolve().parents[2] / "config" / "dolphin.yaml"
+    assert repo_config.exists(), repo_config
+    # Provide volcengine creds so route_for() can expand ${...} placeholders.
+    monkeypatch.setenv("VOLCENGINE_API_BASE", "https://volc.example/v1")
+    monkeypatch.setenv("VOLCENGINE_TOKEN", "vk-test")
+    mc = load_model_config(repo_config)
+    route = mc.route(fast=True)
+    assert "dashscope" not in route.base_url.lower(), route.base_url
+    assert "aliyun" not in route.base_url.lower(), route.base_url

--- a/tests/unit/test_model_config.py
+++ b/tests/unit/test_model_config.py
@@ -100,21 +100,3 @@ def test_legacy_default_model_key_still_works(tmp_path):
                  "clouds:\n  c:\n    api: http://x\n    api_key: k\n", encoding="utf-8")
     mc = load_model_config(p)
     assert mc.default_model == "m" and mc.fast_model == "m"
-
-
-def test_repo_fast_tier_does_not_route_to_aliyun(monkeypatch):
-    """Regression guard (#45): the shipped config/dolphin.yaml `fast` tier must
-    not point at aliyun/dashscope. Background skill jobs (skill-evaluate Judge,
-    reflection) resolve their model via cron.py:_resolve_skill_model() ->
-    fast_model. An expired aliyun key there made every skill evaluation fail
-    with 403 access_denied while normal chat (volcengine) kept working.
-    """
-    repo_config = Path(__file__).resolve().parents[2] / "config" / "dolphin.yaml"
-    assert repo_config.exists(), repo_config
-    # Provide volcengine creds so route_for() can expand ${...} placeholders.
-    monkeypatch.setenv("VOLCENGINE_API_BASE", "https://volc.example/v1")
-    monkeypatch.setenv("VOLCENGINE_TOKEN", "vk-test")
-    mc = load_model_config(repo_config)
-    route = mc.route(fast=True)
-    assert "dashscope" not in route.base_url.lower(), route.base_url
-    assert "aliyun" not in route.base_url.lower(), route.base_url


### PR DESCRIPTION
## 背景

用户 Telegram 收到两类干扰消息：
1. `[Heartbeat] LLM unavailable: Error code: 403 ... aliyun access_denied ... Evaluated 0/9 skills, skipped 1 due to LLM unavailability`
2. 每次打开 Mac 频繁弹 `LLM 已恢复, 心跳任务恢复正常`

## 根因

**问题1 — 哪里用了阿里模型**
后台 skill 任务（skill-evaluate 的 LLM Judge、reflection 打分）**不用 agent 主模型**，而是经 `cron.py:_resolve_skill_model()` 固定取 dolphin `fast` 档。本地 `config/dolphin.yaml` 中 `fast: qwen-turbo` → `cloud: aliyun`（dashscope）。该账户的 `ALIYUN_API_KEY` 已失效，持续返回 **403 access_denied**，于是技能评估全部失败。主聊天模型 `deepseek-volcengine` 正常，所以日常对话不受影响，仅后台 skill 任务报错。

**问题2 — 恢复消息刷屏**
`heartbeat.py` 在 LLM 恢复时 `deliver_result("LLM 已恢复, 心跳任务恢复正常")`。Mac 睡眠时无网络 → probe 失败标记不可用；唤醒后 → probe 成功 → 每次唤醒推一条恢复通知。

## 改动（本 PR 仅含代码层修复）

- `src/everbot/core/runtime/heartbeat.py`: LLM 恢复改为**只记日志、不推送用户**。失败/持续失败告警保留（那才是需要关注的信号）。
- `tests/unit/test_heartbeat_runner_core.py`: 恢复测试断言改为「静默」（`deliver_result` 不被调用）。

## 问题1 的修复（本地配置，不在本 diff 内）

`config/dolphin.yaml` 是 gitignore 的本地部署配置，不随仓库发布。修复方式为把本地该文件的 `fast: qwen-turbo` 改为 `fast: deepseek-volcengine`（已在部署机改好，重启 `everbot` 后生效）。因此该改动不作为代码进入本 PR。

> 备选：也可去阿里云百炼控制台更换有效且已开通 qwen-turbo 的 `ALIYUN_API_KEY`。

## 测试

- `tests/unit/test_model_config.py` — passed
- `tests/unit/test_heartbeat_runner_core.py` — passed

## 注意

代码改动生效需重启 `everbot` 守护进程。

🤖 Generated with [Claude Code](https://claude.com/claude-code)