### PR TITLE
feat(#61): trace-review 扩口语触发词 + 按内容定位 run(--match)

### DIFF
--- a/skills/trace-review/SKILL.md
+++ b/skills/trace-review/SKILL.md
@@ -1,21 +1,22 @@
 ---
 name: trace-review
-description: 对话式复盘/求证一次 milkie run —— 看"这一轮怎么跑的、调了什么工具、命中什么证据、答案的数据来源"。当用户说"复盘上一轮""你刚那个数怎么来的""这个结论怎么得到的""看下执行过程/命中证据""求证一下""上一轮为什么慢/失败"时使用。
+description: 对话式复盘/求证一次 milkie run —— 看"这一轮怎么跑的、调了什么工具、命中什么证据、答案的数据来源"。当用户说"复盘上一轮""复盘下刚的分析""你刚那个数怎么来的""这个结论怎么得到的""上面内容/那篇报告从哪来的""这些内容怎么来的/哪儿来的/哪来的""看下执行过程/命中证据""求证一下""上一轮为什么慢/失败"时使用。亦覆盖对某条已投递报告/推送的来源追问。
 version: "0.1.0"
 tags: [trace, observability, review, provenance, debugging, milkie]
 ---
 
 # Trace Review
 
-复盘一次 milkie run 的执行过程,用于**对话式求证**:把某轮对话的「用户问题 → 执行步骤(工具调用 + 命中证据)→ 最终答案」摊开,让用户核验结论的数据来源、定位慢/失败的原因。
+复盘/求证一次 milkie run:摊开「用户问题→执行步骤(工具调用+命中证据)→答案」核验来源、定位慢/失败。追问『上面内容/那篇报告从哪来的』『这些内容怎么来的/哪儿来的』『复盘下刚的分析』『你那数/结论怎么来的』时用。
 
 milkie 每轮已把完整事件溯源 trace 落盘到 `~/.alfred/milkie/<agent>/runs/<runId>.jsonl`。本 skill **只消费** milkie 现成的诊断产物(`milkie trace execution/report`),不重写诊断逻辑。
 
 ## 何时用
 
-- 用户要核验某个结论/数字的来源:「你刚那个数怎么来的」「这个结论怎么得到的」「求证一下」
-- 用户要看执行过程:「复盘上一轮」「看下你调了什么工具、命中什么」
+- 用户要核验某个结论/数字/内容的来源:「你刚那个数怎么来的」「这个结论怎么得到的」「**上面内容/那篇报告从哪来的**」「**这些内容怎么来的/哪儿来的**」「求证一下」
+- 用户要看执行过程:「复盘上一轮」「**复盘下刚的分析**」「看下你调了什么工具、命中什么」
 - 用户排查上一轮为什么慢 / 失败 / 缓存没命中
+- 用户追问的是**某条具体已投递报告/推送**(不一定是最近一轮)时,用 `--match <报告里的关键词>` 定位产出它的 run,而非盲取最近一轮
 
 ## 命令
 
@@ -27,6 +28,7 @@ python skills/trace-review/scripts/review_run.py [选项]
 |---|---|
 | `--agent NAME` | 收窄到指定 agent(缺省扫所有 agent) |
 | `--run-id ID` | 显式指定 runId(缺省取最近一个**已完成** run) |
+| `--match TEXT` | 按内容定位:取最近一个其**用户输入或最终答案含 TEXT** 的已完成 run。追问"上面那篇报告/那条内容从哪来的"时,传报告里的关键词,定位产出它的那轮(而非盲取最近) |
 | `--brief` | 精简输出(默认详尽,保留完整 query/命中证据) |
 | `--full` | 额外渲染自包含 HTML 报告到 `~/.alfred/logs/traces/<runId>.html` |
 
@@ -43,6 +45,9 @@ python skills/trace-review/scripts/review_run.py --agent demo_agent
 
 # 复盘指定 run 并出 HTML
 python skills/trace-review/scripts/review_run.py --run-id <runId> --full
+
+# 追问"上面那篇报告从哪来的" —— 用报告里的关键词定位产出它的 run
+python skills/trace-review/scripts/review_run.py --match "$SIVE"
 ```
 
 ## 输出契约

--- a/skills/trace-review/scripts/review_run.py
+++ b/skills/trace-review/scripts/review_run.py
@@ -146,18 +146,59 @@ def is_completed(jsonl_path: Path, tail_bytes: int = _TAIL_BYTES) -> bool:
     return COMPLETION_MARKER.encode("utf-8") in data
 
 
+def run_matches(jsonl_path: Path, text: str) -> bool:
+    """#61:该 run 的用户输入(``agent.run.started.input/goal``)或最终答案
+    (``agent.run.completed.lastTextOutput/output``)是否含 ``text``(子串,大小写不敏感)。
+    用于按"那篇报告/那条内容"定位产出它的 run,而非盲取最近一轮。空 text → True(不过滤);
+    文件缺失/读失败 → False。"""
+    if not text:
+        return True
+    needle = text.lower()
+    try:
+        with open(jsonl_path, encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    e = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                p = e.get("payload") or {}
+                if e.get("type") == "agent.run.started":
+                    s = str(p.get("input") or p.get("goal") or "")
+                elif e.get("type") == "agent.run.completed":
+                    s = str(p.get("lastTextOutput") or p.get("output") or "")
+                else:
+                    continue
+                if needle in s.lower():
+                    return True
+    except OSError:
+        return False
+    return False
+
+
 def pick_run(
-    runs: List[Tuple[str, str, Path, float]], *, run_id: Optional[str] = None
+    runs: List[Tuple[str, str, Path, float]],
+    *,
+    run_id: Optional[str] = None,
+    match: Optional[str] = None,
 ) -> Optional[Tuple[str, str, Path]]:
-    """显式 run_id 优先;否则按 mtime 降序取第一个**已完成**的 run。"""
+    """显式 run_id 优先;否则按 mtime 降序取第一个**已完成**的 run。
+
+    ``match`` 给定时(#61):在已完成 run 中,按 mtime 降序取第一个**内容命中** ``match``
+    的(用户追问"上面那篇报告从哪来的"时定位产出它的 run,而非盲取最近);无命中 → None。"""
     if run_id:
         for name, rid, path, _ in runs:
             if rid == run_id:
                 return (name, rid, path)
         return None
     for name, rid, path, _ in sorted(runs, key=lambda r: r[3], reverse=True):
-        if is_completed(path):
-            return (name, rid, path)
+        if not is_completed(path):
+            continue
+        if match and not run_matches(path, match):
+            continue
+        return (name, rid, path)
     return None
 
 
@@ -404,6 +445,12 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p.add_argument("--agent", default=None, help="收窄到指定 agent(缺省扫所有 agent)")
     p.add_argument("--run-id", default=None, help="显式指定 runId(缺省取最近已完成 run)")
+    p.add_argument(
+        "--match",
+        default=None,
+        help="按内容定位 run:取最近一个其用户输入或最终答案含此子串的已完成 run "
+        "(追问『上面那篇报告/那条内容从哪来的』时用,避免盲取最近一轮)",
+    )
     p.add_argument("--brief", action="store_true", help="精简输出(默认详尽)")
     p.add_argument("--full", action="store_true", help="额外渲染 HTML 报告到 ~/.alfred/logs/traces/")
     p.add_argument("--dist", default=None, help="覆盖 milkie dist 路径")
@@ -436,11 +483,13 @@ def run(argv: Optional[Sequence[str]] = None, *, runner: Runner = _default_runne
         )
 
     runs = discover_runs(paths.data_dir_root, args.agent)
-    picked = pick_run(runs, run_id=args.run_id)
+    picked = pick_run(runs, run_id=args.run_id, match=args.match)
     if picked is None:
         scope = f"agent `{args.agent}`" if args.agent else "所有 agent"
         if args.run_id:
             return 2, f"# 复盘失败\n\n在 {scope} 下找不到 runId `{args.run_id}`。"
+        if args.match:
+            return 2, f"# 复盘失败\n\n在 {scope} 下没有内容含 `{args.match}` 的已完成 run。"
         return 2, f"# 复盘失败\n\n{scope} 下没有**已完成**的 run 可复盘。"
 
     agent, run_id, _ = picked

--- a/skills/trace-review/tests/test_review_run.py
+++ b/skills/trace-review/tests/test_review_run.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -404,3 +405,133 @@ def test_run_cli_failure_degrades(tmp_path):
         runner=lambda c, t: _proc(stderr="kaboom", rc=1),
     )
     assert code == 3 and "复盘失败" in md
+
+
+# ---------------------------------------------------------------------------
+# #61: 按内容定位 run(run_matches / pick_run match=)
+# ---------------------------------------------------------------------------
+def _write_run_content(root: Path, agent: str, run_id: str, *, mtime: float,
+                       inp: str = "hi", out: str = "bye") -> Path:
+    runs = root / agent / "runs"
+    runs.mkdir(parents=True, exist_ok=True)
+    f = runs / f"{run_id}.jsonl"
+    f.write_text(
+        json.dumps({"type": "agent.run.started", "payload": {"input": inp}}) + "\n"
+        + json.dumps({"type": "agent.run.completed", "payload": {"lastTextOutput": out}}) + "\n",
+        encoding="utf-8",
+    )
+    os.utime(f, (mtime, mtime))
+    return f
+
+
+def test_run_matches_input_and_output(tmp_path):
+    f = _write_run_content(tmp_path, "a", "r1", mtime=1, inp="分析推文", out="报告里提到 $SIVE 强烈看多")
+    assert rr.run_matches(f, "SIVE") is True          # 命中 output(大小写不敏感)
+    assert rr.run_matches(f, "分析推文") is True       # 命中 input
+    assert rr.run_matches(f, "不存在的内容") is False
+    assert rr.run_matches(f, "") is True               # 空 match 视为不过滤
+
+
+def test_run_matches_missing_file(tmp_path):
+    assert rr.run_matches(tmp_path / "ghost.jsonl", "x") is False
+
+
+def test_pick_run_match_selects_matching_over_latest(tmp_path):
+    # 更新的 run 不含关键词;较老的 run 含 —— match 应越过"最近"选中含关键词的那个
+    _write_run_content(tmp_path, "a", "r_new", mtime=200, inp="闲聊", out="好的")
+    _write_run_content(tmp_path, "a", "r_old", mtime=100, inp="分析推文", out="$SIVE 报告")
+    runs = rr.discover_runs(tmp_path)
+    picked = rr.pick_run(runs, match="SIVE")
+    assert picked is not None
+    assert picked[1] == "r_old"
+
+
+def test_pick_run_match_picks_most_recent_among_matches(tmp_path):
+    _write_run_content(tmp_path, "a", "r1", mtime=100, inp="x", out="$SIVE 旧报告")
+    _write_run_content(tmp_path, "a", "r2", mtime=300, inp="y", out="$SIVE 新报告")
+    runs = rr.discover_runs(tmp_path)
+    picked = rr.pick_run(runs, match="SIVE")
+    assert picked[1] == "r2"   # 多个命中取最近
+
+
+def test_pick_run_match_none_when_no_match(tmp_path):
+    _write_run_content(tmp_path, "a", "r1", mtime=100, inp="x", out="y")
+    runs = rr.discover_runs(tmp_path)
+    assert rr.pick_run(runs, match="无此内容") is None
+
+
+def test_pick_run_no_match_keeps_latest_completed(tmp_path):
+    # 不传 match → 既有行为不变(最近已完成)
+    _write_run_content(tmp_path, "a", "r_old", mtime=100, inp="x", out="y")
+    _write_run_content(tmp_path, "a", "r_new", mtime=200, inp="x", out="y")
+    runs = rr.discover_runs(tmp_path)
+    assert rr.pick_run(runs)[1] == "r_new"
+
+
+def test_run_match_selects_matching_run_end_to_end(tmp_path):
+    """--match:端到端定位到内容命中的那轮(而非最近),并对它跑复盘。"""
+    root = tmp_path / "milkie"
+    _write_run_content(root, "demo", "r_new", mtime=9000, inp="闲聊", out="好的")
+    _write_run_content(root, "demo", "r_old", mtime=1000, inp="分析推文", out="$SIVE 报告")
+    dist = tmp_path / "dist.js"
+    dist.write_text("//", encoding="utf-8")
+    seen: dict = {}
+
+    def _runner(cmd, timeout):
+        seen["run_id"] = cmd[-1]
+        return _proc(stdout=json.dumps({"steps": []}))
+
+    code, md = rr.run(
+        ["--data-dir-root", str(root), "--dist", str(dist),
+         "--config", str(tmp_path / "x.yaml"), "--match", "SIVE"],
+        runner=_runner,
+    )
+    assert code == 0
+    assert seen["run_id"] == "r_old"
+
+
+def test_run_match_no_match_reports_clearly(tmp_path):
+    root = tmp_path / "milkie"
+    _write_run_content(root, "demo", "r1", mtime=1000, inp="x", out="y")
+    dist = tmp_path / "dist.js"
+    dist.write_text("//", encoding="utf-8")
+    code, md = rr.run(
+        ["--data-dir-root", str(root), "--dist", str(dist),
+         "--config", str(tmp_path / "x.yaml"), "--match", "无此内容"],
+    )
+    assert code == 2 and "没有内容含" in md
+
+
+# ---------------------------------------------------------------------------
+# #61 part1: SKILL.md 触发描述须覆盖口语化溯源追问(原 bug:『上面内容从哪来的』不激活)
+# ---------------------------------------------------------------------------
+def _routing_description(skill_md: str, max_chars: int = 150) -> str:
+    """复刻 everbot discover_skills 的 description 提取:# 标题后首段正文,截断到 max_chars。
+    这是 skill_list **路由**实际看到的文本(触发词必须在此 —— frontmatter/何时用 影响不到路由)。"""
+    tm = re.search(r"^#\s+(.+)$", skill_md, re.MULTILINE)
+    after = skill_md[tm.end():] if tm else skill_md
+    para: list[str] = []
+    for line in after.splitlines():
+        s = line.strip()
+        if not para:
+            if not s:
+                continue
+            if s.startswith("#"):
+                break
+        elif not s or s.startswith("#"):
+            break
+        para.append(s)
+    desc = " ".join(para).strip()
+    return desc if len(desc) <= max_chars else desc[:max_chars]
+
+
+def test_skill_md_covers_colloquial_provenance_triggers():
+    skill_md = (Path(__file__).resolve().parents[1] / "SKILL.md").read_text(encoding="utf-8")
+    routed = _routing_description(skill_md)  # 路由实际看到的(截断后)文本
+    for phrase in ["上面", "哪来", "怎么来", "复盘", "这些内容"]:
+        assert phrase in routed, f"路由 description 须含『{phrase}』,否则 skill_list 选不中(#61)"
+
+
+def test_skill_md_documents_match_option():
+    skill_md = (Path(__file__).resolve().parents[1] / "SKILL.md").read_text(encoding="utf-8")
+    assert "--match" in skill_md, "SKILL.md 应文档化 --match(按内容定位 run)"


### PR DESCRIPTION
Closes #61

## 问题
口语化溯源追问(『上面内容从哪来的』『复盘下刚的分析』『这些内容怎么来的』)激活不了 trace-review。

## 根因
skill_list **路由**用的是 SKILL.md 正文首段(everbot `parse_skill_metadata` 截 150 字),**不是** frontmatter `description:` 或『何时用』。触发词须进**正文首段**才影响路由。

## 改动
- **SKILL.md 正文首段**重写为精简+触发词(上面/哪来/怎么来/复盘…分析/这些内容,114 字 ≤150 未截断);frontmatter description、何时用、命令表同步扩。
- **review_run.py**:`run_matches(path,text)` + `pick_run(match=)` + `--match` CLI —— 追问『上面那篇报告从哪来的』时按报告关键词定位产出它的 run(而非盲取最近一轮)。

## 测试(TDD,45 passed)
- `run_matches` 命中 input/output/大小写不敏感/空/缺失文件
- `pick_run(match=)` 越过最近选命中、多命中取最近、无命中 None、不传不变
- `--match` run() 端到端(捕获实际定位的 run_id)
- **路由 description 含触发词**(复刻 `parse_skill_metadata` 提取断言 —— 护住路由而非任意处)
- `--match` 文档化

## 端到端验证
`parse_skill_metadata(skills/trace-review)`(manifest 同源生产函数)现产出含全部触发词的 description;launcher 每次 sidecar spawn 必重写 manifest → 下次 demo_agent spawn(心跳/对话)自动刷新生效。

🤖 Generated with [Claude Code](https://claude.com/claude-code)