### PR TITLE
feat(milkie): skill_list manifest producer — spawn 时写 MILKIE_SKILL_MANIFEST

### DIFF
--- a/src/everbot/core/agent/provider/milkie/launcher.py
+++ b/src/everbot/core/agent/provider/milkie/launcher.py
@@ -5,12 +5,38 @@
 """
 from __future__ import annotations
 
+import json
 import os
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from .agent_spec import build_milkie_agent_md, build_milkie_model_tiers
+
+
+# skill_list manifest(milkie #139):写在 milkie data-dir,经 MILKIE_SKILL_MANIFEST
+# env 告知 serve;milkie 默认 handler 读它返回真实技能列表(去 stub)。
+SKILL_MANIFEST_FILENAME = "skill-manifest.json"
+SKILL_MANIFEST_ENV = "MILKIE_SKILL_MANIFEST"
+
+
+def _render_skill_manifest(skills: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """discover_skills 结果 → skill_list manifest(milkie #139 定稿 schema)。
+
+    v1 每条目写 ``{name, description, dir}``(``dir`` = discover_skills 的
+    ``abs_path``);``version`` 留空待 s-010。milkie 消费 name/description,``dir``
+    为宿主附加字段(milkie handler 原样透传)。
+    """
+    return {
+        "skills": [
+            {
+                "name": s["name"],
+                "description": s.get("description", ""),
+                "dir": s["abs_path"],
+            }
+            for s in skills
+        ]
+    }
 
 
 @dataclass
@@ -41,7 +67,14 @@ class SidecarLauncher:
         self._default_model = default_model
         self._fast_model = fast_model
 
-    def build(self, agent_name: str, *, system_prompt: str, default_model: str | None = None) -> LaunchSpec:
+    def build(
+        self,
+        agent_name: str,
+        *,
+        system_prompt: str,
+        skills: Optional[List[Dict[str, Any]]] = None,
+        default_model: str | None = None,
+    ) -> LaunchSpec:
         # default_model:per-agent 模型覆盖(everbot.agents.<name>.model)。缺省回退全局默认。
         # 不传则**所有 agent 用同一全局模型**——会无视 per-agent 配置(实测踩到:demo_agent
         # 配 deepseek-volcengine 却被用成全局 kimi-code)。
@@ -72,4 +105,15 @@ class SidecarLauncher:
         if default_cloud != "volcengine":
             env.pop("VOLCENGINE_TOKEN", None)
             env.pop("VOLCENGINE_API_BASE", None)
+        # skill_list manifest(milkie #139):skills 非 None 即产出(含空列表 → configured
+        # but empty)。skills is None(注入式 loader / reflector)→ 不写、不设 env,milkie
+        # 侧据缺失 degrade(registryConfigured:false)。与 prompt 技能段同源(provider 侧
+        # 单次 discover_skills)。
+        if skills is not None:
+            manifest_path = data_dir / SKILL_MANIFEST_FILENAME
+            manifest_path.write_text(
+                json.dumps(_render_skill_manifest(skills), ensure_ascii=False, indent=2),
+                encoding="utf-8",
+            )
+            env[SKILL_MANIFEST_ENV] = str(manifest_path)
         return LaunchSpec(cmd=cmd, env=env, data_dir=data_dir, agent_md=agent_md)

--- a/src/everbot/core/agent/provider/milkie/provider.py
+++ b/src/everbot/core/agent/provider/milkie/provider.py
@@ -40,8 +40,16 @@ def _resolve_agent_workspace(agent_name: str) -> Path:
 REFLECTOR_AGENT = "_reflector"
 
 
-def _default_system_prompt_loader(agent_name: str) -> str:
-    """构建 milkie agent 的 system prompt —— 真实来源。
+def _build_default_prompt_and_skills(
+    agent_name: str,
+) -> tuple[str, Optional[list[dict[str, Any]]]]:
+    """构建 milkie agent 的 system prompt + 发现的 skill 列表(同一次 discover_skills)。
+
+    返回 ``(system_prompt, skills)``。``skills is None`` 表示该 agent 没有可发现的
+    技能集(reflector) —— 调用方据此决定是否产出 skill_list manifest(milkie #139)。
+
+    **同源保证**:prompt 的技能段与 skill_list manifest 由这同一份 discover_skills
+    结果产出,杜绝两份表漂移(见 milkie#139 producer 纪律)。
 
     经 :class:`WorkspaceLoader` 读取并合并 agent 工作区的 SOUL/AGENTS/SKILLS/
     USER/MEMORY.md(同 dolphin agent 的 ``$workspace_instructions``,但不耦合
@@ -50,7 +58,7 @@ def _default_system_prompt_loader(agent_name: str) -> str:
     if agent_name == REFLECTOR_AGENT:
         # reflector 的 systemPrompt 即 reflect-JSON 提示;不读业务 workspace(无污染、无需 workspace)。
         from ....runtime.inspector import _REFLECT_SYSTEM_PROMPT  # 延迟引,避免模块期循环
-        return _REFLECT_SYSTEM_PROMPT
+        return _REFLECT_SYSTEM_PROMPT, None
 
     from .....infra.workspace import WorkspaceLoader
     from .skills import build_milkie_skills_section, discover_skills
@@ -65,10 +73,11 @@ def _default_system_prompt_loader(agent_name: str) -> str:
     # 动态发现 shell 型 skill 并注入(milkie 无 dolphin 的 ResourceSkillkit;agent 经
     # 内建 run_command(milkie#134)读 SKILL.md 并跑脚本 —— 与 dolphin 能力对等)。
     # per-agent allowlist:everbot.agents.<name>.skills.include/exclude(A3,对齐 dolphin)。
+    # discover_skills 对 include/exclude 笔误 fail-loud(raise ValueError)——即 milkie#139
+    # 要求的 producer 侧 fail-fast(错误落在 spawn 边界、operator 可见)。
     include, exclude = _agent_skill_filter(agent_name)
-    section = build_milkie_skills_section(
-        discover_skills(workspace, include=include, exclude=exclude), workspace
-    )
+    skills = discover_skills(workspace, include=include, exclude=exclude)
+    section = build_milkie_skills_section(skills, workspace)
     if section:
         base = f"{base}\n\n---\n\n{section}" if base else section
 
@@ -77,7 +86,16 @@ def _default_system_prompt_loader(agent_name: str) -> str:
     if _is_telegram_serving(agent_name):
         from .....channels.attachment_directives import ATTACHMENT_INSTRUCTION
         base = f"{base}\n\n---\n\n{ATTACHMENT_INSTRUCTION}" if base else ATTACHMENT_INSTRUCTION
-    return base
+    return base, skills
+
+
+def _default_system_prompt_loader(agent_name: str) -> str:
+    """构建 milkie agent 的 system prompt —— 真实来源。
+
+    薄包装,委托 :func:`_build_default_prompt_and_skills` 并只取 prompt;保持
+    ``(agent_name) -> str`` 的 loader seam 契约不变。
+    """
+    return _build_default_prompt_and_skills(agent_name)[0]
 
 
 def _agent_skill_filter(agent_name: str):
@@ -177,9 +195,18 @@ class MilkieProvider:
             # agent 都用全局默认模型(实测 bug:demo_agent 被用成 kimi-code 而非其配置的 volcengine)。
             from ...agent_config import resolve_agent_model
             per_agent_model = resolve_agent_model(agent_name) or None
+            # 同源(milkie#139):默认 loader 时跑一次 discover_skills,prompt 技能段与
+            # skill_list manifest 共用同一结果、不漂移。注入式 loader(测试 seam)绕过
+            # 发现 → skills=None → launcher 不产出 manifest(milkie 侧据缺失 degrade)。
+            if self._system_prompt_loader is _default_system_prompt_loader:
+                system_prompt, skills = _build_default_prompt_and_skills(agent_name)
+            else:
+                system_prompt = self._system_prompt_loader(agent_name)
+                skills = None
             spec = launcher.build(
                 agent_name,
-                system_prompt=self._system_prompt_loader(agent_name),
+                system_prompt=system_prompt,
+                skills=skills,
                 default_model=per_agent_model,
             )
             return spec.cmd, spec.env

--- a/tests/unit/test_milkie_launcher.py
+++ b/tests/unit/test_milkie_launcher.py
@@ -1,7 +1,22 @@
 
+import json
+
 import pytest
 
-from src.everbot.core.agent.provider.milkie.launcher import SidecarLauncher, LaunchSpec
+from src.everbot.core.agent.provider.milkie.launcher import (
+    SidecarLauncher,
+    LaunchSpec,
+    SKILL_MANIFEST_ENV,
+    SKILL_MANIFEST_FILENAME,
+)
+
+
+# discover_skills 输出形状(name/title/description/abs_path)。
+_SKILLS = [
+    {"name": "twitter-watch", "title": "Twitter Watch",
+     "description": "抓取 X 用户最新推文", "abs_path": "/abs/twitter-watch"},
+    {"name": "ops", "title": "Ops", "description": "", "abs_path": "/abs/ops"},
+]
 
 
 def _launcher(tmp_path):
@@ -133,3 +148,65 @@ def test_build_uses_per_agent_model_override(tmp_path):
     assert fm["model"]["model"] == "my-model"        # 默认(chat)档用 per-agent 模型
     assert spec.env["OPENAI_API_KEY"] == "k2"        # 用 per-agent 模型的 cloud key
     assert fm["models"]["fast"]["model"] == "global-model"  # fast 档仍全局(单独 concern)
+
+
+# ── skill_list manifest producer(milkie #139）─────────────────────────
+
+def test_build_writes_skill_manifest_and_sets_env(tmp_path):
+    spec = _launcher(tmp_path).build("alice", system_prompt="x", skills=_SKILLS)
+    manifest_path = spec.data_dir / SKILL_MANIFEST_FILENAME
+    assert manifest_path.exists()
+    assert spec.env[SKILL_MANIFEST_ENV] == str(manifest_path)
+    data = json.loads(manifest_path.read_text(encoding="utf-8"))
+    # 定稿 schema:每条目 {name, description, dir}（dir = discover_skills 的 abs_path）。
+    assert data == {"skills": [
+        {"name": "twitter-watch", "description": "抓取 X 用户最新推文", "dir": "/abs/twitter-watch"},
+        {"name": "ops", "description": "", "dir": "/abs/ops"},
+    ]}
+
+
+def test_build_manifest_includes_every_discovered_skill(tmp_path):
+    # 防"漏列"回归:manifest 技能集合 == 传入的 discover_skills 集合，一个不少。
+    spec = _launcher(tmp_path).build("alice", system_prompt="x", skills=_SKILLS)
+    data = json.loads((spec.data_dir / SKILL_MANIFEST_FILENAME).read_text(encoding="utf-8"))
+    assert {s["name"] for s in data["skills"]} == {s["name"] for s in _SKILLS}
+
+
+def test_build_skills_none_writes_no_manifest(tmp_path):
+    # 注入式 loader / reflector：skills=None → 不产出 manifest、不设 env（milkie 侧 degrade）。
+    spec = _launcher(tmp_path).build("alice", system_prompt="x", skills=None)
+    assert not (spec.data_dir / SKILL_MANIFEST_FILENAME).exists()
+    assert SKILL_MANIFEST_ENV not in spec.env
+
+
+def test_build_default_skills_arg_is_none(tmp_path):
+    # 默认不传 skills 即 None → 向后兼容旧调用，不产出 manifest。
+    spec = _launcher(tmp_path).build("alice", system_prompt="x")
+    assert not (spec.data_dir / SKILL_MANIFEST_FILENAME).exists()
+    assert SKILL_MANIFEST_ENV not in spec.env
+
+
+def test_build_empty_skills_writes_configured_empty_manifest(tmp_path):
+    # 空技能集(configured but empty)：写 {skills:[]}、设 env —— 比"未配置"更准确。
+    spec = _launcher(tmp_path).build("alice", system_prompt="x", skills=[])
+    manifest_path = spec.data_dir / SKILL_MANIFEST_FILENAME
+    assert manifest_path.exists()
+    assert spec.env[SKILL_MANIFEST_ENV] == str(manifest_path)
+    assert json.loads(manifest_path.read_text(encoding="utf-8")) == {"skills": []}
+
+
+def test_build_manifest_missing_description_defaults_empty(tmp_path):
+    spec = _launcher(tmp_path).build(
+        "alice", system_prompt="x",
+        skills=[{"name": "n", "title": "N", "abs_path": "/abs/n"}],  # 无 description 键
+    )
+    data = json.loads((spec.data_dir / SKILL_MANIFEST_FILENAME).read_text(encoding="utf-8"))
+    assert data["skills"][0] == {"name": "n", "description": "", "dir": "/abs/n"}
+
+
+def test_build_manifest_is_valid_utf8_json_with_cjk(tmp_path):
+    # ensure_ascii=False：中文按原样写入，不转义。
+    spec = _launcher(tmp_path).build("alice", system_prompt="x", skills=_SKILLS)
+    raw = (spec.data_dir / SKILL_MANIFEST_FILENAME).read_text(encoding="utf-8")
+    assert "抓取 X 用户最新推文" in raw  # 未被 \uXXXX 转义
+    json.loads(raw)  # 合法 JSON

--- a/tests/unit/test_milkie_provider.py
+++ b/tests/unit/test_milkie_provider.py
@@ -616,10 +616,12 @@ def test_injected_system_prompt_loader_is_used(monkeypatch):
     from src.everbot.core.agent.provider.milkie.launcher import LaunchSpec
 
     captured_prompts: list = []
+    captured_skills: list = []
 
     class _CapturingLauncher:
-        def build(self, agent_name, *, system_prompt, default_model=None):
+        def build(self, agent_name, *, system_prompt, skills=None, default_model=None):
             captured_prompts.append(system_prompt)
+            captured_skills.append(skills)
             return LaunchSpec(
                 cmd=["node"], env={}, data_dir=Path("/tmp"), agent_md=Path("/tmp/a.md")
             )
@@ -647,4 +649,43 @@ def test_injected_system_prompt_loader_is_used(monkeypatch):
     # 触发 build 闭包(pool 把闭包存为 self._build)
     cmd, env = pool._build("alice")
     assert captured_prompts == ["PROMPT::alice"]
+    # 注入式 loader 绕过发现 → skills=None → 不产出 manifest(milkie#139)
+    assert captured_skills == [None]
     assert cmd == ["node"]
+
+
+def test_default_loader_feeds_discovered_skills_to_launcher(monkeypatch):
+    """默认 loader 路径:_build 跑一次 discover_skills,把 skills 喂给 launcher(同源 manifest)。"""
+    from pathlib import Path
+
+    import src.everbot.core.agent.provider.milkie.provider as mod
+    from src.everbot.core.agent.provider.milkie.launcher import LaunchSpec
+
+    captured = {}
+
+    class _CapturingLauncher:
+        def build(self, agent_name, *, system_prompt, skills=None, default_model=None):
+            captured["system_prompt"] = system_prompt
+            captured["skills"] = skills
+            return LaunchSpec(
+                cmd=["node"], env={}, data_dir=Path("/tmp"), agent_md=Path("/tmp/a.md")
+            )
+
+    monkeypatch.setattr(
+        "src.everbot.core.agent.provider.milkie.launcher.SidecarLauncher",
+        lambda **kw: _CapturingLauncher(),
+    )
+    monkeypatch.setattr("src.everbot.infra.config.get_config", lambda *a, **k: {})
+
+    # 让默认 loader 返回确定的 (prompt, skills),验证它确实被 _build 调用并透传
+    fake_skills = [{"name": "twitter-watch", "description": "d", "abs_path": "/abs/tw"}]
+    monkeypatch.setattr(
+        mod, "_build_default_prompt_and_skills",
+        lambda name: (f"PROMPT::{name}", fake_skills),
+    )
+
+    # 不注入 loader → 用模块默认 loader → 走"同源 discover"分支
+    prov = mod.MilkieProvider("http://x")
+    cmd, env = prov._get_pool()._build("alice")
+    assert captured["system_prompt"] == "PROMPT::alice"
+    assert captured["skills"] == fake_skills  # 默认路径把 skills 喂到 launcher

--- a/tests/unit/test_milkie_skills.py
+++ b/tests/unit/test_milkie_skills.py
@@ -178,6 +178,75 @@ def test_system_prompt_loader_injects_discovered_skills(tmp_path, monkeypatch):
     assert "run_command" in prompt               # 面向 run_command 的调用说明在
 
 
+# ── _build_default_prompt_and_skills:同源(prompt + skill_list manifest)─────
+
+def _setup_ws_skills(tmp_path, monkeypatch, names, *, agent="a1", config=None):
+    """搭一个 workspace + 若干 skill,隔离全局/仓库 skill 目录。返回 ws。"""
+    from src.everbot.core.agent.provider.milkie import provider as mprov
+    import src.everbot.infra.config as config_module
+
+    ws = tmp_path / "ws"
+    (ws / "skills").mkdir(parents=True)
+    (ws / "SOUL.md").write_text("身份", encoding="utf-8")
+    for n in names:
+        _make_skill(ws / "skills", n, n, f"{n} 的说明")
+    monkeypatch.setattr(mprov, "_resolve_agent_workspace", lambda _n: ws)
+    monkeypatch.setattr(msk, "resolve_skill_dirs", lambda _ws: [ws / "skills"])
+    monkeypatch.setattr(config_module, "get_config", lambda *a, **k: config or {})
+    return ws
+
+
+def test_build_default_returns_prompt_and_skills_same_source(tmp_path, monkeypatch):
+    """返回 (prompt, skills);skills 即 manifest 来源,与 prompt 技能段同一份发现结果。"""
+    from src.everbot.core.agent.provider.milkie import provider as mprov
+
+    _setup_ws_skills(tmp_path, monkeypatch, ["ops", "web", "twitter-watch"])
+    prompt, skills = mprov._build_default_prompt_and_skills("a1")
+
+    names = {s["name"] for s in skills}
+    assert names == {"ops", "web", "twitter-watch"}        # 一个不少(防漏列)
+    # 同源:返回的 prompt 必须等于薄包装 loader 的输出
+    assert prompt == mprov._default_system_prompt_loader("a1")
+    # 同源:每个 skill 都出现在 prompt 技能段里
+    for n in names:
+        assert n in prompt
+    # skills 形状含 manifest 需要的 abs_path
+    assert all("abs_path" in s and "description" in s for s in skills)
+
+
+def test_build_default_reflector_returns_none_skills(tmp_path, monkeypatch):
+    """reflector:无技能集 → skills is None(调用方据此不产出 manifest)。"""
+    from src.everbot.core.agent.provider.milkie import provider as mprov
+
+    prompt, skills = mprov._build_default_prompt_and_skills(mprov.REFLECTOR_AGENT)
+    assert skills is None
+    assert "reflection" in prompt and "JSON" in prompt
+
+
+def test_build_default_respects_include_filter(tmp_path, monkeypatch):
+    from src.everbot.core.agent.provider.milkie import provider as mprov
+
+    _setup_ws_skills(
+        tmp_path, monkeypatch, ["ops", "web", "secret"],
+        config={"everbot": {"agents": {"a1": {"skills": {"include": ["ops", "web"]}}}}},
+    )
+    _prompt, skills = mprov._build_default_prompt_and_skills("a1")
+    assert {s["name"] for s in skills} == {"ops", "web"}  # secret 被白名单挡掉
+
+
+def test_build_default_bad_include_fails_loud(tmp_path, monkeypatch):
+    """producer fail-loud(milkie#139):include 引用不存在的 skill → discover_skills raise。"""
+    import pytest
+    from src.everbot.core.agent.provider.milkie import provider as mprov
+
+    _setup_ws_skills(
+        tmp_path, monkeypatch, ["ops"],
+        config={"everbot": {"agents": {"a1": {"skills": {"include": ["nope"]}}}}},
+    )
+    with pytest.raises(ValueError):
+        mprov._build_default_prompt_and_skills("a1")
+
+
 def test_telegram_agent_gets_attachment_instruction(tmp_path, monkeypatch):
     """telegram-serving agent 的系统提示注入附件输出约定;非 telegram agent 不注入。"""
     from src.everbot.core.agent.provider.milkie import provider as mprov


### PR DESCRIPTION
## 背景

milkie 的 `skill_list` 是 v1 stub（恒返回 `{skills:[]}`），milkie agent "列技能"时被误导漏列（实测 demo_agent 漏 `twitter-watch`）。按 **milkie#139 定稿**：milkie 默认 handler 读 `MILKIE_SKILL_MANIFEST` 指向的 manifest → 返回真实列表；alfred 作为 producer 在 spawn 时产出该 manifest。

> 设计 SoT：xforce-io/milkie#139（problem A，与 #87/MCP 无关）。Closes #48。

## 改动

**provider.py**
- 拆 `_default_system_prompt_loader` → `_build_default_prompt_and_skills` 返回 `(prompt, skills)`；`_default_system_prompt_loader` 退化为薄包装，保 `(name)->str` 的 loader seam 契约不变。
- `_build`：默认 loader 时跑**一次** `discover_skills`，prompt 技能段与 skill_list manifest **同源**（不漂移）；注入式 loader（测试 seam）→ `skills=None` → 不产出 manifest。

**launcher.py**
- `build` 新增 `skills` 参数。非 None → 写 `<data-dir>/skill-manifest.json` + 设 `MILKIE_SKILL_MANIFEST` env。
- schema（对齐 milkie#139 定稿）：每条目 `{name, description, dir}`，`dir = discover_skills 的 abs_path`，`version` 留空待 s-010。
- 空列表 → `{skills:[]}`（configured-but-empty）；`None` → 不写（milkie 侧 degrade）。

**错误策略**
- producer fail-loud：`discover_skills` 对 `include/exclude` 笔误 `raise ValueError` → spawn 失败、operator 可见（符合 milkie#139）。
- consumer 侧降级（未配置/读失败）由 milkie 负责。

## 测试

覆盖：manifest 内容/env 接线、同源（manifest 集合==发现集合，防漏列回归）、`None` 不产出、空集 configured-empty、缺 description 默认空、CJK 不转义 JSON、producer fail-loud、默认-vs-注入 loader 分支。

milkie 相关单测 **348 passed**。

## 生效条件

本 producer 侧合并后**惰性**（manifest 躺着不被读）；**milkie#139 consumer 合并当天自动生效，零额外 alfred 部署**。届时 demo_agent "列技能"经 skill_list 查表，不再漏 twitter-watch。

🤖 Generated with [Claude Code](https://claude.com/claude-code)