### PR TITLE
feat(milkie): 列举技能引导 agent 调 skill_list 工具（确定性，防漏列）

### DIFF
--- a/src/everbot/core/agent/provider/milkie/skills.py
+++ b/src/everbot/core/agent/provider/milkie/skills.py
@@ -132,6 +132,12 @@ def build_milkie_skills_section(skills: List[Dict[str, Any]], workspace_root: Pa
         "再按文档用 `run_command` 执行其脚本（用脚本的绝对路径）。文档里的 "
         f"`$SKILL_DIR` 指该技能目录、`$WORKSPACE_ROOT` 指 `{workspace_root}`。",
         "",
+        # 列举意图 → 走 skill_list 工具(权威完整),而非凭本段落手抄(手抄是非确定性的,
+        # 实测会漏列;skill_list 由 manifest 背书,见 milkie#139 / alfred#50)。
+        "⚠️ 当用户要求**列举/罗列你的全部技能**（如「你有哪些技能」「列出技能」）时，"
+        "调用 `skill_list` 工具获取权威完整清单后再作答，**不要凭本段落或记忆手动罗列**"
+        "（手动罗列易漏列技能）。`skill_list` 返回的每个条目含 `dir` 字段，即上面各技能的目录。",
+        "",
     ]
     for s in skills:
         desc = s["description"] or s["title"]

--- a/tests/unit/test_milkie_skills.py
+++ b/tests/unit/test_milkie_skills.py
@@ -75,7 +75,17 @@ def test_build_section_includes_run_command_and_paths(tmp_path):
     assert "$WORKSPACE_ROOT" in section and "/ws" in section
 
 
+def test_build_section_nudges_enumeration_to_skill_list(tmp_path):
+    """列举意图引导到 skill_list 工具(确定性,防漏列;alfred#50)。"""
+    skills = [{"name": "ops", "title": "Ops", "description": "运维", "abs_path": "/abs/ops"}]
+    section = msk.build_milkie_skills_section(skills, Path("/ws"))
+    assert "skill_list" in section            # 指向工具
+    assert "列举" in section or "罗列" in section  # 命中枚举意图
+    assert "不要" in section                   # 明确禁止手抄
+
+
 def test_build_section_empty_when_no_skills():
+    # 空技能集仍 ""（不渲染指令，行为不变）。
     assert msk.build_milkie_skills_section([], Path("/ws")) == ""
 
 


### PR DESCRIPTION
## 背景

milkie#139 + alfred#48/#49 已让 `skill_list` 返回真实完整技能列表（manifest）。上线验证时实测：demo_agent "列出技能"**直接从系统提示「已安装技能」prose 段转述、未调用 skill_list**——这次抄全了（twitter-watch 在内），但**走的是当初漏列的同一条非确定性手抄路**，不保证下次不再漏。

即：确定性路径（skill_list）已就位、已接通，但 agent 不调它 → 仍是"通常对、非保证"。

## 改动

在 `build_milkie_skills_section`（`provider/milkie/skills.py`）「已安装技能」段抬头加一条指令：**用户要求列举/罗列全部技能时，调用 `skill_list` 工具取权威清单再作答，不要凭本段落或记忆手抄**（手抄易漏列）。

- prose 段**保留**（仍承载"怎么用"：dir + run_command 说明）；本 PR 只把**枚举意图**引导到确定性工具。
- 不动技能所有权、不移除 prose 段（省 token 是独立方向）。

## 测试

`test_build_section_nudges_enumeration_to_skill_list`：section 含 `skill_list` + 命中枚举意图（列举/罗列）+ 明确"不要"手抄；空技能集仍返回 `""`（行为不变）。`test_milkie_skills.py` 23 passed。

## 验证生效

合并后下次 demo_agent 重 spawn serve（agent.md 重建含新指令）即生效；"列技能"将走 skill_list 查表，确定性列全。

Closes #50。关联 alfred#48/#49（producer）、milkie#139（consumer）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)