### PR TITLE
feat(#47): 利用 milkie trace 能力 — runId 捕获 + 带外失败留证(主路径)

### DIFF
--- a/src/everbot/core/agent/provider/base.py
+++ b/src/everbot/core/agent/provider/base.py
@@ -33,6 +33,14 @@ class AgentProvider(Protocol):
 
     def is_error(self, agent: Any) -> bool: ...
 
+    def capture_trace(self, agent: Any) -> Optional[Any]:
+        """#47:为这一(失败)轮留证一份带外诊断 trace,返回产物路径或 None。
+
+        通用能力:中立调用方(cron 失败分支)只调它、不碰任何 provider 私有标识。
+        无此能力 / 无可留证的 provider 返回 None(默认)。MilkieProvider 经
+        ``milkie trace`` 渲染落盘 run 的 HTML 报告。"""
+        return None
+
     def is_user_interrupt_paused(self, agent: Any) -> bool: ...
 
     async def call_llm(

--- a/src/everbot/core/agent/provider/milkie/provider.py
+++ b/src/everbot/core/agent/provider/milkie/provider.py
@@ -135,6 +135,9 @@ class MilkieAgentHandle:
     base_url: str
     context_id: str
     name: str = ""
+    # #47: milkie 的单次运行 id(milkie#140 经终止帧回传),provider 私有 —— 供
+    # Provider 据此定位落盘 trace(`milkie trace <runId>`)。绝不进中立 _progress。
+    last_run_id: Optional[str] = None
 
 
 class MilkieProvider:
@@ -301,14 +304,21 @@ class MilkieProvider:
                             raise RuntimeError(
                                 f"milkie agent error: {data.get('message') or data}"
                             )
-                        if event == "agent.run.completed" and data.get("status") == "error":
-                            msg = (
-                                data.get("error")
-                                or data.get("output")
-                                or data.get("lastTextOutput")
-                                or "unknown error"
-                            )
-                            raise RuntimeError(f"milkie agent run failed: {msg}")
+                        if event == "agent.run.completed":
+                            # #47: 捕获本轮 runId(milkie#140)到 handle —— 必须在
+                            # 下面 error 抛出之前,失败 run 才同样可被留证。runId 是
+                            # milkie 私有,只落在 provider 内的 handle,不进 _progress。
+                            run_id = data.get("runId")
+                            if run_id:
+                                handle.last_run_id = run_id
+                            if data.get("status") == "error":
+                                msg = (
+                                    data.get("error")
+                                    or data.get("output")
+                                    or data.get("lastTextOutput")
+                                    or "unknown error"
+                                )
+                                raise RuntimeError(f"milkie agent run failed: {msg}")
                         item = milkie_event_to_progress(event, data)
                         if item is not None:
                             yield {"_progress": [item]}

--- a/src/everbot/core/agent/provider/milkie/provider.py
+++ b/src/everbot/core/agent/provider/milkie/provider.py
@@ -21,9 +21,30 @@ import httpx
 
 from .adapter import milkie_event_to_progress
 from .sse import SSEParser
+from .....infra.milkie_trace import capture_trace_report
 from .....infra.user_data import get_user_data_manager
 
 logger = logging.getLogger(__name__)
+
+
+def _milkie_data_dir(agent_name: str) -> Path:
+    """该 agent 的 milkie sidecar 数据目录(= 传给 ``serve --data-dir`` 的目录,
+    ``<data_dir_root>/<agent_name>``,与 launcher 的 data-dir 构造一致)。供
+    ``capture_trace`` 定位落盘 trace —— 即 ``milkie trace --data-dir`` 的入参。"""
+    root = "~/.alfred/milkie"
+    try:
+        from .....infra.config import get_config
+
+        milkie_cfg = ((get_config() or {}).get("everbot", {}) or {}).get("milkie", {}) or {}
+        root = milkie_cfg.get("data_dir_root") or root
+    except Exception:
+        pass
+    return Path(root).expanduser() / agent_name
+
+
+def _traces_dir() -> Path:
+    """trace 留证 HTML 的落点(``~/.alfred/logs/traces``,与 daemon 日志同根)。"""
+    return Path("~/.alfred/logs/traces").expanduser()
 
 
 def _resolve_agent_workspace(agent_name: str) -> Path:
@@ -332,6 +353,23 @@ class MilkieProvider:
 
     def is_error(self, agent: Any) -> bool:
         return False
+
+    def capture_trace(self, agent: Any) -> Optional[Path]:
+        """#47:为这一(失败)轮留证 —— 通用能力,中立调用方(cron 失败分支)只调它、
+        不碰 runId。内部从 ``handle.last_run_id``(milkie 私有,step2 在终止帧捕获)取 runId,
+        shell ``milkie trace report --data-dir <sidecar-data> <runId>`` 写 HTML 到 traces_dir。
+
+        best-effort,带外:失败返回 None、不抛(经 chokepoint 保证)。无 runId
+        (非 milkie 路径 / 未跑过)→ None,不调 CLI。runId 不出 Provider 边界。"""
+        run_id = getattr(agent, "last_run_id", None)
+        if not run_id:
+            return None
+        agent_name = getattr(agent, "name", "") or ""
+        return capture_trace_report(
+            run_id,
+            traces_dir=_traces_dir(),
+            data_dir=str(_milkie_data_dir(agent_name)),
+        )
 
     def is_user_interrupt_paused(self, agent: Any) -> bool:
         # milkie#137:经 serve /context/state 查运行态。paused ⇔ context 被 /interrupt

--- a/src/everbot/core/runtime/heartbeat.py
+++ b/src/everbot/core/runtime/heartbeat.py
@@ -1351,9 +1351,31 @@ If not, reply with `HEARTBEAT_OK`.
         system_prompt_override: Optional[str] = None,
     ) -> str:
         """执行 Agent"""
-        if isinstance(system_prompt_override, str):
-            return await self._run_agent_with_override(agent, message, system_prompt_override)
-        return await self._run_heartbeat_turn(agent, message)
+        try:
+            if isinstance(system_prompt_override, str):
+                return await self._run_agent_with_override(agent, message, system_prompt_override)
+            return await self._run_heartbeat_turn(agent, message)
+        except Exception:
+            # #47:后台 turn(cron/heartbeat llm 任务、反思)失败 → 带外留证一份
+            # milkie trace HTML。失败 run 的 runId 已在 provider.run_turn 的终止帧
+            # 捕获到 handle(step2),此处经 provider 通用能力渲染。best-effort,不掩盖原错。
+            self._capture_trace_safe(agent)
+            raise
+
+    def _capture_trace_safe(self, agent: Any) -> None:
+        """#47:经 provider 通用能力为失败的后台 turn 带外留证诊断 trace。
+
+        best-effort:provider 无此能力 / 无 runId(非 milkie 路径)返回 None;留证
+        自身任何异常一律吞掉,绝不掩盖原始失败、绝不拖垮失败处理(对齐 #45 静默恢复)。
+        """
+        try:
+            from ..agent.provider import provider_for
+
+            path = provider_for(agent).capture_trace(agent)
+            if path is not None:
+                logger.info("[%s] 失败 turn 已留证 trace:%s", self.agent_name, path)
+        except Exception as exc:
+            logger.debug("[%s] capture_trace 留证失败(忽略):%s", self.agent_name, exc)
 
     @staticmethod
     def _extract_llm_result(events: list[dict[str, Any]]) -> str:

--- a/src/everbot/infra/milkie_trace.py
+++ b/src/everbot/infra/milkie_trace.py
@@ -1,16 +1,14 @@
-"""#47: 带外 trace 留证 chokepoint —— alfred 侧消费 milkie 已落盘 trace 的唯一入口。
+"""#47: Best-effort Milkie trace report capture chokepoint.
 
-shell `milkie trace report --data-dir <D> <runId>`(milkie#144 的对称契约),把它产
-出的 HTML 写到 ``traces_dir/<runId>.html``。设计取向:
+Shell out to ``milkie trace report --data-dir <D> <runId>`` (milkie#144)
+and write the generated HTML to ``traces_dir/<runId>.html``.
 
-* **浅耦合**:只调 milkie CLI、消费其产物;**绝不解析** ``<D>/runs/*.jsonl`` 或
-  milkie 的事件 schema(那是 milkie 的大脑,不复制)。``data_dir`` 即给 ``serve
-  --data-dir`` 的同一目录,alfred 不需知道 ``runs/<runId>.jsonl`` 文件布局。
-* **带外 + best-effort**:任何失败(milkie 缺失 / 非零退出 / 写盘失败)返回 None、
-  不抛异常、不留半截文件 —— 它服务于失败留证等路径,绝不能反过来拖垮调用方。
+This module only consumes Milkie's CLI output. It does not parse
+``<D>/runs/*.jsonl`` or depend on Milkie event internals. The ``data_dir`` value
+must be the same directory passed to ``serve --data-dir``.
 
-runId 由 Provider 从 milkie#140 的终止帧捕获(``MilkieAgentHandle.last_run_id``),
-是 milkie 私有标识;本模块只把它当不透明字符串传给 CLI。
+Trace capture runs on failure paths, so it must never block or mask the
+original error. Any CLI, timeout, or filesystem failure returns ``None``.
 """
 from __future__ import annotations
 
@@ -21,9 +19,11 @@ from typing import Callable, Optional, Sequence
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_TRACE_TIMEOUT_SECONDS = 5.0
 
-def _default_runner(cmd: Sequence[str]) -> subprocess.CompletedProcess:
-    return subprocess.run(cmd, capture_output=True, text=True)
+
+def _default_runner(cmd: Sequence[str], timeout: float) -> subprocess.CompletedProcess:
+    return subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
 
 
 def capture_trace_report(
@@ -32,25 +32,29 @@ def capture_trace_report(
     traces_dir: Path,
     data_dir: str,
     milkie_cmd: Sequence[str] = ("milkie",),
-    runner: Callable[[Sequence[str]], subprocess.CompletedProcess] = _default_runner,
+    timeout_seconds: float = DEFAULT_TRACE_TIMEOUT_SECONDS,
+    runner: Callable[[Sequence[str], float], subprocess.CompletedProcess] = _default_runner,
 ) -> Optional[Path]:
-    """渲染 ``run_id`` 的 trace HTML 报告到 ``traces_dir/<run_id>.html``。
+    """Render ``run_id`` into ``traces_dir/<run_id>.html`` via Milkie CLI.
 
-    ``data_dir`` 须为该 agent 的 milkie sidecar 数据目录(即传给 ``serve
-    --data-dir`` 的那个,``<data_dir>/runs/`` 下有落盘的 run)。返回写出的路径,
-    或 None(留证失败,调用方应静默继续)。
+    ``data_dir`` must be the agent sidecar data directory used by
+    ``serve --data-dir``. Returns the written path, or ``None`` when best-effort
+    capture fails.
     """
     if not run_id:
         return None
     cmd = [*milkie_cmd, "trace", "report", "--data-dir", str(data_dir), run_id]
     try:
-        proc = runner(cmd)
-    except Exception as exc:  # milkie 缺失 / OSError 等 —— 带外留证不该拖垮调用方
-        logger.debug("milkie trace report 执行失败(run=%s):%s", run_id, exc)
+        proc = runner(cmd, timeout_seconds)
+    except subprocess.TimeoutExpired as exc:
+        logger.debug("milkie trace report timed out(run=%s):%s", run_id, exc)
+        return None
+    except Exception as exc:
+        logger.debug("milkie trace report failed(run=%s):%s", run_id, exc)
         return None
     if proc.returncode != 0 or not proc.stdout:
         logger.debug(
-            "milkie trace report 非零退出(run=%s, rc=%s):%s",
+            "milkie trace report exited unsuccessfully(run=%s, rc=%s):%s",
             run_id, proc.returncode, getattr(proc, "stderr", ""),
         )
         return None
@@ -61,5 +65,5 @@ def capture_trace_report(
         out.write_text(proc.stdout, encoding="utf-8")
         return out
     except OSError as exc:
-        logger.debug("写 trace 报告失败(run=%s):%s", run_id, exc)
+        logger.debug("failed to write trace report(run=%s):%s", run_id, exc)
         return None

--- a/src/everbot/infra/milkie_trace.py
+++ b/src/everbot/infra/milkie_trace.py
@@ -1,0 +1,65 @@
+"""#47: 带外 trace 留证 chokepoint —— alfred 侧消费 milkie 已落盘 trace 的唯一入口。
+
+shell `milkie trace report --data-dir <D> <runId>`(milkie#144 的对称契约),把它产
+出的 HTML 写到 ``traces_dir/<runId>.html``。设计取向:
+
+* **浅耦合**:只调 milkie CLI、消费其产物;**绝不解析** ``<D>/runs/*.jsonl`` 或
+  milkie 的事件 schema(那是 milkie 的大脑,不复制)。``data_dir`` 即给 ``serve
+  --data-dir`` 的同一目录,alfred 不需知道 ``runs/<runId>.jsonl`` 文件布局。
+* **带外 + best-effort**:任何失败(milkie 缺失 / 非零退出 / 写盘失败)返回 None、
+  不抛异常、不留半截文件 —— 它服务于失败留证等路径,绝不能反过来拖垮调用方。
+
+runId 由 Provider 从 milkie#140 的终止帧捕获(``MilkieAgentHandle.last_run_id``),
+是 milkie 私有标识;本模块只把它当不透明字符串传给 CLI。
+"""
+from __future__ import annotations
+
+import logging
+import subprocess
+from pathlib import Path
+from typing import Callable, Optional, Sequence
+
+logger = logging.getLogger(__name__)
+
+
+def _default_runner(cmd: Sequence[str]) -> subprocess.CompletedProcess:
+    return subprocess.run(cmd, capture_output=True, text=True)
+
+
+def capture_trace_report(
+    run_id: Optional[str],
+    *,
+    traces_dir: Path,
+    data_dir: str,
+    milkie_cmd: Sequence[str] = ("milkie",),
+    runner: Callable[[Sequence[str]], subprocess.CompletedProcess] = _default_runner,
+) -> Optional[Path]:
+    """渲染 ``run_id`` 的 trace HTML 报告到 ``traces_dir/<run_id>.html``。
+
+    ``data_dir`` 须为该 agent 的 milkie sidecar 数据目录(即传给 ``serve
+    --data-dir`` 的那个,``<data_dir>/runs/`` 下有落盘的 run)。返回写出的路径,
+    或 None(留证失败,调用方应静默继续)。
+    """
+    if not run_id:
+        return None
+    cmd = [*milkie_cmd, "trace", "report", "--data-dir", str(data_dir), run_id]
+    try:
+        proc = runner(cmd)
+    except Exception as exc:  # milkie 缺失 / OSError 等 —— 带外留证不该拖垮调用方
+        logger.debug("milkie trace report 执行失败(run=%s):%s", run_id, exc)
+        return None
+    if proc.returncode != 0 or not proc.stdout:
+        logger.debug(
+            "milkie trace report 非零退出(run=%s, rc=%s):%s",
+            run_id, proc.returncode, getattr(proc, "stderr", ""),
+        )
+        return None
+    try:
+        out_dir = Path(traces_dir)
+        out_dir.mkdir(parents=True, exist_ok=True)
+        out = out_dir / f"{run_id}.html"
+        out.write_text(proc.stdout, encoding="utf-8")
+        return out
+    except OSError as exc:
+        logger.debug("写 trace 报告失败(run=%s):%s", run_id, exc)
+        return None

--- a/tests/unit/test_heartbeat_runner_core.py
+++ b/tests/unit/test_heartbeat_runner_core.py
@@ -86,6 +86,78 @@ async def test_restricted_agent_factory_keeps_resource_skill_tools(tmp_path: Pat
     )
 
 
+# ── #47: 后台 turn 失败 → provider.capture_trace 带外留证 ──
+
+
+def _patch_provider_for(monkeypatch, provider):
+    import importlib
+    prov_mod = importlib.import_module(
+        HeartbeatRunner.__module__.rsplit(".", 2)[0] + ".agent.provider"
+    )
+    monkeypatch.setattr(prov_mod, "provider_for", lambda agent: provider)
+
+
+@pytest.mark.asyncio
+async def test_run_agent_captures_trace_on_failure_then_reraises(tmp_path, monkeypatch):
+    """后台 turn 失败 → 调 provider.capture_trace(agent) 留证,并仍向上 re-raise
+    (留证是带外副作用,不吞掉失败)。"""
+    runner = _make_runner(workspace_path=tmp_path)
+
+    async def boom(agent, message):
+        raise RuntimeError("milkie agent run failed: boom")
+
+    monkeypatch.setattr(runner, "_run_heartbeat_turn", boom)
+
+    captured: list = []
+    provider = SimpleNamespace(
+        capture_trace=lambda agent: captured.append(agent) or (tmp_path / "x.html")
+    )
+    _patch_provider_for(monkeypatch, provider)
+
+    sentinel_agent = object()
+    with pytest.raises(RuntimeError, match="boom"):
+        await runner._run_agent(sentinel_agent, "do work")
+    assert captured == [sentinel_agent]   # 留证被调用,入参为失败的 agent
+
+
+@pytest.mark.asyncio
+async def test_run_agent_success_does_not_capture_trace(tmp_path, monkeypatch):
+    """成功 turn 不留证(留证只在失败路径)。"""
+    runner = _make_runner(workspace_path=tmp_path)
+
+    async def ok(agent, message):
+        return "done"
+
+    monkeypatch.setattr(runner, "_run_heartbeat_turn", ok)
+
+    called: list = []
+    provider = SimpleNamespace(capture_trace=lambda agent: called.append(agent))
+    _patch_provider_for(monkeypatch, provider)
+
+    result = await runner._run_agent(object(), "do work")
+    assert result == "done"
+    assert called == []
+
+
+@pytest.mark.asyncio
+async def test_run_agent_capture_trace_failure_does_not_mask_original_error(tmp_path, monkeypatch):
+    """留证本身抛异常也不能掩盖/替换原始失败 —— 带外不该拖垮失败处理。"""
+    runner = _make_runner(workspace_path=tmp_path)
+
+    async def boom(agent, message):
+        raise RuntimeError("original boom")
+
+    monkeypatch.setattr(runner, "_run_heartbeat_turn", boom)
+
+    def explode(agent):
+        raise OSError("capture blew up")
+
+    _patch_provider_for(monkeypatch, SimpleNamespace(capture_trace=explode))
+
+    with pytest.raises(RuntimeError, match="original boom"):
+        await runner._run_agent(object(), "do work")
+
+
 def _build_structured_md(tasks: list[dict] | None = None) -> str:
     """Build a valid HEARTBEAT.md string with optional task list."""
     task_list = {"version": 2, "tasks": tasks or []}

--- a/tests/unit/test_milkie_provider.py
+++ b/tests/unit/test_milkie_provider.py
@@ -120,6 +120,46 @@ async def test_run_turn_raises_on_error_frame():
         await client.aclose()
 
 
+# ── #47: capture milkie's per-run id off the terminal frame (milkie#140) ──
+# runId is milkie-private and must NOT enter the neutral _progress contract; it
+# is stashed on the provider-internal handle so the Provider can later locate the
+# recorded trace (`milkie trace <runId>`). Never surfaced to turn_orchestrator.
+
+async def test_run_turn_captures_runid_onto_handle():
+    """The completed terminal frame's runId is stashed on the handle (not _progress)."""
+    sse = _sse(
+        ("agent.run.started", {"contextId": "c"}),
+        ("message_delta", {"text": "hi"}),
+        ("agent.run.completed", {"status": "completed", "output": "hi", "runId": "run-abc"}),
+    )
+    p, client = _provider(sse)
+    handle = MilkieAgentHandle("http://sidecar", "c")
+    try:
+        events = [e async for e in p.run_turn(handle, "hi")]
+    finally:
+        await client.aclose()
+    assert handle.last_run_id == "run-abc"
+    # runId must not leak into the neutral _progress contract
+    assert "run-abc" not in json.dumps(events)
+
+
+async def test_run_turn_captures_runid_even_on_error_terminal():
+    """失败 run 也要留得到 runId(供 cron 失败分支留证):error 终止帧的 runId
+    必须在抛 RuntimeError 前捕获到 handle。"""
+    sse = _sse(
+        ("agent.run.started", {"contextId": "c"}),
+        ("agent.run.completed", {"status": "error", "output": "boom", "runId": "run-err"}),
+    )
+    p, client = _provider(sse)
+    handle = MilkieAgentHandle("http://sidecar", "c")
+    try:
+        with pytest.raises(RuntimeError):
+            _ = [e async for e in p.run_turn(handle, "hi")]
+    finally:
+        await client.aclose()
+    assert handle.last_run_id == "run-err"
+
+
 async def test_run_turn_sends_contextid_and_input_to_chat():
     cap: dict = {}
     p, client = _provider(_sse(("agent.run.completed", {"status": "completed", "output": ""})), cap)

--- a/tests/unit/test_milkie_provider.py
+++ b/tests/unit/test_milkie_provider.py
@@ -9,6 +9,7 @@ import json
 import httpx
 import pytest
 
+from src.everbot.core.agent.provider.milkie import provider as provider_mod
 from src.everbot.core.agent.provider.milkie.provider import MilkieAgentHandle, MilkieProvider
 
 
@@ -158,6 +159,42 @@ async def test_run_turn_captures_runid_even_on_error_terminal():
     finally:
         await client.aclose()
     assert handle.last_run_id == "run-err"
+
+
+# ── #47: capture_trace — 中立能力,内部从 handle.last_run_id 取 runId,调带外 chokepoint ──
+
+def test_capture_trace_returns_none_without_run_id(monkeypatch):
+    """无 runId(从未跑过 / 非 milkie 路径)→ 返回 None,绝不调 chokepoint。"""
+    called: list = []
+    monkeypatch.setattr(provider_mod, "capture_trace_report", lambda *a, **k: called.append(1))
+    p = MilkieProvider("http://x")
+    h = MilkieAgentHandle("http://s", "c", name="alice")  # last_run_id 默认 None
+    assert p.capture_trace(h) is None
+    assert called == []
+
+
+def test_capture_trace_invokes_chokepoint_with_runid_and_agent_data_dir(monkeypatch, tmp_path):
+    """有 runId → 用 handle.last_run_id + 按 agent.name 解析的 sidecar data_dir 调 chokepoint。
+    runId 不出 Provider —— 由 capture_trace 内部取用。"""
+    captured: dict = {}
+
+    def fake_report(run_id, *, traces_dir, data_dir, **kw):
+        captured.update(run_id=run_id, traces_dir=traces_dir, data_dir=data_dir)
+        return tmp_path / f"{run_id}.html"
+
+    monkeypatch.setattr(provider_mod, "capture_trace_report", fake_report)
+    monkeypatch.setattr(provider_mod, "_milkie_data_dir", lambda name: f"/data/{name}")
+    monkeypatch.setattr(provider_mod, "_traces_dir", lambda: tmp_path)
+
+    p = MilkieProvider("http://x")
+    h = MilkieAgentHandle("http://s", "c", name="alice")
+    h.last_run_id = "run-77"
+
+    out = p.capture_trace(h)
+    assert out == tmp_path / "run-77.html"
+    assert captured["run_id"] == "run-77"
+    assert captured["data_dir"] == "/data/alice"   # data_dir 由 agent.name 推出
+    assert captured["traces_dir"] == tmp_path
 
 
 async def test_run_turn_sends_contextid_and_input_to_chat():

--- a/tests/unit/test_milkie_trace.py
+++ b/tests/unit/test_milkie_trace.py
@@ -1,10 +1,7 @@
-"""#47: `infra/milkie_trace.py` —— 带外 trace 留证 chokepoint。
+"""#47: Best-effort trace capture chokepoint tests."""
 
-shell `milkie trace report --data-dir <D> <runId>`(milkie#144 的对称契约),把
-HTML 写到 traces_dir。best-effort:任何失败返回 None、不抛、不留半截文件,绝不解析
-jsonl(只消费 milkie CLI 产物)。注入 fake runner 验证命令构造与退化行为,不依赖
-真实 milkie 二进制。
-"""
+import subprocess
+
 from src.everbot.infra.milkie_trace import capture_trace_report
 
 
@@ -18,32 +15,37 @@ class _FakeProc:
 def test_capture_trace_report_writes_html_and_returns_path(tmp_path):
     calls: dict = {}
 
-    def runner(cmd):
+    def runner(cmd, timeout):
         calls["cmd"] = cmd
+        calls["timeout"] = timeout
         return _FakeProc(0, stdout="<html>trace</html>")
 
     out = capture_trace_report(
-        "run-abc", traces_dir=tmp_path, data_dir="/sidecar/data", runner=runner
+        "run-abc",
+        traces_dir=tmp_path,
+        data_dir="/sidecar/data",
+        timeout_seconds=1.5,
+        runner=runner,
     )
 
     assert out == tmp_path / "run-abc.html"
     assert out.read_text(encoding="utf-8") == "<html>trace</html>"
-    # 对称契约 milkie#144:`milkie trace report --data-dir <D> <runId>`,传给 serve 的同一 data-dir
+    # Milkie#144 contract: use the same data-dir passed to serve.
     assert calls["cmd"][-5:] == ["trace", "report", "--data-dir", "/sidecar/data", "run-abc"]
+    assert calls["timeout"] == 1.5
 
 
 def test_capture_trace_report_none_for_falsy_runid(tmp_path):
-    def runner(cmd):
-        raise AssertionError("空 runId 不应执行任何命令")
+    def runner(cmd, timeout):
+        raise AssertionError("runner should not be called for an empty run id")
 
     assert capture_trace_report("", traces_dir=tmp_path, data_dir="/d", runner=runner) is None
     assert capture_trace_report(None, traces_dir=tmp_path, data_dir="/d", runner=runner) is None
 
 
 def test_capture_trace_report_returns_none_on_command_failure(tmp_path):
-    """退化:milkie trace 非零退出 → 返回 None、不抛、不留半截文件
-    (不能拖垮调用它的失败分支)。"""
-    def runner(cmd):
+    """A non-zero CLI exit returns None without writing a partial report."""
+    def runner(cmd, timeout):
         return _FakeProc(1, stdout="", stderr="no run found")
 
     out = capture_trace_report("run-x", traces_dir=tmp_path, data_dir="/d", runner=runner)
@@ -52,8 +54,25 @@ def test_capture_trace_report_returns_none_on_command_failure(tmp_path):
 
 
 def test_capture_trace_report_tolerates_runner_exception(tmp_path):
-    """异常:runner 抛异常(milkie 不存在 / OSError)也吞掉返回 None,带外留证不崩。"""
-    def runner(cmd):
+    """Runner exceptions are swallowed because trace capture is best-effort."""
+    def runner(cmd, timeout):
         raise FileNotFoundError("milkie not found")
 
     assert capture_trace_report("run-x", traces_dir=tmp_path, data_dir="/d", runner=runner) is None
+
+
+def test_capture_trace_report_returns_none_on_timeout(tmp_path):
+    """A hung CLI times out and degrades to None."""
+    def runner(cmd, timeout):
+        raise subprocess.TimeoutExpired(cmd=cmd, timeout=timeout)
+
+    out = capture_trace_report(
+        "run-slow",
+        traces_dir=tmp_path,
+        data_dir="/d",
+        timeout_seconds=0.01,
+        runner=runner,
+    )
+
+    assert out is None
+    assert list(tmp_path.iterdir()) == []

--- a/tests/unit/test_milkie_trace.py
+++ b/tests/unit/test_milkie_trace.py
@@ -1,0 +1,59 @@
+"""#47: `infra/milkie_trace.py` —— 带外 trace 留证 chokepoint。
+
+shell `milkie trace report --data-dir <D> <runId>`(milkie#144 的对称契约),把
+HTML 写到 traces_dir。best-effort:任何失败返回 None、不抛、不留半截文件,绝不解析
+jsonl(只消费 milkie CLI 产物)。注入 fake runner 验证命令构造与退化行为,不依赖
+真实 milkie 二进制。
+"""
+from src.everbot.infra.milkie_trace import capture_trace_report
+
+
+class _FakeProc:
+    def __init__(self, returncode: int, stdout: str = "", stderr: str = ""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def test_capture_trace_report_writes_html_and_returns_path(tmp_path):
+    calls: dict = {}
+
+    def runner(cmd):
+        calls["cmd"] = cmd
+        return _FakeProc(0, stdout="<html>trace</html>")
+
+    out = capture_trace_report(
+        "run-abc", traces_dir=tmp_path, data_dir="/sidecar/data", runner=runner
+    )
+
+    assert out == tmp_path / "run-abc.html"
+    assert out.read_text(encoding="utf-8") == "<html>trace</html>"
+    # 对称契约 milkie#144:`milkie trace report --data-dir <D> <runId>`,传给 serve 的同一 data-dir
+    assert calls["cmd"][-5:] == ["trace", "report", "--data-dir", "/sidecar/data", "run-abc"]
+
+
+def test_capture_trace_report_none_for_falsy_runid(tmp_path):
+    def runner(cmd):
+        raise AssertionError("空 runId 不应执行任何命令")
+
+    assert capture_trace_report("", traces_dir=tmp_path, data_dir="/d", runner=runner) is None
+    assert capture_trace_report(None, traces_dir=tmp_path, data_dir="/d", runner=runner) is None
+
+
+def test_capture_trace_report_returns_none_on_command_failure(tmp_path):
+    """退化:milkie trace 非零退出 → 返回 None、不抛、不留半截文件
+    (不能拖垮调用它的失败分支)。"""
+    def runner(cmd):
+        return _FakeProc(1, stdout="", stderr="no run found")
+
+    out = capture_trace_report("run-x", traces_dir=tmp_path, data_dir="/d", runner=runner)
+    assert out is None
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_capture_trace_report_tolerates_runner_exception(tmp_path):
+    """异常:runner 抛异常(milkie 不存在 / OSError)也吞掉返回 None,带外留证不崩。"""
+    def runner(cmd):
+        raise FileNotFoundError("milkie not found")
+
+    assert capture_trace_report("run-x", traces_dir=tmp_path, data_dir="/d", runner=runner) is None


### PR DESCRIPTION
实现 #47 主路径(第 1–3 件)。第 4 件 trace skill 为**可选**,本 PR 未含,故不自动关闭 #47。

## 背景

milkie sidecar 每轮早已把完整事件溯源 trace 落盘,但 alfred 从未消费。本 PR 接通:失败的后台 turn 自动带外留证一份 `milkie trace` HTML 报告。

## 前置(milkie 侧)
- xforce-io/milkie#141 **已合并**:终止帧 `agent.run.completed` 回传 runId。
- xforce-io/milkie#145(closes #144)**待合并**:`trace --data-dir`,与 `serve --data-dir` 对称。

## 改动(2 提交)

**`e0de164` runId 捕获 + chokepoint**
- `MilkieAgentHandle.last_run_id`;`run_turn` 在 `agent.run.completed` 帧捕获 runId,**在 error 抛出之前**(失败 run 同样可留证)。runId 是 milkie 私有,只落 provider 内 handle,**绝不进中立 `_progress`**。
- `infra/milkie_trace.py`:带外留证 chokepoint,shell `milkie trace report --data-dir <D> <runId>` 写 HTML。best-effort——任何失败返回 None、不抛、不留半截文件,**绝不解析 jsonl**(只消费 CLI 产物)。

**`a6b44c1` Provider 能力 + 失败挂点**
- `base.py`(Protocol):`capture_trace(agent)` 默认 no-op 返回 None(通用能力,无 trace 的 provider 自然降级)。
- `MilkieProvider.capture_trace`:从 `handle.last_run_id` 取 runId、按 `agent.name` 解析 sidecar data_dir、调 chokepoint。**runId 不出 Provider 边界**。
- `heartbeat._run_agent`:包裹后台 turn,失败时 `provider_for(agent).capture_trace(agent)` 带外留证再 re-raise。覆盖 cron llm 任务 + heartbeat 反思,**不动 cron**(保持其 provider 中立)。范围:仅后台任务(经评审选定)。

## 守住的边界
- runId 私有 → 不进 `_progress`(测试断言)。
- 留证带外 best-effort → 失败吞掉、不掩盖原错、不拖垮失败处理(对齐 #45 静默恢复)。
- 只消费 milkie CLI,不复制其诊断逻辑。

## 优雅降级
capture_trace 依赖 milkie#145 的 `--data-dir`。在其合并 + milkie dist 重建前,chokepoint 非零退出 → 返回 None、不报错(留证暂缺,不崩)。

## 测试(全程 TDD,RED→GREEN)
- runId 捕获 2、chokepoint 4、capture_trace 2、heartbeat 留证 3。
- 全量单元 **1663 passed**。

Refs #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)