### PR TITLE
feat(skills): trace-review —— 对话式自省 milkie run(落地 #53/#47 §五)

### DIFF
--- a/skills/trace-review/SKILL.md
+++ b/skills/trace-review/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: trace-review
+description: 对话式复盘/求证一次 milkie run —— 看"这一轮怎么跑的、调了什么工具、命中什么证据、答案的数据来源"。当用户说"复盘上一轮""你刚那个数怎么来的""这个结论怎么得到的""看下执行过程/命中证据""求证一下""上一轮为什么慢/失败"时使用。
+version: "0.1.0"
+tags: [trace, observability, review, provenance, debugging, milkie]
+---
+
+# Trace Review
+
+复盘一次 milkie run 的执行过程,用于**对话式求证**:把某轮对话的「用户问题 → 执行步骤(工具调用 + 命中证据)→ 最终答案」摊开,让用户核验结论的数据来源、定位慢/失败的原因。
+
+milkie 每轮已把完整事件溯源 trace 落盘到 `~/.alfred/milkie/<agent>/runs/<runId>.jsonl`。本 skill **只消费** milkie 现成的诊断产物(`milkie trace execution/report`),不重写诊断逻辑。
+
+## 何时用
+
+- 用户要核验某个结论/数字的来源:「你刚那个数怎么来的」「这个结论怎么得到的」「求证一下」
+- 用户要看执行过程:「复盘上一轮」「看下你调了什么工具、命中什么」
+- 用户排查上一轮为什么慢 / 失败 / 缓存没命中
+
+## 命令
+
+```bash
+python skills/trace-review/scripts/review_run.py [选项]
+```
+
+| 选项 | 含义 |
+|---|---|
+| `--agent NAME` | 收窄到指定 agent(缺省扫所有 agent) |
+| `--run-id ID` | 显式指定 runId(缺省取最近一个**已完成** run) |
+| `--brief` | 精简输出(默认详尽,保留完整 query/命中证据) |
+| `--full` | 额外渲染自包含 HTML 报告到 `~/.alfred/logs/traces/<runId>.html` |
+
+缺省行为:取最近一个**已完成**的 run —— 当前正在进行的这一轮尚未完成,会被自动排除,因此缺省即"上一轮"。
+
+### 常见用法
+
+```bash
+# 复盘上一轮(全局最近完成的 run)
+python skills/trace-review/scripts/review_run.py
+
+# 复盘某个 agent 的上一轮
+python skills/trace-review/scripts/review_run.py --agent demo_agent
+
+# 复盘指定 run 并出 HTML
+python skills/trace-review/scripts/review_run.py --run-id <runId> --full
+```
+
+## 输出契约
+
+返回 markdown:
+
+- **用户问题** / **最终答案**
+- **执行步骤**:按序每步 —— LLM(cache 命中率 + region 组成)或 工具(名称 · query · 命中证据 · status)
+- **可疑信号**:缓存冷启、工具非零退出 / stderr、空召回等
+
+通过"工具 query + 命中证据 + 最终答案"的对照,即可判断答案里的数据**确实来自某次工具调用的真实返回**(而非编造)。
+
+## 边界
+
+- 只读 milkie trace 产物,不解析 jsonl、不重算 projection(承接 #47 §六)。
+- 配置(dist / data-dir-root / node-bin)读 `~/.alfred/config.yaml` 的 `everbot.milkie`,缺省回退默认。
+- dist 缺失 / 无已完成 run / CLI 失败 → 返回明确的 markdown 说明,不崩。
+
+## 局限(细粒度血缘需后续工具层增强)
+
+本 skill 做的是**执行过程求证**(看到工具调用与其真实返回)。更细的"某条论断 cite 了哪段原文"的结构化血缘,需要 milkie 侧让取数工具铸 lineage 对象(见 #47 §五讨论),不在本 skill 范围。

--- a/skills/trace-review/scripts/review_run.py
+++ b/skills/trace-review/scripts/review_run.py
@@ -1,0 +1,471 @@
+#!/usr/bin/env python3
+"""trace-review skill —— 对话式自省一次 milkie run(落地 issue #53 / #47 §五)。
+
+milkie 每轮已把完整事件溯源 trace 落盘到 ``<data_dir_root>/<agent>/runs/<runId>.jsonl``。
+本脚本**只消费** milkie 现成的诊断产物 —— shell 调 ``node <dist> trace execution/report
+<runId>`` 并把投影渲染成 markdown digest(承接 #47 §六:不解析 jsonl、不重算 projection、
+不在 Python 重建诊断逻辑)。run 选取需要判断"是否完成",仅 tail 扫一个事件标记,不属诊断逻辑。
+
+agent 经内建 ``run_command`` 调用:
+
+    python skills/trace-review/scripts/review_run.py [--agent NAME] [--run-id ID] [--brief] [--full]
+
+缺省复盘"全局最近一个**已完成** run"(当前 in-flight 那轮尚未 completed,天然被排除 →
+正好命中上一轮)。配置(dist / data-dir-root / node-bin)读 ``~/.alfred/config.yaml`` 的
+``everbot.milkie``,缺省回退 launcher 默认;CLI flag 最高优先(便于测试)。
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
+
+# skills/trace-review/scripts/review_run.py → parents[3] = alfred 仓根
+REPO_ROOT = Path(__file__).resolve().parents[3]
+DEFAULT_DATA_DIR_ROOT = Path("~/.alfred/milkie").expanduser()
+DEFAULT_DIST = REPO_ROOT.parent / "milkie" / "dist" / "cli" / "index.js"
+DEFAULT_NODE_BIN = "node"
+DEFAULT_CONFIG = Path("~/.alfred/config.yaml").expanduser()
+TRACES_DIR = Path("~/.alfred/logs/traces").expanduser()
+
+COMPLETION_MARKER = "agent.run.completed"
+DEFAULT_CLI_TIMEOUT = 20.0
+_TAIL_BYTES = 131072  # 完成标记在末尾;只扫尾部,避免读大文件全文
+
+Runner = Callable[[Sequence[str], float], subprocess.CompletedProcess]
+
+
+class TraceReviewError(Exception):
+    """带 markdown 话术的可控失败 —— main 捕获后打印给 agent 转述,绝不抛栈。"""
+
+
+def _default_runner(cmd: Sequence[str], timeout: float) -> subprocess.CompletedProcess:
+    """跑 CLI,stdout 重定向到临时文件再读回。
+
+    milkie/Node 经**管道**输出大 JSON 时,``process.exit`` 可能在 stdout 未 drain 完就退出
+    → 截断(实测约 45KB 处)。重定向到文件(同步 fd 写)绕开该 bug。stderr 量小,仍走 pipe。
+    """
+    with tempfile.TemporaryFile(mode="w+", encoding="utf-8") as out:
+        proc = subprocess.run(
+            list(cmd), stdout=out, stderr=subprocess.PIPE, text=True, timeout=timeout
+        )
+        out.seek(0)
+        stdout = out.read()
+    return subprocess.CompletedProcess(list(cmd), proc.returncode, stdout, proc.stderr)
+
+
+# ---------------------------------------------------------------------------
+# 配置解析
+# ---------------------------------------------------------------------------
+@dataclass(frozen=True)
+class MilkiePaths:
+    dist: Path
+    data_dir_root: Path
+    node_bin: str
+
+
+def _load_milkie_cfg(config_path: Optional[Path] = None) -> Dict[str, Any]:
+    """读 alfred config 的 ``everbot.milkie`` 段。缺省/无 yaml/解析失败 → {}(回退默认)。"""
+    path = Path(config_path) if config_path else DEFAULT_CONFIG
+    if not path.is_file():
+        return {}
+    try:
+        import yaml  # 可选依赖;缺失则全部走默认
+    except Exception:
+        return {}
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    except Exception:
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    everbot = data.get("everbot") if isinstance(data.get("everbot"), dict) else {}
+    milkie = (everbot or {}).get("milkie")
+    return milkie if isinstance(milkie, dict) else {}
+
+
+def resolve_paths(
+    *,
+    dist: Optional[str] = None,
+    data_dir_root: Optional[str] = None,
+    node_bin: Optional[str] = None,
+    config_path: Optional[Path] = None,
+) -> MilkiePaths:
+    """优先级:CLI 显式 > config everbot.milkie > launcher 默认。"""
+    cfg = _load_milkie_cfg(config_path)
+    return MilkiePaths(
+        dist=Path(dist or cfg.get("dist_path") or DEFAULT_DIST).expanduser(),
+        data_dir_root=Path(data_dir_root or cfg.get("data_dir_root") or DEFAULT_DATA_DIR_ROOT).expanduser(),
+        node_bin=str(node_bin or cfg.get("node_bin") or DEFAULT_NODE_BIN),
+    )
+
+
+# ---------------------------------------------------------------------------
+# run 发现与选取
+# ---------------------------------------------------------------------------
+def discover_runs(
+    data_dir_root: Path, agent: Optional[str] = None
+) -> List[Tuple[str, str, Path, float]]:
+    """返回 ``[(agent, run_id, jsonl_path, mtime), ...]``。``agent`` 收窄到单个。"""
+    root = Path(data_dir_root)
+    if not root.is_dir():
+        return []
+    if agent:
+        agent_names: List[str] = [agent]
+    else:
+        agent_names = sorted(p.name for p in root.iterdir() if (p / "runs").is_dir())
+    out: List[Tuple[str, str, Path, float]] = []
+    for name in agent_names:
+        runs_dir = root / name / "runs"
+        if not runs_dir.is_dir():
+            continue
+        for f in runs_dir.glob("*.jsonl"):
+            try:
+                mtime = f.stat().st_mtime
+            except OSError:
+                continue
+            out.append((name, f.stem, f, mtime))
+    return out
+
+
+def is_completed(jsonl_path: Path, tail_bytes: int = _TAIL_BYTES) -> bool:
+    """run 是否跑完 —— tail 扫 ``agent.run.completed`` 标记。文件缺失/读失败 → False。"""
+    try:
+        size = jsonl_path.stat().st_size
+        with open(jsonl_path, "rb") as fh:
+            if size > tail_bytes:
+                fh.seek(size - tail_bytes)
+            data = fh.read()
+    except OSError:
+        return False
+    return COMPLETION_MARKER.encode("utf-8") in data
+
+
+def pick_run(
+    runs: List[Tuple[str, str, Path, float]], *, run_id: Optional[str] = None
+) -> Optional[Tuple[str, str, Path]]:
+    """显式 run_id 优先;否则按 mtime 降序取第一个**已完成**的 run。"""
+    if run_id:
+        for name, rid, path, _ in runs:
+            if rid == run_id:
+                return (name, rid, path)
+        return None
+    for name, rid, path, _ in sorted(runs, key=lambda r: r[3], reverse=True):
+        if is_completed(path):
+            return (name, rid, path)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# milkie CLI 调用(消费产物,不重写逻辑)
+# ---------------------------------------------------------------------------
+def _run_cli(
+    paths: MilkiePaths,
+    subcmd: Sequence[str],
+    data_dir: Path,
+    run_id: str,
+    *,
+    runner: Runner,
+    timeout: float,
+) -> subprocess.CompletedProcess:
+    cmd = [paths.node_bin, str(paths.dist), "trace", *subcmd, "--data-dir", str(data_dir), run_id]
+    try:
+        return runner(cmd, timeout)
+    except subprocess.TimeoutExpired as exc:
+        raise TraceReviewError(f"milkie trace {' '.join(subcmd)} 超时({timeout}s):{exc}")
+    except FileNotFoundError as exc:
+        raise TraceReviewError(f"无法执行 node/milkie(检查 node_bin/dist):{exc}")
+    except Exception as exc:  # noqa: BLE001 —— best-effort,统一降级
+        raise TraceReviewError(f"milkie trace {' '.join(subcmd)} 执行失败:{exc}")
+
+
+def fetch_execution(
+    paths: MilkiePaths,
+    data_dir: Path,
+    run_id: str,
+    *,
+    runner: Runner = _default_runner,
+    timeout: float = DEFAULT_CLI_TIMEOUT,
+) -> Dict[str, Any]:
+    """``trace execution`` → 执行投影 dict。非零退出/空输出/非 JSON → TraceReviewError。"""
+    proc = _run_cli(paths, ["execution"], data_dir, run_id, runner=runner, timeout=timeout)
+    if proc.returncode != 0 or not (proc.stdout or "").strip():
+        raise TraceReviewError(
+            f"trace execution 失败(rc={proc.returncode}):{(proc.stderr or '').strip()[:300]}"
+        )
+    try:
+        data = json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        raise TraceReviewError(f"trace execution 输出非 JSON:{exc}")
+    if not isinstance(data, dict):
+        raise TraceReviewError("trace execution 投影格式异常(非对象)")
+    return data
+
+
+def render_report_html(
+    paths: MilkiePaths,
+    data_dir: Path,
+    run_id: str,
+    *,
+    runner: Runner = _default_runner,
+    timeout: float = DEFAULT_CLI_TIMEOUT,
+    traces_dir: Path = TRACES_DIR,
+) -> Optional[Path]:
+    """``trace report`` → 自包含 HTML 落 ``traces_dir/<run_id>.html``。best-effort:失败 None。"""
+    try:
+        proc = _run_cli(paths, ["report"], data_dir, run_id, runner=runner, timeout=timeout)
+    except TraceReviewError:
+        return None
+    if proc.returncode != 0 or not (proc.stdout or "").strip():
+        return None
+    try:
+        out_dir = Path(traces_dir)
+        out_dir.mkdir(parents=True, exist_ok=True)
+        out = out_dir / f"{run_id}.html"
+        out.write_text(proc.stdout, encoding="utf-8")
+        return out
+    except OSError:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# 投影 → markdown digest
+# ---------------------------------------------------------------------------
+def _text_of(content: Any) -> str:
+    """把 message/response 的 content 规整成纯文本(string 或 [{type:text,text}])。"""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = [
+            c.get("text", "")
+            for c in content
+            if isinstance(c, dict) and c.get("type") == "text"
+        ]
+        return "\n".join(p for p in parts if p)
+    return ""
+
+
+def extract_io(projection: Dict[str, Any]) -> Tuple[str, str]:
+    """从执行投影取(用户问题, 最终答案)。问题=首个 LLM step 的末条 user 消息;答案=末个有
+    response 的 LLM step。"""
+    steps = projection.get("steps") or []
+    llms = [s for s in steps if isinstance(s, dict) and s.get("kind") == "llm"]
+    question = ""
+    if llms:
+        messages = (llms[0].get("prompt") or {}).get("messages") or []
+        for msg in reversed(messages):
+            if isinstance(msg, dict) and msg.get("role") == "user":
+                question = _text_of(msg.get("content"))
+                if question:
+                    break
+    final = ""
+    for step in reversed(llms):
+        resp = step.get("response")
+        if isinstance(resp, dict):
+            final = _text_of(resp.get("content"))
+            if final:
+                break
+    return question, final
+
+
+def _trunc(text: str, limit: int) -> str:
+    text = text or ""
+    if len(text) <= limit:
+        return text
+    return text[:limit] + f"…(截断,共 {len(text)} 字)"
+
+
+def _compact(value: Any, limit: int) -> str:
+    if isinstance(value, str):
+        return _trunc(value, limit)
+    try:
+        return _trunc(json.dumps(value, ensure_ascii=False), limit)
+    except (TypeError, ValueError):
+        return _trunc(str(value), limit)
+
+
+def _summarize_tool_output(output: Any) -> Tuple[str, str]:
+    """返回 (命中证据摘要, 异常说明)。异常说明非空 → 计入可疑信号。"""
+    if isinstance(output, dict) and (
+        "stdout" in output or "stderr" in output or "exitCode" in output
+    ):
+        stdout = (output.get("stdout") or "").strip()
+        stderr = (output.get("stderr") or "").strip()
+        code = output.get("exitCode")
+        evidence = stdout or "(stdout 为空)"
+        bad = ""
+        if code not in (0, None):
+            bad = f"exitCode={code}"
+        if stderr:
+            bad = (bad + "; " if bad else "") + f"stderr: {_trunc(stderr, 200)}"
+        if not stdout and not bad:
+            bad = "stdout 为空(可能无召回/无产出)"
+        return evidence, bad
+    if output is None:
+        return "(无输出)", ""
+    return _compact(output, 4000), ""
+
+
+def _summarize_regions(region_groups: Any) -> str:
+    if not isinstance(region_groups, list):
+        return ""
+    parts = []
+    for g in region_groups:
+        if not isinstance(g, dict):
+            continue
+        stability = g.get("stability")
+        n = len(g.get("regions") or [])
+        if stability:
+            parts.append(f"{stability}×{n}")
+    return ", ".join(parts)
+
+
+def render_digest(
+    agent: str,
+    run_id: str,
+    projection: Dict[str, Any],
+    *,
+    brief: bool = False,
+    report_path: Optional[Path] = None,
+) -> str:
+    steps = projection.get("steps") or []
+    question, final = extract_io(projection)
+    ans_limit = 800 if brief else 100000
+    query_limit = 200 if brief else 2000
+    evid_limit = 200 if brief else 4000
+
+    lines: List[str] = [
+        f"# Run 复盘 · {agent} · `{run_id}`",
+        "",
+        f"**步骤数**: {len(steps)}" + ("  ·  模式: 精简" if brief else "  ·  模式: 详尽"),
+    ]
+    if report_path:
+        lines.append(f"**HTML 报告**: `{report_path}`")
+    lines += [
+        "",
+        "## 用户问题",
+        question.strip() or "_(未捕获)_",
+        "",
+        "## 最终答案",
+        _trunc(final.strip(), ans_limit) or "_(无)_",
+        "",
+        "## 执行步骤",
+    ]
+
+    suspicions: List[str] = []
+    for i, step in enumerate(steps):
+        if not isinstance(step, dict):
+            lines.append(f"- **[{i}]** _(异常步骤)_")
+            continue
+        kind = step.get("kind")
+        if kind == "llm":
+            ch = step.get("cacheHealth") or {}
+            tier = ch.get("tier")
+            hit = ch.get("hitRate") or 0
+            lines.append(
+                f"- **[{i}] LLM** · cache={tier} 命中率={hit:.0%} "
+                f"(read {ch.get('readTokens', 0)}/{ch.get('totalInputTokens', 0)} tok)"
+            )
+            if not brief:
+                regions = _summarize_regions(step.get("regionGroups"))
+                if regions:
+                    lines.append(f"    - region: {regions}")
+            if i > 0 and tier == "cold":
+                suspicions.append(f"步骤[{i}] LLM 缓存冷启(命中率 0),可能拖慢/费 token")
+        elif kind == "tool":
+            tool = step.get("tool") or {}
+            name = tool.get("name")
+            status = tool.get("status")
+            lines.append(f"- **[{i}] 工具 `{name}`** · status={status}")
+            lines.append(f"    - query: {_compact(tool.get('input'), query_limit)}")
+            evidence, bad = _summarize_tool_output(tool.get("output"))
+            lines.append(f"    - 命中: {_trunc(evidence, evid_limit)}")
+            if bad:
+                suspicions.append(f"步骤[{i}] 工具 `{name}` {bad}")
+        else:
+            lines.append(f"- **[{i}] {step.get('label') or kind}**")
+
+    lines += ["", "## 可疑信号"]
+    lines += [f"- ⚠️ {s}" for s in suspicions] if suspicions else ["- 无明显异常"]
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# 入口
+# ---------------------------------------------------------------------------
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description="复盘一次 milkie run 的执行过程(求证/自省),输出 markdown。"
+    )
+    p.add_argument("--agent", default=None, help="收窄到指定 agent(缺省扫所有 agent)")
+    p.add_argument("--run-id", default=None, help="显式指定 runId(缺省取最近已完成 run)")
+    p.add_argument("--brief", action="store_true", help="精简输出(默认详尽)")
+    p.add_argument("--full", action="store_true", help="额外渲染 HTML 报告到 ~/.alfred/logs/traces/")
+    p.add_argument("--dist", default=None, help="覆盖 milkie dist 路径")
+    p.add_argument("--data-dir-root", default=None, help="覆盖 milkie data-dir 根")
+    p.add_argument("--node-bin", default=None, help="覆盖 node 可执行")
+    p.add_argument("--config", default=None, help="覆盖 alfred config.yaml 路径")
+    return p
+
+
+def run(argv: Optional[Sequence[str]] = None, *, runner: Runner = _default_runner) -> Tuple[int, str]:
+    """返回 (exit_code, markdown)。runner 可注入便于测试。"""
+    args = build_parser().parse_args(argv)
+    paths = resolve_paths(
+        dist=args.dist,
+        data_dir_root=args.data_dir_root,
+        node_bin=args.node_bin,
+        config_path=Path(args.config) if args.config else None,
+    )
+
+    if not paths.dist.is_file():
+        return 4, (
+            f"# 复盘失败\n\nmilkie dist 不存在:`{paths.dist}`\n\n"
+            "请确认 milkie 已构建,或经 `everbot.milkie.dist_path` / `--dist` 指定。"
+        )
+
+    if not paths.data_dir_root.is_dir():
+        return 2, (
+            f"# 复盘失败\n\nmilkie data 目录不存在:`{paths.data_dir_root}`\n\n"
+            "可能还没有任何 milkie run 落盘。"
+        )
+
+    runs = discover_runs(paths.data_dir_root, args.agent)
+    picked = pick_run(runs, run_id=args.run_id)
+    if picked is None:
+        scope = f"agent `{args.agent}`" if args.agent else "所有 agent"
+        if args.run_id:
+            return 2, f"# 复盘失败\n\n在 {scope} 下找不到 runId `{args.run_id}`。"
+        return 2, f"# 复盘失败\n\n{scope} 下没有**已完成**的 run 可复盘。"
+
+    agent, run_id, _ = picked
+    data_dir = paths.data_dir_root / agent
+
+    try:
+        projection = fetch_execution(paths, data_dir, run_id, runner=runner)
+    except TraceReviewError as exc:
+        return 3, f"# 复盘失败\n\n{exc}"
+
+    report_path: Optional[Path] = None
+    if args.full:
+        report_path = render_report_html(paths, data_dir, run_id, runner=runner)
+
+    digest = render_digest(
+        agent, run_id, projection, brief=args.brief, report_path=report_path
+    )
+    return 0, digest
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    code, text = run(argv)
+    print(text)
+    return code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/trace-review/tests/test_review_run.py
+++ b/skills/trace-review/tests/test_review_run.py
@@ -1,0 +1,406 @@
+"""trace-review skill 测试 —— 覆盖 runId 选取(显式/缺省/排除 in-flight/无 run)、
+配置回退、CLI 失败降级、投影解析与 digest 渲染。"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+import review_run as rr  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+def _write_run(root: Path, agent: str, run_id: str, *, completed: bool, mtime: float) -> Path:
+    runs = root / agent / "runs"
+    runs.mkdir(parents=True, exist_ok=True)
+    f = runs / f"{run_id}.jsonl"
+    lines = [json.dumps({"type": "agent.run.started", "payload": {"input": "hi"}})]
+    if completed:
+        lines.append(json.dumps({"type": "agent.run.completed", "payload": {"lastTextOutput": "bye"}}))
+    f.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    os.utime(f, (mtime, mtime))
+    return f
+
+
+def _proc(stdout="", stderr="", rc=0):
+    return subprocess.CompletedProcess(args=["x"], returncode=rc, stdout=stdout, stderr=stderr)
+
+
+def _runner_ok(payload: dict):
+    def _r(cmd, timeout):
+        return _proc(stdout=json.dumps(payload))
+    return _r
+
+
+# ---------------------------------------------------------------------------
+# resolve_paths / config
+# ---------------------------------------------------------------------------
+def test_resolve_paths_defaults_when_no_config(tmp_path):
+    p = rr.resolve_paths(config_path=tmp_path / "nope.yaml")
+    assert p.dist == rr.DEFAULT_DIST
+    assert p.data_dir_root == rr.DEFAULT_DATA_DIR_ROOT
+    assert p.node_bin == rr.DEFAULT_NODE_BIN
+
+
+def test_resolve_paths_cli_overrides_win(tmp_path):
+    p = rr.resolve_paths(dist="/x/dist.js", data_dir_root="/d", node_bin="mynode")
+    assert p.dist == Path("/x/dist.js")
+    assert p.data_dir_root == Path("/d")
+    assert p.node_bin == "mynode"
+
+
+def test_resolve_paths_reads_everbot_milkie(tmp_path):
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(
+        "everbot:\n  milkie:\n    dist_path: /from/cfg.js\n    node_bin: nodejs\n",
+        encoding="utf-8",
+    )
+    p = rr.resolve_paths(config_path=cfg)
+    assert p.dist == Path("/from/cfg.js")
+    assert p.node_bin == "nodejs"
+    # 未在 config 设的回退默认
+    assert p.data_dir_root == rr.DEFAULT_DATA_DIR_ROOT
+
+
+def test_load_cfg_malformed_yaml_falls_back(tmp_path):
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text("everbot: [this is: not valid: mapping", encoding="utf-8")
+    assert rr._load_milkie_cfg(cfg) == {}
+
+
+# ---------------------------------------------------------------------------
+# is_completed
+# ---------------------------------------------------------------------------
+def test_is_completed_true(tmp_path):
+    f = _write_run(tmp_path, "a", "r1", completed=True, mtime=1000)
+    assert rr.is_completed(f) is True
+
+
+def test_is_completed_false_when_no_marker(tmp_path):
+    f = _write_run(tmp_path, "a", "r1", completed=False, mtime=1000)
+    assert rr.is_completed(f) is False
+
+
+def test_is_completed_false_when_missing(tmp_path):
+    assert rr.is_completed(tmp_path / "ghost.jsonl") is False
+
+
+def test_is_completed_scans_only_tail(tmp_path):
+    # marker 在末尾,即便前面塞大量噪声也应命中(tail 窗口覆盖结尾)
+    runs = tmp_path / "a" / "runs"
+    runs.mkdir(parents=True)
+    f = runs / "big.jsonl"
+    noise = "\n".join(json.dumps({"type": "clock.read", "i": i}) for i in range(5000))
+    f.write_text(noise + "\n" + json.dumps({"type": "agent.run.completed"}) + "\n", encoding="utf-8")
+    assert rr.is_completed(f, tail_bytes=4096) is True
+
+
+# ---------------------------------------------------------------------------
+# discover_runs / pick_run
+# ---------------------------------------------------------------------------
+def test_discover_runs_across_agents(tmp_path):
+    _write_run(tmp_path, "a", "r1", completed=True, mtime=1000)
+    _write_run(tmp_path, "b", "r2", completed=True, mtime=2000)
+    runs = rr.discover_runs(tmp_path)
+    assert {(a, rid) for a, rid, _, _ in runs} == {("a", "r1"), ("b", "r2")}
+
+
+def test_discover_runs_agent_narrows(tmp_path):
+    _write_run(tmp_path, "a", "r1", completed=True, mtime=1000)
+    _write_run(tmp_path, "b", "r2", completed=True, mtime=2000)
+    runs = rr.discover_runs(tmp_path, agent="a")
+    assert [(a, rid) for a, rid, _, _ in runs] == [("a", "r1")]
+
+
+def test_discover_runs_missing_root(tmp_path):
+    assert rr.discover_runs(tmp_path / "nope") == []
+
+
+def test_pick_run_latest_completed(tmp_path):
+    _write_run(tmp_path, "a", "old", completed=True, mtime=1000)
+    _write_run(tmp_path, "a", "new", completed=True, mtime=3000)
+    runs = rr.discover_runs(tmp_path)
+    picked = rr.pick_run(runs)
+    assert picked is not None and picked[1] == "new"
+
+
+def test_pick_run_excludes_inflight(tmp_path):
+    # 最新文件是 in-flight(无 completed 标记) → 应跳过取上一轮 completed
+    _write_run(tmp_path, "a", "done", completed=True, mtime=2000)
+    _write_run(tmp_path, "a", "inflight", completed=False, mtime=9000)
+    runs = rr.discover_runs(tmp_path)
+    picked = rr.pick_run(runs)
+    assert picked is not None and picked[1] == "done"
+
+
+def test_pick_run_explicit_id(tmp_path):
+    _write_run(tmp_path, "a", "r1", completed=True, mtime=1000)
+    _write_run(tmp_path, "a", "r2", completed=False, mtime=2000)
+    runs = rr.discover_runs(tmp_path)
+    # 显式指定即便未完成也返回
+    picked = rr.pick_run(runs, run_id="r2")
+    assert picked is not None and picked[1] == "r2"
+
+
+def test_pick_run_explicit_id_not_found(tmp_path):
+    _write_run(tmp_path, "a", "r1", completed=True, mtime=1000)
+    runs = rr.discover_runs(tmp_path)
+    assert rr.pick_run(runs, run_id="ghost") is None
+
+
+def test_pick_run_none_when_all_inflight(tmp_path):
+    _write_run(tmp_path, "a", "r1", completed=False, mtime=1000)
+    runs = rr.discover_runs(tmp_path)
+    assert rr.pick_run(runs) is None
+
+
+# ---------------------------------------------------------------------------
+# fetch_execution(CLI 消费 + 降级)
+# ---------------------------------------------------------------------------
+def test_fetch_execution_ok():
+    paths = rr.MilkiePaths(dist=Path("/d.js"), data_dir_root=Path("/d"), node_bin="node")
+    proj = rr.fetch_execution(paths, Path("/d/a"), "r1", runner=_runner_ok({"steps": []}))
+    assert proj == {"steps": []}
+
+
+def test_fetch_execution_nonzero_degrades():
+    paths = rr.MilkiePaths(dist=Path("/d.js"), data_dir_root=Path("/d"), node_bin="node")
+    with pytest.raises(rr.TraceReviewError):
+        rr.fetch_execution(paths, Path("/d/a"), "r1", runner=lambda c, t: _proc(stderr="boom", rc=1))
+
+
+def test_fetch_execution_bad_json_degrades():
+    paths = rr.MilkiePaths(dist=Path("/d.js"), data_dir_root=Path("/d"), node_bin="node")
+    with pytest.raises(rr.TraceReviewError):
+        rr.fetch_execution(paths, Path("/d/a"), "r1", runner=lambda c, t: _proc(stdout="not json"))
+
+
+def test_fetch_execution_timeout_degrades():
+    paths = rr.MilkiePaths(dist=Path("/d.js"), data_dir_root=Path("/d"), node_bin="node")
+
+    def _timeout(cmd, timeout):
+        raise subprocess.TimeoutExpired(cmd, timeout)
+
+    with pytest.raises(rr.TraceReviewError):
+        rr.fetch_execution(paths, Path("/d/a"), "r1", runner=_timeout)
+
+
+def test_fetch_execution_node_missing_degrades():
+    paths = rr.MilkiePaths(dist=Path("/d.js"), data_dir_root=Path("/d"), node_bin="node")
+
+    def _nofile(cmd, timeout):
+        raise FileNotFoundError("node")
+
+    with pytest.raises(rr.TraceReviewError):
+        rr.fetch_execution(paths, Path("/d/a"), "r1", runner=_nofile)
+
+
+# ---------------------------------------------------------------------------
+# extract_io
+# ---------------------------------------------------------------------------
+def test_extract_io_list_and_string_content():
+    proj = {
+        "steps": [
+            {
+                "kind": "llm",
+                "prompt": {"messages": [{"role": "user", "content": "问题A"}]},
+                "response": {"content": [{"type": "text", "text": "答案A"}]},
+            }
+        ]
+    }
+    q, a = rr.extract_io(proj)
+    assert q == "问题A" and a == "答案A"
+
+
+def test_extract_io_picks_last_user_and_last_response():
+    proj = {
+        "steps": [
+            {
+                "kind": "llm",
+                "prompt": {"messages": [
+                    {"role": "user", "content": "旧"},
+                    {"role": "assistant", "content": "x"},
+                    {"role": "user", "content": "最新问题"},
+                ]},
+                "response": {"content": [{"type": "text", "text": "中间答"}]},
+            },
+            {"kind": "tool", "tool": {"name": "run_command"}},
+            {"kind": "llm", "prompt": {"messages": []}, "response": {"content": [{"type": "text", "text": "最终答"}]}},
+        ]
+    }
+    q, a = rr.extract_io(proj)
+    assert q == "最新问题" and a == "最终答"
+
+
+def test_extract_io_missing_gracefully():
+    assert rr.extract_io({"steps": []}) == ("", "")
+    assert rr.extract_io({}) == ("", "")
+
+
+# ---------------------------------------------------------------------------
+# render_digest
+# ---------------------------------------------------------------------------
+def _projection_with_signals():
+    return {
+        "steps": [
+            {
+                "kind": "llm",
+                "cacheHealth": {"tier": "cold", "hitRate": 0, "readTokens": 0, "totalInputTokens": 5000},
+                "regionGroups": [{"stability": "immutable", "regions": [{}]}],
+                "prompt": {"messages": [{"role": "user", "content": "帮我推送"}]},
+                "response": {"content": [{"type": "text", "text": "好的"}]},
+            },
+            {
+                "kind": "tool",
+                "tool": {
+                    "name": "run_command",
+                    "input": {"command": "python main.py"},
+                    "output": {"stdout": "", "stderr": "No such file", "exitCode": 2},
+                    "status": "ok",
+                },
+            },
+            {
+                "kind": "llm",
+                "cacheHealth": {"tier": "cold", "hitRate": 0, "readTokens": 0, "totalInputTokens": 5200},
+                "prompt": {"messages": []},
+                "response": {"content": [{"type": "text", "text": "最终答案"}]},
+            },
+        ]
+    }
+
+
+def test_render_digest_detailed_contains_core():
+    md = rr.render_digest("demo_agent", "run-x", _projection_with_signals())
+    assert "demo_agent" in md and "run-x" in md
+    assert "帮我推送" in md          # 问题
+    assert "run_command" in md        # 工具
+    assert "cache=cold" in md         # cacheHealth
+    assert "region:" in md            # 详尽模式带 region
+    # 可疑信号:第 2 个 LLM 冷启 + 工具 exitCode!=0/stderr
+    assert "缓存冷启" in md
+    assert "exitCode=2" in md
+    assert "stderr" in md
+
+
+def test_render_digest_brief_omits_region_and_truncates():
+    proj = _projection_with_signals()
+    proj["steps"][2]["response"]["content"][0]["text"] = "X" * 2000
+    md = rr.render_digest("a", "r", proj, brief=True)
+    assert "region:" not in md
+    assert "截断" in md  # 答案被截断
+    assert "模式: 精简" in md
+
+
+def test_render_digest_empty_signals():
+    proj = {
+        "steps": [
+            {
+                "kind": "llm",
+                "cacheHealth": {"tier": "hot", "hitRate": 0.9, "readTokens": 100, "totalInputTokens": 110},
+                "prompt": {"messages": [{"role": "user", "content": "q"}]},
+                "response": {"content": [{"type": "text", "text": "a"}]},
+            }
+        ]
+    }
+    md = rr.render_digest("a", "r", proj)
+    assert "无明显异常" in md
+
+
+def test_render_digest_with_report_path():
+    md = rr.render_digest("a", "r", {"steps": []}, report_path=Path("/x/r.html"))
+    assert "/x/r.html" in md
+
+
+def test_summarize_tool_output_empty_stdout_flagged():
+    evidence, bad = rr._summarize_tool_output({"stdout": "", "stderr": "", "exitCode": 0})
+    assert "为空" in bad
+
+
+# ---------------------------------------------------------------------------
+# run()  端到端(注入 runner + 真实文件系统)
+# ---------------------------------------------------------------------------
+def test_run_end_to_end(tmp_path):
+    root = tmp_path / "milkie"
+    _write_run(root, "demo", "good", completed=True, mtime=2000)
+    _write_run(root, "demo", "inflight", completed=False, mtime=9000)
+    dist = tmp_path / "dist.js"
+    dist.write_text("//", encoding="utf-8")
+
+    proj = {
+        "steps": [
+            {
+                "kind": "llm",
+                "cacheHealth": {"tier": "hot", "hitRate": 0.8, "readTokens": 80, "totalInputTokens": 100},
+                "prompt": {"messages": [{"role": "user", "content": "复盘问题"}]},
+                "response": {"content": [{"type": "text", "text": "回答"}]},
+            }
+        ]
+    }
+    code, md = rr.run(
+        ["--data-dir-root", str(root), "--dist", str(dist), "--config", str(tmp_path / "x.yaml")],
+        runner=_runner_ok(proj),
+    )
+    assert code == 0
+    assert "good" in md          # 选了 completed 的上一轮,排除 inflight
+    assert "复盘问题" in md
+
+
+def test_run_dist_missing(tmp_path):
+    code, md = rr.run(
+        ["--data-dir-root", str(tmp_path), "--dist", str(tmp_path / "ghost.js"),
+         "--config", str(tmp_path / "x.yaml")]
+    )
+    assert code == 4 and "dist 不存在" in md
+
+
+def test_run_no_data_dir(tmp_path):
+    dist = tmp_path / "dist.js"
+    dist.write_text("//", encoding="utf-8")
+    code, md = rr.run(
+        ["--data-dir-root", str(tmp_path / "nope"), "--dist", str(dist),
+         "--config", str(tmp_path / "x.yaml")]
+    )
+    assert code == 2 and "data 目录不存在" in md
+
+
+def test_run_no_completed_run(tmp_path):
+    root = tmp_path / "milkie"
+    _write_run(root, "demo", "inflight", completed=False, mtime=1000)
+    dist = tmp_path / "dist.js"
+    dist.write_text("//", encoding="utf-8")
+    code, md = rr.run(
+        ["--data-dir-root", str(root), "--dist", str(dist), "--config", str(tmp_path / "x.yaml")]
+    )
+    assert code == 2 and "没有**已完成**的 run" in md
+
+
+def test_run_explicit_run_id_not_found(tmp_path):
+    root = tmp_path / "milkie"
+    _write_run(root, "demo", "r1", completed=True, mtime=1000)
+    dist = tmp_path / "dist.js"
+    dist.write_text("//", encoding="utf-8")
+    code, md = rr.run(
+        ["--data-dir-root", str(root), "--dist", str(dist), "--run-id", "ghost",
+         "--config", str(tmp_path / "x.yaml")]
+    )
+    assert code == 2 and "找不到 runId" in md
+
+
+def test_run_cli_failure_degrades(tmp_path):
+    root = tmp_path / "milkie"
+    _write_run(root, "demo", "r1", completed=True, mtime=1000)
+    dist = tmp_path / "dist.js"
+    dist.write_text("//", encoding="utf-8")
+    code, md = rr.run(
+        ["--data-dir-root", str(root), "--dist", str(dist), "--config", str(tmp_path / "x.yaml")],
+        runner=lambda c, t: _proc(stderr="kaboom", rc=1),
+    )
+    assert code == 3 and "复盘失败" in md


### PR DESCRIPTION
## 背景

落地 #53 / #47 §五「可选扩展:trace skill」。#47 Provider 主路径(`capture_trace` 失败带外留证)已 merge,本 PR 补其推迟的 skill 子项 —— 让用户在 telegram **对话式**对结果求证、看「这一轮怎么跑的、调了什么工具、命中什么证据、答案数据来源」。

## 改动

新增 `skills/trace-review/`:agent 经内建 `run_command` 调,消费 milkie 现成 `trace execution/report <runId>`,把某轮 run 渲染成 markdown digest:

- **用户问题 / 最终答案**
- **执行步骤**:逐步 LLM(cache 命中率 + region 组成)/ 工具(名称 · query · 命中证据 · status)
- **可疑信号**:缓存冷启、工具非零退出 / stderr、空召回

缺省取最近一个**已完成** run(当前 in-flight 轮尚未 completed,自动排除 → 即"上一轮");支持 `--agent` / `--run-id` / `--brief` / `--full`(出 HTML)。

守 #47 §六底线:**只消费 trace 产物,不解析 jsonl、不重算 projection、不在 Python 重建诊断逻辑**。

## 顺带修一个真实坑

Node CLI 经**管道**输出大 JSON 时 `process.exit` 不等 stdout drain → 截断(实测 ~45KB)。默认 runner 改为 stdout 重定向临时文件再读回绕开。

> ⚠️ 同根因坑另有一处未修:`infra/milkie_trace.py` 的 `capture_trace_report`(#47 主路径)同样用管道跑 `trace report`,大 HTML(~558KB)会被截断。属 #47 解耦,另开 fix 跟进。

## 测试

35 个单测,覆盖:runId 选取(显式/缺省/排除 in-flight/无 run)、配置回退、CLI 失败降级(非零/超时/坏 JSON/node 缺失)、投影解析、digest 渲染。

```
skills/trace-review 35 passed · 与 ops 同跑 82 passed · skills/ 全量 89 passed(零回归)
```

真机 `--agent demo_agent` 端到端验证通过(完整 digest + `--full` 出 HTML)。

Closes #53 · 关联 #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)