### PR TITLE
monastery: fix #66

### DIFF
--- a/src/everbot/channels/telegram_channel.py
+++ b/src/everbot/channels/telegram_channel.py
@@ -886,18 +886,15 @@ class TelegramChannel:
         """
         if HAS_TELEGRAMIFY:
             try:
-                plain, entities = tg_md_convert(text)
-                entity_dicts = [e.to_dict() for e in entities]
-                if entity_dicts:
-                    return plain, entity_dicts
-                # No entities produced — try normalising tables first
+                # Normalise +---+ style tables unconditionally before conversion.
+                # Must happen first: messages with bold/link entities would otherwise
+                # return early and never reach table normalisation (issue #66).
                 if "+" in text and "---" in text:
                     normalised = TelegramChannel._normalize_tables(text)
                     if normalised != text:
-                        plain2, entities2 = tg_md_convert(normalised)
-                        entity_dicts2 = [e.to_dict() for e in entities2]
-                        if entity_dicts2:
-                            return plain2, entity_dicts2
+                        text = normalised
+                plain, entities = tg_md_convert(text)
+                entity_dicts = [e.to_dict() for e in entities]
                 return plain, entity_dicts
             except Exception as exc:
                 logger.warning("telegramify_markdown conversion failed: %s", exc)

--- a/tests/unit/test_telegram_channel.py
+++ b/tests/unit/test_telegram_channel.py
@@ -1498,3 +1498,111 @@ async def test_maybe_attach_projection_creates_handle_when_not_cached(tmp_path):
     ch._session_manager.cache_agent.assert_called_once()
     attach.assert_awaited_once()
     assert attach.call_args.args[0] is created
+
+
+# ===========================================================================
+# 16. _convert_markdown — table normalisation gate (issue #66)
+# ===========================================================================
+
+class TestConvertMarkdown:
+    """_convert_markdown must normalise +---+ tables unconditionally, even when
+    the message also has entity-producing spans (bold headings, ticker links).
+
+    Old bug: normalisation was gated behind ``if not entity_dicts``, so any
+    message with bold/link entities skipped table conversion entirely.
+    """
+
+    # Reusable fixture: message with bold heading AND a +--- style table
+    _MIXED_TEXT = (
+        "**投资信号汇总**\n\n"
+        "标的        | 信号    | 强度\n"
+        "------------+--------+------\n"
+        "$SIVE       | 买入    | 强\n"
+        "$XFAB       | 观望    | 中\n"
+    )
+
+    @staticmethod
+    def _fake_entity():
+        """Minimal entity stub returned by the mocked tg_md_convert."""
+        class _E:
+            def to_dict(self):
+                return {"type": "bold", "offset": 0, "length": 8}
+        return _E()
+
+    def test_table_normalised_before_convert_when_entities_present(self):
+        """tg_md_convert must receive normalised text (no ---+--- separator)
+        even when it would produce entities (bold heading).  This is the
+        direct regression test for the issue #66 gate bug."""
+        import src.everbot.channels.telegram_channel as ch_mod
+
+        captured = []
+
+        def fake_convert(t):
+            captured.append(t)
+            # Simulate a convert that produces an entity (bold heading)
+            return (t, [self._fake_entity()])
+
+        with patch("src.everbot.channels.telegram_channel.HAS_TELEGRAMIFY", True), \
+             patch("src.everbot.channels.telegram_channel.tg_md_convert", fake_convert, create=True):
+            plain, entities = TelegramChannel._convert_markdown(self._MIXED_TEXT)
+
+        assert captured, "tg_md_convert was never called"
+        received = captured[0]
+
+        # The separator line must be normalised — no raw +---+ form
+        assert "---+---" not in received, (
+            f"Table was NOT normalised before tg_md_convert.\nGot:\n{received}"
+        )
+        assert "----+--------+------" not in received, (
+            f"Original +---+ separator still present.\nGot:\n{received}"
+        )
+        # Standard MD separator should be present after normalisation
+        assert "| --- |" in received, (
+            f"Expected normalised '| --- |' separator.\nGot:\n{received}"
+        )
+
+        # Entities should still pass through unchanged
+        assert entities is not None
+        assert len(entities) == 1
+        assert entities[0]["type"] == "bold"
+
+    def test_table_normalised_when_no_entities(self):
+        """Existing behaviour: table is also normalised when convert produces no entities."""
+        captured = []
+
+        def fake_convert(t):
+            captured.append(t)
+            return (t, [])  # no entities
+
+        with patch("src.everbot.channels.telegram_channel.HAS_TELEGRAMIFY", True), \
+             patch("src.everbot.channels.telegram_channel.tg_md_convert", fake_convert, create=True):
+            plain, entities = TelegramChannel._convert_markdown(self._MIXED_TEXT)
+
+        assert captured
+        received = captured[0]
+        assert "| --- |" in received
+        assert "----+--------+------" not in received
+
+    def test_plain_text_without_table_unchanged(self):
+        """Text without +---+ markers must not be modified before conversion."""
+        text = "**Hello** world\n\nSome *italic* text."
+        captured = []
+
+        def fake_convert(t):
+            captured.append(t)
+            return (t, [self._fake_entity()])
+
+        with patch("src.everbot.channels.telegram_channel.HAS_TELEGRAMIFY", True), \
+             patch("src.everbot.channels.telegram_channel.tg_md_convert", fake_convert, create=True):
+            TelegramChannel._convert_markdown(text)
+
+        assert captured[0] == text, "Non-table text must pass through unmodified"
+
+    def test_fallback_when_no_telegramify(self):
+        """When telegramify is absent, heading markers are stripped (existing fallback)."""
+        text = "# Heading\n\nSome text."
+        with patch("src.everbot.channels.telegram_channel.HAS_TELEGRAMIFY", False):
+            plain, entities = TelegramChannel._convert_markdown(text)
+        assert "# " not in plain
+        assert "Heading" in plain
+        assert entities is None


### PR DESCRIPTION
Proposed fix for #66 (no test suite detected).

## 本次改动

107 个测试全部通过。

[Phase 4] 状态: ✅

---

## 修复总结

- **根因**: `_convert_markdown`（`telegram_channel.py:891`）在 `tg_md_convert` 产出 entity 后立刻 `return`，将 `_normalize_tables` 死锁在「无 entity 兜底」分支，导致含加粗/链接的消息完全绕过表格归一化
- **测试覆盖缺口**: 无任何 `_convert_markdown` 单元测试，特别缺少「有 entity + `+---+` 分隔表格」联合场景
- **修复方案**: 将表格归一化移到 `tg_md_convert` 调用**之前**无条件执行（检测到 `+`/`---` 即先归一化再转换），同时删去原先的双次调用逻辑，简化为单路径
- **新增测试**: 4 个（`TestConvertMarkdown`）
  - `test_table_normalised_before_convert_when_entities_present` — 直接复现 #66 核心 bug
  - `test_table_normalised_when_no_entities` — 覆盖原有无 entity 场景
  - `test_plain_text_without_table_unchanged` — 无表格文本不被篡改
  - `test_fallback_when_no_telegramify` — telegramify 缺失时 fallback 路径
- **回归结果**: 全部 107 个测试通过 ✅

Closes #66

<details><summary>diff</summary>

```diff
diff --git a/src/everbot/channels/telegram_channel.py b/src/everbot/channels/telegram_channel.py
index 678facc..5e4fe52 100644
--- a/src/everbot/channels/telegram_channel.py
+++ b/src/everbot/channels/telegram_channel.py
@@ -886,18 +886,15 @@ class TelegramChannel:
         """
         if HAS_TELEGRAMIFY:
             try:
-                plain, entities = tg_md_convert(text)
-                entity_dicts = [e.to_dict() for e in entities]
-                if entity_dicts:
-                    return plain, entity_dicts
-                # No entities produced — try normalising tables first
+                # Normalise +---+ style tables unconditionally before conversion.
+                # Must happen first: messages with bold/link entities would otherwise
+                # return early and never reach table normalisation (issue #66).
                 if "+" in text and "---" in text:
                     normalised = TelegramChannel._normalize_tables(text)
                     if normalised != text:
-                        plain2, entities2 = tg_md_convert(normalised)
-                        entity_dicts2 = [e.to_dict() for e in entities2]
-                        if entity_dicts2:
-                            return plain2, entity_dicts2
+                        text = normalised
+                plain, entities = tg_md_convert(text)
+                entity_dicts = [e.to_dict() for e in entities]
                 return plain, entity_dicts
             except Exception as exc:
                 logger.warning("telegramify_markdown conversion failed: %s", exc)
diff --git a/tests/unit/test_telegram_channel.py b/tests/unit/test_telegram_channel.py
index 9f6d132..88d9753 100644
--- a/tests/unit/test_telegram_channel.py
+++ b/tests/unit/test_telegram_channel.py
@@ -1498,3 +1498,111 @@ async def test_maybe_attach_projection_creates_handle_when_not_cached(tmp_path):
     ch._session_manager.cache_agent.assert_called_once()
     attach.assert_awaited_once()
     assert attach.call_args.args[0] is created
+
+
+# ===========================================================================
+# 16. _convert_markdown — table normalisation gate (issue #66)
+# ===========================================================================
+
+class TestConvertMarkdown:
+    """_convert_markdown must normalise +---+ tables unconditionally, even when
+    the message also has entity-producing spans (bold headings, ticker links).
+
+    Old bug: normalisation was gated behind ``if not entity_dicts``, so any
+    message with bold/link entities skipped table conversion entirely.
+    """
+
+    # Reusable fixture: message with bold heading AND a +--- style table
+    _MIXED_TEXT = (
+        "**投资信号汇总**\n\n"
+        "标的        | 信号    | 强度\n"
+        "------------+--------+------\n"
+        "$SIVE       | 买入    | 强\n"
+        "$XFAB       | 观望    | 中\n"
+    )
+
+    @staticmethod
+    def _fake_entity():
+        """Minimal entity stub returned by the mocked tg_md_convert."""
+        class _E:
+            def to_dict(self):
+                return {"type": "bold", "offset": 0, "length": 8}
+        return _E()
+
+    def test_table_normalised_before_convert_when_entities_present(self):
+        """tg_md_convert must receive normalised text (no ---+--- separator)
+        even when it would produce entities (bold heading).  This is the
+        direct regression test for the issue #66 gate bug."""
+        import src.everbot.channels.telegram_channel as ch_mod
+
+        captured = []
+
+        def fake_convert(t):
+            captured.append(t)
+            # Simulate a convert that produces an entity (bold heading)
+            return (t, [self._fake_entity()])
+
+        with patch("src.everbot.channels.telegram_channel.HAS_TELEGRAMIFY", True), \
+             patch("src.everbot.channels.telegram_channel.tg_md_convert", fake_convert, create=True):
+            plain, entities = TelegramChannel._convert_markdown(self._MIXED_TEXT)
+
+        assert captured, "tg_md_convert was never called"
+        received = captured[0]
+
+        # The separator line must be normalised — no raw +---+ form
+        assert "---+---" not in received, (
+            f"Table was NOT normalised before tg_md_convert.\nGot:\n{received}"
+        )
+        assert "----+--------+------" not in received, (
+            f"Original +---+ separator still present.\nGot:\n{received}"
+        )
+        # Standard MD separator should be present after normalisation
+        assert "| --- |" in received, (
+            f"Expected normalised '| --- |' separator.\nGot:\n{received}"
+        )
+
+        # Entities should still pass through unchanged
+        assert entities is not None
+        assert len(entities) == 1
+        assert entities[0]["type"] == "bold"
+
+    def test_table_normalised_when_no_entities(self):
+        """Existing behaviour: table is also normalised when convert produces no entities."""
+        captured = []
+
+        def fake_convert(t):
+            captured.append(t)
+            return (t, [])  # no entities
+
+        with patch("src.everbot.channels.telegram_channel.HAS_TELEGRAMIFY", True), \
+             patch("src.everbot.channels.telegram_channel.tg_md_convert", fake_convert, create=True):
+            plain, entities = TelegramChannel._convert_markdown(self._MIXED_TEXT)
+
+        assert captured
+        received = captured[0]
+        assert "| --- |" in received
+        assert "----+--------+------" not in received
+
+    def test_plain_text_without_table_unchanged(self):
+        """Text without +---+ markers must not be modified before conversion."""
+        text = "**Hello** world\n\nSome *italic* text."
+        captured = []
+
+        def fake_convert(t):
+            captured.append(t)
+            return (t, [self._fake_entity()])
+
+        with patch("src.everbot.channels.telegram_channel.HAS_TELEGRAMIFY", True), \
+             patch("src.everbot.channels.telegram_channel.tg_md_convert", fake_convert, create=True):
+            TelegramChannel._convert_markdown(text)
+
+        assert captured[0] == text, "Non-table text must pass through unmodified"
+
+    def test_fallback_when_no_telegramify(self):
+        """When telegramify is absent, heading markers are stripped (existing fallback)."""
+        text = "# Heading\n\nSome text."
+        with patch("src.everbot.channels.telegram_channel.HAS_TELEGRAMIFY", False):
+            plain, entities = TelegramChannel._convert_markdown(text)
+        assert "# " not in plain
+        assert "Heading" in plain
+        assert entities is None
```
</details>

— monastery (draft; review and merge if good).