### PR TITLE
fix(milkie): capture_trace_report 大 HTML 留证被管道截断

### DIFF
--- a/src/everbot/infra/milkie_trace.py
+++ b/src/everbot/infra/milkie_trace.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import logging
 import subprocess
+import tempfile
 from pathlib import Path
 from typing import Callable, Optional, Sequence
 
@@ -23,7 +24,20 @@ DEFAULT_TRACE_TIMEOUT_SECONDS = 5.0
 
 
 def _default_runner(cmd: Sequence[str], timeout: float) -> subprocess.CompletedProcess:
-    return subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    """跑 milkie CLI,stdout 重定向到临时文件再读回。
+
+    milkie/Node 经**管道**输出大内容时,``process.exit`` 可能在 stdout 未 drain 完就退出
+    → 截断(实测 execution JSON 约 45KB 处断;``trace report`` 的 HTML 可达 ~558KB,必断)。
+    用 ``capture_output=True``(pipe)会拿到残缺 HTML。重定向到文件(同步 fd 写)绕开该
+    bug。stderr 量小,仍走 pipe。详见 #55。
+    """
+    with tempfile.TemporaryFile(mode="w+", encoding="utf-8") as out:
+        proc = subprocess.run(
+            list(cmd), stdout=out, stderr=subprocess.PIPE, text=True, timeout=timeout
+        )
+        out.seek(0)
+        stdout = out.read()
+    return subprocess.CompletedProcess(list(cmd), proc.returncode, stdout, proc.stderr)
 
 
 def capture_trace_report(

--- a/tests/unit/test_milkie_trace.py
+++ b/tests/unit/test_milkie_trace.py
@@ -1,8 +1,9 @@
 """#47: Best-effort trace capture chokepoint tests."""
 
 import subprocess
+import sys
 
-from src.everbot.infra.milkie_trace import capture_trace_report
+from src.everbot.infra.milkie_trace import _default_runner, capture_trace_report
 
 
 class _FakeProc:
@@ -59,6 +60,30 @@ def test_capture_trace_report_tolerates_runner_exception(tmp_path):
         raise FileNotFoundError("milkie not found")
 
     assert capture_trace_report("run-x", traces_dir=tmp_path, data_dir="/d", runner=runner) is None
+
+
+def test_default_runner_captures_large_stdout_without_truncation():
+    """#55: 真实 runner 经文件重定向捕获大 stdout,不被管道 drain 截断。
+
+    用真实子进程输出远超管道缓冲(>45KB,实测截断点)的内容,断言完整拿回。
+    """
+    size = 600_000  # ~600KB,模拟 trace report HTML 量级
+    code = f"import sys; sys.stdout.write('A' * {size})"
+    proc = _default_runner([sys.executable, "-c", code], 30.0)
+
+    assert proc.returncode == 0
+    assert len(proc.stdout) == size
+    assert proc.stdout == "A" * size
+
+
+def test_default_runner_propagates_returncode_and_stderr():
+    """#55: 非零退出码与 stderr 仍正确透出(stderr 走 pipe)。"""
+    code = "import sys; sys.stderr.write('boom'); sys.exit(3)"
+    proc = _default_runner([sys.executable, "-c", code], 30.0)
+
+    assert proc.returncode == 3
+    assert "boom" in proc.stderr
+    assert proc.stdout == ""
 
 
 def test_capture_trace_report_returns_none_on_timeout(tmp_path):


### PR DESCRIPTION
## 问题

#47 后台失败自动留证(`infra/milkie_trace.py` `capture_trace_report`)用 `subprocess.run(cmd, capture_output=True, ...)`(**管道**)跑 `milkie trace report <runId>`。

但 Node CLI 经管道输出大内容时 `process.exit` 在 stdout pipe 未 drain 完就退出 → **截断**(execution JSON 实测约 45KB 处断;`trace report` 的 HTML 可达 **~558KB**,必断)。

后果:`~/.alfred/logs/traces/<runId>.html` 是残缺文件,排障打不开/缺尾。

## 修法

`_default_runner` 改为把 CLI stdout **重定向到临时文件再读回**(同步 fd 写,不受 drain 影响),stderr 量小仍走 pipe。对外接口与调用方不变。对齐 #54 trace-review skill 的同款修法。

## 验证

- 真机:`capture_trace_report` 落盘 HTML **558825 字节**,与 `node <dist> trace report > file` 直接重定向**一致**、结尾 `</html>` 完整(此前被截断)。
- 测试:补真实 `_default_runner` 大输出(600KB)不截断 + 非零退出码/stderr 透出;原有注入式 runner 降级用例不回归。`tests/unit/test_milkie_trace.py` 7 passed。

Closes #55 · 关联 #47、#54

🤖 Generated with [Claude Code](https://claude.com/claude-code)