### PR TITLE
fix(milkie): capture_trace 自动留证走 node+dist(修字面 milkie 不在 PATH)

### DIFF
--- a/src/everbot/core/agent/provider/milkie/provider.py
+++ b/src/everbot/core/agent/provider/milkie/provider.py
@@ -47,6 +47,25 @@ def _traces_dir() -> Path:
     return Path("~/.alfred/logs/traces").expanduser()
 
 
+def _milkie_cli_cmd() -> tuple[str, str]:
+    """milkie CLI 的调用前缀 ``(node_bin, dist_path)`` —— 与 pool 装配同源解析。
+
+    sidecar 是经 ``node <dist>/cli/index.js`` 启动的,环境通常**没有 ``milkie`` 可执行**;
+    自动留证必须用同一 node+dist 调 ``trace report``,否则 ``FileNotFoundError`` → 静默失效
+    (#57)。缺省回退 ``node`` + ``../milkie/dist/cli/index.js``(相对 alfred 仓)。"""
+    node_bin = "node"
+    dist_path = Path(__file__).resolve().parents[6].parent / "milkie" / "dist" / "cli" / "index.js"
+    try:
+        from .....infra.config import get_config
+
+        milkie_cfg = ((get_config() or {}).get("everbot", {}) or {}).get("milkie", {}) or {}
+        node_bin = milkie_cfg.get("node_bin") or node_bin
+        dist_path = Path(milkie_cfg.get("dist_path") or dist_path)
+    except Exception:
+        pass
+    return node_bin, str(dist_path.expanduser())
+
+
 def _resolve_agent_workspace(agent_name: str) -> Path:
     """解析 agent 工作区目录(= ``~/.alfred/agents/<name>``)。
 
@@ -365,10 +384,12 @@ class MilkieProvider:
         if not run_id:
             return None
         agent_name = getattr(agent, "name", "") or ""
+        # #57:用 sidecar 实际的 node+dist 调 CLI —— 环境无字面 ``milkie`` 可执行。
         return capture_trace_report(
             run_id,
             traces_dir=_traces_dir(),
             data_dir=str(_milkie_data_dir(agent_name)),
+            milkie_cmd=_milkie_cli_cmd(),
         )
 
     def is_user_interrupt_paused(self, agent: Any) -> bool:

--- a/tests/unit/test_milkie_provider.py
+++ b/tests/unit/test_milkie_provider.py
@@ -766,3 +766,56 @@ def test_default_loader_feeds_discovered_skills_to_launcher(monkeypatch):
     cmd, env = prov._get_pool()._build("alice")
     assert captured["system_prompt"] == "PROMPT::alice"
     assert captured["skills"] == fake_skills  # 默认路径把 skills 喂到 launcher
+
+
+# ---------------------------------------------------------------------------
+# #57: capture_trace 走 node+dist(而非字面 milkie)
+# ---------------------------------------------------------------------------
+def test_milkie_cli_cmd_defaults(monkeypatch):
+    monkeypatch.setattr("src.everbot.infra.config.get_config", lambda *a, **k: {})
+    node_bin, dist = provider_mod._milkie_cli_cmd()
+    assert node_bin == "node"
+    assert dist.endswith("milkie/dist/cli/index.js")
+
+
+def test_milkie_cli_cmd_reads_config(monkeypatch):
+    monkeypatch.setattr(
+        "src.everbot.infra.config.get_config",
+        lambda *a, **k: {"everbot": {"milkie": {"node_bin": "/usr/bin/node18", "dist_path": "/opt/milkie/x.js"}}},
+    )
+    node_bin, dist = provider_mod._milkie_cli_cmd()
+    assert node_bin == "/usr/bin/node18"
+    assert dist == "/opt/milkie/x.js"
+
+
+def test_capture_trace_forwards_node_dist_cmd(monkeypatch, tmp_path):
+    """capture_trace 必须把 milkie_cmd=(node, dist) 转发给 chokepoint,而非默认字面 milkie。"""
+    monkeypatch.setattr("src.everbot.infra.config.get_config", lambda *a, **k: {})
+    captured: dict = {}
+
+    def _fake_report(run_id, *, traces_dir, data_dir, milkie_cmd=("milkie",), **kw):
+        captured.update(run_id=run_id, milkie_cmd=tuple(milkie_cmd), data_dir=data_dir)
+        return tmp_path / f"{run_id}.html"
+
+    monkeypatch.setattr(provider_mod, "capture_trace_report", _fake_report)
+
+    agent = MilkieAgentHandle(base_url="http://x", context_id="c", name="demo_agent")
+    agent.last_run_id = "run-123"
+    out = MilkieProvider("http://x").capture_trace(agent)
+
+    assert out == tmp_path / "run-123.html"
+    assert captured["run_id"] == "run-123"
+    # 关键:前缀是 node + dist,不是字面 milkie
+    assert captured["milkie_cmd"][0] == "node"
+    assert captured["milkie_cmd"][1].endswith("milkie/dist/cli/index.js")
+    assert "milkie" != captured["milkie_cmd"][0]
+
+
+def test_capture_trace_none_without_run_id(monkeypatch):
+    """无 last_run_id(非 milkie 路径/未跑过)→ None,不调 chokepoint。"""
+    def _boom(*a, **k):
+        raise AssertionError("不应调用 capture_trace_report")
+
+    monkeypatch.setattr(provider_mod, "capture_trace_report", _boom)
+    agent = MilkieAgentHandle(base_url="http://x", context_id="c", name="a")  # last_run_id 默认 None
+    assert MilkieProvider("http://x").capture_trace(agent) is None


### PR DESCRIPTION
## 问题

#47 后台失败自动留证经 `MilkieProvider.capture_trace`(`provider.py`)调 `capture_trace_report(...)` 时**不传 `milkie_cmd`** → 默认 `("milkie",)`,shell `milkie trace report ...`。

但 sidecar 实际用 **`node <dist>/cli/index.js`** 启动,环境**无 `milkie` 可执行**(`which milkie` → not found)→ runner 抛 `FileNotFoundError` → best-effort 吞掉 → **返回 None,留证从不落盘**。#56 修的"大 HTML 截断"在这条路根本没跑到。

## 修法

加 `_milkie_cli_cmd()` helper(与 pool 装配同源解析:`everbot.milkie.{node_bin,dist_path}`,缺省回退 `node` + `../milkie/dist/cli/index.js`),`capture_trace` 传 `milkie_cmd=(node_bin, dist_path)`。对齐 #54 trace-review skill 的做法。

## 验证

- 真机:`capture_trace` 对真实 run 落盘 **558825 字节** HTML、结尾 `</html>` 完整(此前返回 None、不落盘)。
- 测试:`_milkie_cli_cmd` 默认/读配置;`capture_trace` 转发 `(node,dist)` 前缀而非字面 `milkie`;无 runId → None 不调 CLI。
- 回归:`test_milkie_provider` + `test_milkie_trace` 全量 **51 passed**。

至此 #47 后台自动留证链路整条打通(#56 修截断 + #57 修 PATH)。

Closes #57 · 关联 #47、#56、#54

🤖 Generated with [Claude Code](https://claude.com/claude-code)