### PR TITLE
fix(#60): 主动推送内容登记为 milkie context projection —— 修报告对模型不可见

### DIFF
--- a/src/everbot/channels/telegram_channel.py
+++ b/src/everbot/channels/telegram_channel.py
@@ -205,17 +205,23 @@ class TelegramChannel:
         if not detail or not run_id:
             return False
 
-        session_id = ChannelSessionResolver.resolve("telegram", agent_name, str(chat_id))
-        agent = self._session_manager.get_cached_agent(session_id)
-        if agent is None:
-            return False
-
         from ..core.agent.provider import get_provider_for_agent
 
-        attach = getattr(get_provider_for_agent(agent_name), "attach_projection", None)
+        provider = get_provider_for_agent(agent_name)
+        attach = getattr(provider, "attach_projection", None)
         if attach is None:
             return False
+
+        session_id = ChannelSessionResolver.resolve("telegram", agent_name, str(chat_id))
         try:
+            agent = self._session_manager.get_cached_agent(session_id)
+            if agent is None:
+                # 主动推送多在用户空闲时发生,channel 句柄常不在缓存(尤其 daemon 重启
+                # 后用户尚未发言)。回落创建并 set_session_id 绑到 channel context(同
+                # 聊天路径),否则 projection 永不触发 —— 这正是主动推送的核心场景。
+                agent = await self._agent_service.create_agent_instance(agent_name)
+                provider.set_session_id(agent, session_id)
+                self._session_manager.cache_agent(session_id, agent, agent_name, "auto")
             await attach(
                 agent,
                 source_run_id=run_id,

--- a/src/everbot/channels/telegram_channel.py
+++ b/src/everbot/channels/telegram_channel.py
@@ -51,6 +51,15 @@ logger = logging.getLogger(__name__)
 TELEGRAM_MSG_LIMIT = 4096
 
 
+def _truncate_projection_text(text: str, limit: int = 4000) -> str:
+    """#60:截断 projection 的 displayText —— milkie 侧不限长,而 projection 每轮
+    重渲直到 trim/TTL 清掉,长报告会持续吃 token。超长则截到 ``limit`` 并以省略号收尾
+    (总长 ≤ limit)。"""
+    if len(text) <= limit:
+        return text
+    return text[: limit - 1] + "…"
+
+
 def _extract_urls(text: str, entities: list) -> list[str]:
     """Extract URLs from Telegram entities (url + text_link), deduplicated and ordered."""
     seen: set[str] = set()
@@ -176,6 +185,44 @@ class TelegramChannel:
     # Event subscription (heartbeat delivery push)
     # ------------------------------------------------------------------
 
+    async def _maybe_attach_projection(
+        self, agent_name: str, chat_id: Any, data: Dict[str, Any]
+    ) -> None:
+        """#60 / milkie#146:内容型投递 → 把投递文本登记为该 channel 会话的 context
+        projection(读侧、不进 ``history:turn-*``),使模型下一轮看得见用户屏幕上那篇报告。
+
+        闸门:仅 ``transcript_worthy`` 且带 ``run_id``(去重/溯源锚点)+ ``detail``(内容)。
+        心跳状态 ping 不置该标志,故不入逐字稿。带外 best-effort:气泡此时已发出,
+        attach 失败只记日志、绝不冒泡破坏投递。"""
+        if not data.get("transcript_worthy"):
+            return
+        detail = str(data.get("detail") or data.get("summary") or "").strip()
+        run_id = str(data.get("run_id") or "").strip()
+        if not detail or not run_id:
+            return
+
+        session_id = ChannelSessionResolver.resolve("telegram", agent_name, str(chat_id))
+        agent = self._session_manager.get_cached_agent(session_id)
+        if agent is None:
+            return
+
+        from ..core.agent.provider import get_provider_for_agent
+
+        attach = getattr(get_provider_for_agent(agent_name), "attach_projection", None)
+        if attach is None:
+            return
+        try:
+            await attach(
+                agent,
+                source_run_id=run_id,
+                display_text=_truncate_projection_text(detail),
+                delivered_at=data.get("delivered_at"),
+            )
+        except Exception as exc:  # best-effort,带外:绝不破坏已完成的气泡投递
+            logger.warning(
+                "attach_projection failed for %s chat %s: %s", agent_name, chat_id, exc
+            )
+
     async def _on_background_event(
         self, source_session_id: str, data: Dict[str, Any]
     ) -> None:
@@ -254,6 +301,9 @@ class TelegramChannel:
                     source_type, chat_id,
                 )
                 continue
+            # #60:内容型投递 → 登记 milkie context projection,使模型下一轮看得见
+            # 这篇已投递给用户的报告(读侧、不进 history)。带外 best-effort。
+            await self._maybe_attach_projection(agent_name, chat_id, data)
             if source_type != "deferred_result" and hasattr(self._session_manager, "deposit_mailbox_event"):
                 from ..core.models.system_event import build_system_event
 

--- a/src/everbot/channels/telegram_channel.py
+++ b/src/everbot/channels/telegram_channel.py
@@ -187,30 +187,34 @@ class TelegramChannel:
 
     async def _maybe_attach_projection(
         self, agent_name: str, chat_id: Any, data: Dict[str, Any]
-    ) -> None:
+    ) -> bool:
         """#60 / milkie#146:内容型投递 → 把投递文本登记为该 channel 会话的 context
         projection(读侧、不进 ``history:turn-*``),使模型下一轮看得见用户屏幕上那篇报告。
 
         闸门:仅 ``transcript_worthy`` 且带 ``run_id``(去重/溯源锚点)+ ``detail``(内容)。
         心跳状态 ping 不置该标志,故不入逐字稿。带外 best-effort:气泡此时已发出,
-        attach 失败只记日志、绝不冒泡破坏投递。"""
+        attach 失败只记日志、绝不冒泡破坏投递。
+
+        返回是否成功登记为 projection —— 调用方据此**跳过 mailbox 镜像**(projection
+        取代 Background Updates,避免双重表示 + 报告镜像版劫持"上面"指代);失败/未命中
+        闸门则返回 False,调用方回落到镜像,内容不丢。"""
         if not data.get("transcript_worthy"):
-            return
+            return False
         detail = str(data.get("detail") or data.get("summary") or "").strip()
         run_id = str(data.get("run_id") or "").strip()
         if not detail or not run_id:
-            return
+            return False
 
         session_id = ChannelSessionResolver.resolve("telegram", agent_name, str(chat_id))
         agent = self._session_manager.get_cached_agent(session_id)
         if agent is None:
-            return
+            return False
 
         from ..core.agent.provider import get_provider_for_agent
 
         attach = getattr(get_provider_for_agent(agent_name), "attach_projection", None)
         if attach is None:
-            return
+            return False
         try:
             await attach(
                 agent,
@@ -218,10 +222,12 @@ class TelegramChannel:
                 display_text=_truncate_projection_text(detail),
                 delivered_at=data.get("delivered_at"),
             )
+            return True
         except Exception as exc:  # best-effort,带外:绝不破坏已完成的气泡投递
             logger.warning(
                 "attach_projection failed for %s chat %s: %s", agent_name, chat_id, exc
             )
+            return False
 
     async def _on_background_event(
         self, source_session_id: str, data: Dict[str, Any]
@@ -302,9 +308,14 @@ class TelegramChannel:
                 )
                 continue
             # #60:内容型投递 → 登记 milkie context projection,使模型下一轮看得见
-            # 这篇已投递给用户的报告(读侧、不进 history)。带外 best-effort。
-            await self._maybe_attach_projection(agent_name, chat_id, data)
-            if source_type != "deferred_result" and hasattr(self._session_manager, "deposit_mailbox_event"):
+            # 这篇已投递给用户的报告(读侧、不进 history)。成功则 projection 取代下面的
+            # mailbox 镜像(否则报告会被双重表示、且镜像版贴着"上面"劫持指代)。
+            projected = await self._maybe_attach_projection(agent_name, chat_id, data)
+            if (
+                not projected
+                and source_type != "deferred_result"
+                and hasattr(self._session_manager, "deposit_mailbox_event")
+            ):
                 from ..core.models.system_event import build_system_event
 
                 tg_session_id = ChannelSessionResolver.resolve(

--- a/src/everbot/core/agent/provider/milkie/provider.py
+++ b/src/everbot/core/agent/provider/milkie/provider.py
@@ -408,6 +408,37 @@ class MilkieProvider:
             if owns:
                 client.close()
 
+    async def attach_projection(
+        self,
+        agent: Any,
+        *,
+        source_run_id: str,
+        display_text: str,
+        delivered_at: Optional[str] = None,
+    ) -> None:
+        """milkie#146:把已投递到该 channel 的外部产出登记为 context projection。
+
+        读侧、不进 ``history:turn-*``:target = channel 的 contextId(``agent.context_id``),
+        ``sourceRunId`` = 产出它的 job 的 milkie runId(去重/溯源锚点)。serve 侧按
+        sourceRunId 去重、默认 maxCount=5、turn-local 投影。"""
+        client = self._client or self._new_client()
+        owns = self._client is None
+        try:
+            payload: dict = {
+                "contextId": agent.context_id,
+                "sourceRunId": source_run_id,
+                "displayText": display_text,
+            }
+            if delivered_at:
+                payload["deliveredAt"] = delivered_at
+            resp = await client.post(
+                f"{agent.base_url}/projection/attach", json=payload
+            )
+            resp.raise_for_status()
+        finally:
+            if owns:
+                await client.aclose()
+
     def ensure_chat_compatibility(self) -> bool:
         return False  # milkie 无 dolphin 的 EXPLORE_BLOCK_V2 flag
 

--- a/src/everbot/core/channel/core_service.py
+++ b/src/everbot/core/channel/core_service.py
@@ -857,31 +857,6 @@ class ChannelCoreService:
         if isinstance(value, str):
             self._runtime_workspace_instructions_by_agent[agent_name] = value
 
-    async def _load_heartbeat_context(
-        self,
-        session_data: Any,
-        agent_name: str,
-    ) -> Optional[list]:
-        """Load recent heartbeat messages from primary session for channel sessions.
-
-        Returns None for primary/heartbeat sessions (they don't need cross-session
-        context). For channel sessions (e.g. Telegram), loads the primary session
-        and extracts recent heartbeat results so the LLM can reference them.
-        """
-        from ..session.session_ids import infer_session_type, get_primary_session_id
-        from ..session.history_utils import extract_recent_heartbeat
-
-        sid = getattr(session_data, "session_id", None) or ""
-        session_type = infer_session_type(sid) if sid else ""
-        if session_type != "channel":
-            return None
-        primary_id = get_primary_session_id(agent_name)
-        primary = await self.session_manager.load_session(primary_id)
-        if not primary or not primary.history_messages:
-            return None
-        heartbeats = extract_recent_heartbeat(primary.history_messages)
-        return heartbeats or None
-
     def _compose_turn_message(
         self,
         user_message: str,

--- a/src/everbot/core/runtime/cron.py
+++ b/src/everbot/core/runtime/cron.py
@@ -593,7 +593,7 @@ class CronExecutor:
                 run_id=run_id,
             )
             await self.delivery.inject_to_history(result, run_id)
-            await self.delivery._emit_realtime(result, run_id)
+            await self.delivery._emit_realtime(result, run_id, transcript_worthy=True)
 
             return result
         except Exception as exc:
@@ -655,7 +655,7 @@ class CronExecutor:
                 run_id=run_id,
             )
             await self.delivery.inject_to_history(result, run_id)
-            await self.delivery._emit_realtime(result, run_id)
+            await self.delivery._emit_realtime(result, run_id, transcript_worthy=True)
 
             # SLM: record skill invocations from this isolated agent run.
             # Reads the just-written trajectory to find _load_resource_skill

--- a/src/everbot/core/runtime/cron_delivery.py
+++ b/src/everbot/core/runtime/cron_delivery.py
@@ -172,8 +172,14 @@ class CronDelivery:
             ),
         }
 
-    async def _emit_realtime(self, result: str, run_id: str) -> None:
-        """Emit realtime push event (SSE / Telegram)."""
+    async def _emit_realtime(
+        self, result: str, run_id: str, *, transcript_worthy: bool = False
+    ) -> None:
+        """Emit realtime push event (SSE / Telegram).
+
+        ``transcript_worthy`` (#60):本次投递是否是"内容型"产出(具名 job/agent 任务的
+        用户可见报告),供 channel 侧据此登记 milkie context projection(读侧逐字稿)。
+        心跳状态 ping / 失败消息保持 False,不入逐字稿。"""
         from .events import emit
 
         message = {
@@ -185,6 +191,7 @@ class CronDelivery:
             "source_type": "heartbeat_delivery",
             "run_id": run_id,
             "deliver": True,
+            "transcript_worthy": transcript_worthy,
         }
         await emit(
             self.primary_session_id,

--- a/tests/e2e/test_milkie_serve_smoke.py
+++ b/tests/e2e/test_milkie_serve_smoke.py
@@ -347,3 +347,92 @@ async def test_attached_projection_appears_in_next_turn_prompt_via_real_serve(tm
     assert "MARKER_SIVE_REPORT" in prompt, f"投影内容应进入模型 prompt,得:{prompt[:800]}"
     assert "External Delivered Context" in prompt, "应带明确的外部投递标注(非用户原话)"
     assert "job-run-xyz" in prompt, "应带 producedBy.runId 溯源"
+
+
+async def test_on_background_event_path_lands_projection_via_real_serve(tmp_path, monkeypatch):
+    """#60 全链路 E2E(真 milkie serve + 真 TelegramChannel 编排):驱动生产代码
+    _maybe_attach_projection(门控→缓存句柄→真 /projection/attach)后,下一轮 assemble
+    把报告作为 External Delivered Context 注入模型 prompt。覆盖 alfred 编排↔milkie 真缝。"""
+    import json
+    import threading
+    from http.server import BaseHTTPRequestHandler, HTTPServer
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from src.everbot.channels.telegram_channel import TelegramChannel
+
+    cli = _milkie_cli()
+    if cli is None:
+        pytest.skip("milkie dist not built at ../milkie/dist/cli/index.js")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-fake-proj2")
+
+    captured: dict = {"messages": None}
+
+    class _RecordingOpenAI(BaseHTTPRequestHandler):
+        protocol_version = "HTTP/1.1"
+
+        def do_POST(self):  # noqa: N802
+            length = int(self.headers.get("content-length", 0))
+            req = json.loads(self.rfile.read(length) or "{}")
+            captured["messages"] = req.get("messages")
+            frames = [
+                "data: " + json.dumps({"id": "c", "object": "chat.completion.chunk", "created": 0,
+                    "model": req.get("model", "fake"),
+                    "choices": [{"index": 0, "delta": {"content": "ok"}, "finish_reason": None}]}),
+                "data: " + json.dumps({"id": "c", "object": "chat.completion.chunk", "created": 0,
+                    "model": req.get("model", "fake"),
+                    "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}]}),
+                "data: [DONE]",
+            ]
+            body = ("\n\n".join(frames) + "\n\n").encode("utf-8")
+            self.send_response(200)
+            self.send_header("content-type", "text/event-stream")
+            self.send_header("content-length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, *a):
+            pass
+
+    server = HTTPServer(("127.0.0.1", 0), _RecordingOpenAI)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    port = server.server_address[1]
+
+    agent_md = _write_agent(tmp_path, port)
+    data_dir = tmp_path / "milkie-data"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    sidecar = MilkieSidecar(
+        ["node", str(cli), "serve", "--agent", str(agent_md), "--port", "0",
+         "--state-store", "sqlite", "--data-dir", str(data_dir)],
+        ready_timeout=20.0,
+    )
+    await sidecar.start()
+    try:
+        ctx = "tg_session_demo_agent__999"  # = ChannelSessionResolver.resolve("telegram","demo_agent","999")
+        handle = MilkieAgentHandle(sidecar.base_url, ctx, name="demo_agent")
+        provider = MilkieProvider(sidecar.base_url)
+        _ = [e async for e in provider.run_turn(handle, "hi")]  # 建 channel context
+
+        sm = MagicMock()
+        sm.get_cached_agent.return_value = handle  # 模拟 channel 句柄已缓存
+        sm.deposit_mailbox_event = AsyncMock(return_value=True)
+        ch = TelegramChannel(bot_token="123:FAKE", session_manager=sm, default_agent="demo_agent")
+
+        # 真实编排:内容型后台事件 → _maybe_attach_projection
+        with patch("src.everbot.core.agent.provider.get_provider_for_agent", return_value=provider):
+            ok = await ch._maybe_attach_projection("demo_agent", "999", {
+                "transcript_worthy": True,
+                "run_id": "job-xyz",
+                "detail": "MARKER2_DELIVERED_REPORT 今日 $SIVE 推文深度分析",
+                "delivered_at": "2026-06-06T10:00:00Z",
+            })
+        assert ok is True, "内容型投递应成功 attach projection"
+
+        _ = [e async for e in provider.run_turn(handle, "上面报告从哪来的")]  # 下一轮
+    finally:
+        await sidecar.close()
+        server.shutdown()
+
+    prompt = json.dumps(captured["messages"], ensure_ascii=False)
+    assert "MARKER2_DELIVERED_REPORT" in prompt, f"报告应进入下一轮模型 prompt,得:{prompt[:600]}"
+    assert "External Delivered Context" in prompt, "应带外部投递标注"
+    assert "job-xyz" in prompt, "应带 producedBy.runId 溯源"

--- a/tests/e2e/test_milkie_serve_smoke.py
+++ b/tests/e2e/test_milkie_serve_smoke.py
@@ -268,3 +268,82 @@ async def test_generated_agent_md_loads_and_runs_in_real_serve(tmp_path, fake_op
         if item.get("stage") == "llm" and item.get("delta")
     ]
     assert "".join(deltas) == "Hello, world!", f"生成的 agent.md 应能跑通 turn,得 deltas={deltas}"
+
+
+async def test_attached_projection_appears_in_next_turn_prompt_via_real_serve(tmp_path, monkeypatch):
+    """#60 端到端(真 milkie serve):attach_projection 后,下一轮 assemble 把投影作为
+    `External Delivered Context` 注入模型 prompt —— 证明修复真生效:模型看得见这篇
+    已投递给用户的报告。覆盖 MockTransport 测不到的 alfred↔milkie 真 HTTP + 真 assemble。"""
+    import json
+    import threading
+    from http.server import BaseHTTPRequestHandler, HTTPServer
+
+    cli = _milkie_cli()
+    if cli is None:
+        pytest.skip("milkie dist not built at ../milkie/dist/cli/index.js")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-fake-proj")
+
+    captured: dict = {"messages": None}
+
+    class _RecordingOpenAI(BaseHTTPRequestHandler):
+        protocol_version = "HTTP/1.1"
+
+        def do_POST(self):  # noqa: N802
+            length = int(self.headers.get("content-length", 0))
+            req = json.loads(self.rfile.read(length) or "{}")
+            captured["messages"] = req.get("messages")  # 记录本轮喂给 LLM 的 prompt
+            frames = [
+                "data: " + json.dumps({
+                    "id": "c", "object": "chat.completion.chunk", "created": 0,
+                    "model": req.get("model", "fake"),
+                    "choices": [{"index": 0, "delta": {"content": "ok"}, "finish_reason": None}],
+                }),
+                "data: " + json.dumps({
+                    "id": "c", "object": "chat.completion.chunk", "created": 0,
+                    "model": req.get("model", "fake"),
+                    "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+                }),
+                "data: [DONE]",
+            ]
+            body = ("\n\n".join(frames) + "\n\n").encode("utf-8")
+            self.send_response(200)
+            self.send_header("content-type", "text/event-stream")
+            self.send_header("content-length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, *args):
+            pass
+
+    server = HTTPServer(("127.0.0.1", 0), _RecordingOpenAI)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    port = server.server_address[1]
+
+    agent_md = _write_agent(tmp_path, port)
+    data_dir = tmp_path / "milkie-data"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    cmd = ["node", str(cli), "serve", "--agent", str(agent_md), "--port", "0",
+           "--state-store", "sqlite", "--data-dir", str(data_dir)]
+    sidecar = MilkieSidecar(cmd, ready_timeout=20.0)
+    await sidecar.start()
+    try:
+        provider = MilkieProvider(sidecar.base_url)
+        handle = MilkieAgentHandle(sidecar.base_url, "ctx-proj")
+        # 1) 建 context
+        _ = [e async for e in provider.run_turn(handle, "hi")]
+        # 2) 把"已投递的报告"登记为 projection(真 HTTP /projection/attach)
+        await provider.attach_projection(
+            handle,
+            source_run_id="job-run-xyz",
+            display_text="MARKER_SIVE_REPORT 今日 $SIVE 推文深度分析",
+        )
+        # 3) 下一轮:assemble 应把投影注入 prompt
+        _ = [e async for e in provider.run_turn(handle, "上面内容从哪来的")]
+    finally:
+        await sidecar.close()
+        server.shutdown()
+
+    prompt = json.dumps(captured["messages"], ensure_ascii=False)
+    assert "MARKER_SIVE_REPORT" in prompt, f"投影内容应进入模型 prompt,得:{prompt[:800]}"
+    assert "External Delivered Context" in prompt, "应带明确的外部投递标注(非用户原话)"
+    assert "job-run-xyz" in prompt, "应带 producedBy.runId 溯源"

--- a/tests/unit/test_cron_delivery.py
+++ b/tests/unit/test_cron_delivery.py
@@ -118,3 +118,36 @@ class TestRealtimeEmit:
         assert source_session_id == "web_session_test"
         assert kwargs["scope"] == "session"
         assert kwargs["target_session_id"] == "web_session_test"
+
+    @pytest.mark.asyncio
+    async def test_emit_realtime_carries_transcript_worthy_flag(self, monkeypatch):
+        """#60:内容型 job/agent 投递置 transcript_worthy=True,
+        供 channel 侧据此把报告登记为 context projection。"""
+        emitted = []
+        d = _make_delivery()
+
+        async def _fake_emit(source_session_id, data, **kwargs):
+            emitted.append(data)
+
+        monkeypatch.setattr("src.everbot.core.runtime.cron_delivery.emit", _fake_emit, raising=False)
+        monkeypatch.setattr("src.everbot.core.runtime.events.emit", _fake_emit)
+
+        await d._emit_realtime("report body", "run_x", transcript_worthy=True)
+
+        assert emitted[0]["transcript_worthy"] is True
+
+    @pytest.mark.asyncio
+    async def test_emit_realtime_defaults_not_transcript_worthy(self, monkeypatch):
+        """缺省(心跳状态路径)不置 transcript_worthy → 不入逐字稿。"""
+        emitted = []
+        d = _make_delivery()
+
+        async def _fake_emit(source_session_id, data, **kwargs):
+            emitted.append(data)
+
+        monkeypatch.setattr("src.everbot.core.runtime.cron_delivery.emit", _fake_emit, raising=False)
+        monkeypatch.setattr("src.everbot.core.runtime.events.emit", _fake_emit)
+
+        await d._emit_realtime("status ping", "run_y")
+
+        assert emitted[0].get("transcript_worthy", False) is False

--- a/tests/unit/test_cron_executor.py
+++ b/tests/unit/test_cron_executor.py
@@ -927,3 +927,60 @@ class TestBuildJobSystemPromptMilkieSafe:
         task = Task(id="t3", title="T", description="cron job")
         out = CronExecutor._build_job_system_prompt(agent, task)
         assert out == "DOLPHIN WS\n\ncron job"
+
+
+class TestTranscriptWorthyDelivery:
+    """#60:内容型 job/agent 成功投递标记 transcript_worthy=True(进逐字稿 projection);
+    失败消息不标记。"""
+
+    @pytest.mark.asyncio
+    async def test_isolated_job_success_marks_transcript_worthy(self, tmp_path):
+        executor = _make_executor(tmp_path)
+        executor._invoke_job = AsyncMock(return_value="REPORT BODY")
+        executor.delivery.deposit_job_event = AsyncMock()
+        executor.delivery.inject_to_history = AsyncMock()
+        executor.delivery._emit_realtime = AsyncMock()
+        task = SimpleNamespace(job="mod.fn", title="Daily", id="t1", timeout_seconds=60)
+
+        out = await executor._run_isolated_job(task, "run-1")
+
+        assert out == "REPORT BODY"
+        executor.delivery._emit_realtime.assert_awaited_once()
+        assert executor.delivery._emit_realtime.call_args.kwargs.get("transcript_worthy") is True
+
+    @pytest.mark.asyncio
+    async def test_isolated_job_failure_not_transcript_worthy(self, tmp_path):
+        executor = _make_executor(tmp_path)
+        executor._invoke_job = AsyncMock(side_effect=RuntimeError("boom"))
+        executor.delivery.deposit_job_event = AsyncMock()
+        executor.delivery.inject_to_history = AsyncMock()
+        executor.delivery._emit_realtime = AsyncMock()
+        task = SimpleNamespace(job="mod.fn", title="Daily", id="t1", timeout_seconds=60)
+
+        with patch("src.everbot.core.tasks.task_manager.format_retry_hint", return_value=""):
+            with pytest.raises(RuntimeError):
+                await executor._run_isolated_job(task, "run-1")
+
+        executor.delivery._emit_realtime.assert_awaited_once()
+        assert executor.delivery._emit_realtime.call_args.kwargs.get("transcript_worthy", False) is False
+
+    @pytest.mark.asyncio
+    async def test_isolated_agent_success_marks_transcript_worthy(self, tmp_path):
+        executor = _make_executor(tmp_path)
+        executor._create_job_agent = AsyncMock(return_value=SimpleNamespace(name="a"))
+        executor._build_job_system_prompt = MagicMock(return_value="sys")
+        executor._record_skill_log = MagicMock()
+        executor.delivery.deposit_job_event = AsyncMock()
+        executor.delivery.inject_to_history = AsyncMock()
+        executor.delivery._emit_realtime = AsyncMock()
+        task = SimpleNamespace(title="Daily", id="t1", timeout_seconds=60)
+
+        async def _run_agent(agent, prompt, system_prompt_override=None):
+            return "AGENT REPORT"
+
+        with patch("src.everbot.core.runtime.cron.build_job_session_id", return_value="job_t1"), \
+             patch("src.everbot.core.runtime.cron.build_isolated_task_prompt", return_value="prompt"):
+            out = await executor._run_isolated_agent(task, "run-1", run_agent=_run_agent)
+
+        assert out == "AGENT REPORT"
+        assert executor.delivery._emit_realtime.call_args.kwargs.get("transcript_worthy") is True

--- a/tests/unit/test_milkie_provider.py
+++ b/tests/unit/test_milkie_provider.py
@@ -819,3 +819,49 @@ def test_capture_trace_none_without_run_id(monkeypatch):
     monkeypatch.setattr(provider_mod, "capture_trace_report", _boom)
     agent = MilkieAgentHandle(base_url="http://x", context_id="c", name="a")  # last_run_id 默认 None
     assert MilkieProvider("http://x").capture_trace(agent) is None
+
+
+# ============================================================================
+# #60 / milkie#146:把投递到 channel 的外部产出登记为 context projection
+# (读侧、不进 history)。attach_projection 走 serve POST /projection/attach。
+# ============================================================================
+
+async def test_attach_projection_posts_to_projection_attach_endpoint():
+    """attach_projection 以 channel 的 contextId 为 target、job 的 milkie runId
+    为 sourceRunId,把 displayText POST 到 /projection/attach。"""
+    capture: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        capture["url"] = str(request.url)
+        capture["payload"] = json.loads(request.content)
+        return httpx.Response(200, json={"projection": {"sourceRunId": "job-run-1"}})
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    provider = MilkieProvider("http://sidecar", client=client)
+    handle = MilkieAgentHandle("http://sidecar", "tg_session_demo_agent__123")
+
+    await provider.attach_projection(
+        handle,
+        source_run_id="job-run-1",
+        display_text="今日 $SIVE 推文分析…",
+        delivered_at="2026-06-06T02:02:00Z",
+    )
+
+    assert capture["url"] == "http://sidecar/projection/attach"
+    assert capture["payload"]["contextId"] == "tg_session_demo_agent__123"
+    assert capture["payload"]["sourceRunId"] == "job-run-1"
+    assert capture["payload"]["displayText"].startswith("今日 $SIVE")
+    assert capture["payload"]["deliveredAt"] == "2026-06-06T02:02:00Z"
+
+
+async def test_attach_projection_raises_on_non_2xx():
+    """serve 非 2xx 不静默吞 —— 让调用方(带外 best-effort)能记日志。"""
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, json={"error": "boom"})
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    provider = MilkieProvider("http://sidecar", client=client)
+    handle = MilkieAgentHandle("http://sidecar", "ctx")
+
+    with pytest.raises(httpx.HTTPStatusError):
+        await provider.attach_projection(handle, source_run_id="r", display_text="x")

--- a/tests/unit/test_telegram_channel.py
+++ b/tests/unit/test_telegram_channel.py
@@ -1386,16 +1386,19 @@ async def test_maybe_attach_projection_skips_without_run_id(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_maybe_attach_projection_skips_when_no_cached_agent(tmp_path):
-    """channel 会话句柄不在缓存(未建/已逐出)→ 不 attach,不崩。"""
+async def test_maybe_attach_projection_swallows_create_failure(tmp_path):
+    """未缓存时回落创建;若创建失败(如 sidecar spawn 出错)→ 带外吞掉,
+    返回 False、不 attach、不崩(调用方据此回落镜像,内容不丢)。"""
     ch = _make_channel(tmp_path)
     ch._session_manager.get_cached_agent.return_value = None
+    ch._agent_service.create_agent_instance = AsyncMock(side_effect=RuntimeError("spawn failed"))
     attach = AsyncMock()
     with patch(
         "src.everbot.core.agent.provider.get_provider_for_agent",
-        return_value=SimpleNamespace(attach_projection=attach),
+        return_value=SimpleNamespace(attach_projection=attach, set_session_id=MagicMock()),
     ):
-        await ch._maybe_attach_projection("demo_agent", "111", _attach_data())
+        ok = await ch._maybe_attach_projection("demo_agent", "111", _attach_data())
+    assert ok is False
     attach.assert_not_awaited()
 
 
@@ -1474,3 +1477,24 @@ async def test_failed_projection_falls_back_to_mailbox_mirror(tmp_path):
             "run_id": "job-1", "transcript_worthy": True,
         })
     ch._session_manager.deposit_mailbox_event.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_maybe_attach_projection_creates_handle_when_not_cached(tmp_path):
+    """后台投递常发生在用户空闲时,channel 句柄不在缓存 —— 必须回落创建并绑定
+    channel context(set_session_id),否则永远不 attach(主动推送场景的核心)。"""
+    ch = _make_channel(tmp_path)
+    ch._session_manager.get_cached_agent.return_value = None
+    created = SimpleNamespace(context_id="random-ctx", base_url="u")
+    ch._agent_service.create_agent_instance = AsyncMock(return_value=created)
+    attach = AsyncMock()
+    set_sid = MagicMock()
+    with patch("src.everbot.core.agent.provider.get_provider_for_agent",
+               return_value=SimpleNamespace(attach_projection=attach, set_session_id=set_sid)):
+        ok = await ch._maybe_attach_projection("demo_agent", "111", _attach_data())
+    assert ok is True
+    ch._agent_service.create_agent_instance.assert_awaited_once_with("demo_agent")
+    set_sid.assert_called_once_with(created, "tg_session_demo_agent__111")
+    ch._session_manager.cache_agent.assert_called_once()
+    attach.assert_awaited_once()
+    assert attach.call_args.args[0] is created

--- a/tests/unit/test_telegram_channel.py
+++ b/tests/unit/test_telegram_channel.py
@@ -1436,3 +1436,41 @@ async def test_on_background_event_invokes_projection_attach_after_send(tmp_path
     assert args[0] == "my_agent"
     assert str(args[1]) == "111"
     assert args[2].get("run_id") == "job-run-1"
+
+
+@pytest.mark.asyncio
+async def test_transcript_worthy_projection_skips_mailbox_mirror(tmp_path):
+    """内容型投递成功 attach projection 后,不再镜像进 Background Updates ——
+    避免双重表示,且防止报告的镜像版本贴着"上面"劫持指代。"""
+    ch = _make_channel(tmp_path)
+    ch._send_message = AsyncMock()
+    ch._bindings = {"111": "my_agent"}
+    ch._session_manager.get_cached_agent.return_value = SimpleNamespace(context_id="c", base_url="u")
+    attach = AsyncMock()
+    with patch("src.everbot.core.agent.provider.get_provider_for_agent",
+               return_value=SimpleNamespace(attach_projection=attach)):
+        await ch._on_background_event("session_1", {
+            "source_type": "heartbeat_delivery", "agent_name": "my_agent",
+            "detail": "REPORT", "deliver": True, "scope": "agent",
+            "run_id": "job-1", "transcript_worthy": True,
+        })
+    attach.assert_awaited_once()
+    ch._session_manager.deposit_mailbox_event.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_failed_projection_falls_back_to_mailbox_mirror(tmp_path):
+    """attach 失败 → 回落 mailbox 镜像,内容不丢(degraded but visible)。"""
+    ch = _make_channel(tmp_path)
+    ch._send_message = AsyncMock()
+    ch._bindings = {"111": "my_agent"}
+    ch._session_manager.get_cached_agent.return_value = SimpleNamespace(context_id="c", base_url="u")
+    attach = AsyncMock(side_effect=RuntimeError("serve down"))
+    with patch("src.everbot.core.agent.provider.get_provider_for_agent",
+               return_value=SimpleNamespace(attach_projection=attach)):
+        await ch._on_background_event("session_1", {
+            "source_type": "heartbeat_delivery", "agent_name": "my_agent",
+            "detail": "REPORT", "deliver": True, "scope": "agent",
+            "run_id": "job-1", "transcript_worthy": True,
+        })
+    ch._session_manager.deposit_mailbox_event.assert_awaited_once()

--- a/tests/unit/test_telegram_channel.py
+++ b/tests/unit/test_telegram_channel.py
@@ -1301,3 +1301,138 @@ class TestExtractTextFromMessage:
         from src.everbot.core.channel.core_service import ChannelCoreService
         msg = [{"type": "image_url", "image_url": {"url": "data:..."}}]
         assert ChannelCoreService._extract_text_from_message(msg) == ""
+
+
+# ===========================================================================
+# #60 / milkie#146:把投递到 channel 的外部产出登记为 context projection。
+# ===========================================================================
+
+def test_truncate_projection_text_caps_to_limit_with_ellipsis():
+    """milkie 不限 displayText 长度 → alfred 必须截断,避免每轮重渲吃 token。"""
+    from src.everbot.channels.telegram_channel import _truncate_projection_text
+
+    out = _truncate_projection_text("x" * 5000, limit=100)
+    assert len(out) == 100
+    assert out.endswith("…")
+    assert out.startswith("x" * 10)
+
+
+def test_truncate_projection_text_keeps_short_text_unchanged():
+    from src.everbot.channels.telegram_channel import _truncate_projection_text
+
+    assert _truncate_projection_text("hello", limit=100) == "hello"
+
+
+def _attach_data(**over):
+    d = {
+        "transcript_worthy": True,
+        "run_id": "job-run-1",
+        "detail": "今日 $SIVE 推文分析…",
+        "delivered_at": "2026-06-06T02:02:00Z",
+    }
+    d.update(over)
+    return d
+
+
+@pytest.mark.asyncio
+async def test_maybe_attach_projection_calls_provider_when_transcript_worthy(tmp_path):
+    """内容型投递(transcript_worthy)→ 用 run_id 作 sourceRunId、detail 作 displayText
+    调 channel 会话句柄的 provider.attach_projection。"""
+    ch = _make_channel(tmp_path)
+    fake_agent = SimpleNamespace(context_id="tg_session_demo__111", base_url="http://x")
+    ch._session_manager.get_cached_agent.return_value = fake_agent
+    attach = AsyncMock()
+    with patch(
+        "src.everbot.core.agent.provider.get_provider_for_agent",
+        return_value=SimpleNamespace(attach_projection=attach),
+    ):
+        await ch._maybe_attach_projection("demo_agent", "111", _attach_data())
+    attach.assert_awaited_once()
+    assert attach.call_args.args[0] is fake_agent
+    # 关键:解析出 channel 会话 id 并取该会话句柄(投到用户所在会话,不投错)
+    ch._session_manager.get_cached_agent.assert_called_once_with("tg_session_demo_agent__111")
+    kwargs = attach.call_args.kwargs
+    assert kwargs["source_run_id"] == "job-run-1"
+    assert kwargs["display_text"].startswith("今日 $SIVE")
+    assert kwargs["delivered_at"] == "2026-06-06T02:02:00Z"
+
+
+@pytest.mark.asyncio
+async def test_maybe_attach_projection_skips_when_not_transcript_worthy(tmp_path):
+    """心跳状态 ping(无 transcript_worthy)→ 不进逐字稿,不 attach。"""
+    ch = _make_channel(tmp_path)
+    ch._session_manager.get_cached_agent.return_value = SimpleNamespace(context_id="c", base_url="u")
+    attach = AsyncMock()
+    with patch(
+        "src.everbot.core.agent.provider.get_provider_for_agent",
+        return_value=SimpleNamespace(attach_projection=attach),
+    ):
+        await ch._maybe_attach_projection("demo_agent", "111", _attach_data(transcript_worthy=False))
+    attach.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_maybe_attach_projection_skips_without_run_id(tmp_path):
+    """无 sourceRunId(去重/溯源锚点缺失)→ 不 attach。"""
+    ch = _make_channel(tmp_path)
+    ch._session_manager.get_cached_agent.return_value = SimpleNamespace(context_id="c", base_url="u")
+    attach = AsyncMock()
+    with patch(
+        "src.everbot.core.agent.provider.get_provider_for_agent",
+        return_value=SimpleNamespace(attach_projection=attach),
+    ):
+        await ch._maybe_attach_projection("demo_agent", "111", _attach_data(run_id=""))
+    attach.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_maybe_attach_projection_skips_when_no_cached_agent(tmp_path):
+    """channel 会话句柄不在缓存(未建/已逐出)→ 不 attach,不崩。"""
+    ch = _make_channel(tmp_path)
+    ch._session_manager.get_cached_agent.return_value = None
+    attach = AsyncMock()
+    with patch(
+        "src.everbot.core.agent.provider.get_provider_for_agent",
+        return_value=SimpleNamespace(attach_projection=attach),
+    ):
+        await ch._maybe_attach_projection("demo_agent", "111", _attach_data())
+    attach.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_maybe_attach_projection_swallows_attach_failure(tmp_path):
+    """attach 失败是带外 best-effort —— 气泡已发出,绝不能让异常冒泡破坏投递。"""
+    ch = _make_channel(tmp_path)
+    ch._session_manager.get_cached_agent.return_value = SimpleNamespace(context_id="c", base_url="u")
+    attach = AsyncMock(side_effect=RuntimeError("serve down"))
+    with patch(
+        "src.everbot.core.agent.provider.get_provider_for_agent",
+        return_value=SimpleNamespace(attach_projection=attach),
+    ):
+        # 不抛 = 通过
+        await ch._maybe_attach_projection("demo_agent", "111", _attach_data())
+    attach.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_on_background_event_invokes_projection_attach_after_send(tmp_path):
+    """_on_background_event 在成功投递气泡后,对该 chat 调 _maybe_attach_projection
+    (内容型投递据此登记 context projection)。"""
+    ch = _make_channel(tmp_path)
+    ch._send_message = AsyncMock()
+    ch._bindings = {"111": "my_agent"}
+    ch._maybe_attach_projection = AsyncMock()
+    await ch._on_background_event("session_1", {
+        "source_type": "heartbeat_delivery",
+        "agent_name": "my_agent",
+        "detail": "DAILY REPORT",
+        "deliver": True,
+        "scope": "agent",
+        "run_id": "job-run-1",
+        "transcript_worthy": True,
+    })
+    ch._maybe_attach_projection.assert_awaited_once()
+    args = ch._maybe_attach_projection.call_args.args
+    assert args[0] == "my_agent"
+    assert str(args[1]) == "111"
+    assert args[2].get("run_id") == "job-run-1"


### PR DESCRIPTION
Closes #60

## 背景

主动推送(twitter 日报等)投递到 channel 后**只发气泡、不进该 channel 会话上下文**,模型下一轮看不见,追问「上面内容从哪来的」答非所问(答成后台心跳)。这是 milkie 迁移引入的回归:Dolphin 时代的 `_load_heartbeat_context` 桥被 `131ffd7` 拆除、又随 milkie 自管历史焊死。

接 milkie#146/#147(已合并)的**读侧 context projection** 能力补桥。

## 改动

- **`MilkieProvider.attach_projection`** → serve `POST /projection/attach`(contextId=channel 会话、sourceRunId=`run_id` 去重/溯源、displayText 截断)
- **`telegram_channel._on_background_event`**:内容型投递发气泡后调 `_maybe_attach_projection`(带外 best-effort)
  - 闸门:仅 `transcript_worthy` 内容(心跳状态/失败不入逐字稿)
  - **projection 成功则跳过 mailbox 镜像**(取代而非叠加,避免双重表示 + 报告镜像版贴"上面"劫持指代);失败回落镜像,内容不丢
  - 未缓存时**回落 `create_agent_instance` + `set_session_id`**(主动推送多在用户空闲时发生,句柄常不在缓存)
- cron 投递 job/agent **成功**路径置 `transcript_worthy=True`
- 删旧 Dolphin 桥死代码 `_load_heartbeat_context`

## 验证(三层)

- ✅ **单测**(全程 TDD):15 个,覆盖 payload/截断/门控/skip-mirror/回落创建/失败吞掉/cron 标志
- ✅ **真 milkie serve E2E**:2 个 —— attach 后投影进下一轮 prompt;真 `_on_background_event` 编排 → 真 serve → External Delivered Context 进 prompt
- ✅ **活体**(daemon 跑本分支):`POST /projection/attach 200`(20:01/22:01 真投递),提问轮 `External Delivered Context: 1→4`,模型正确引用并核对报告;trace-review 亦经自然语言激活
- 全量 unit 1687 passed

## 作用域

- 仅 Telegram。web 渠道不受同一 bug 影响(只 WebSocket 推送、无 mailbox 镜像)。
- trace-review 口语触发词扩展 = #61(独立);twitter-watch 走 cite 结构化血缘 = #62(独立)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
