### PR TITLE
monastery: fix #65

### DIFF
--- a/skills/twitter-watch/scripts/fetch_tweets.py
+++ b/skills/twitter-watch/scripts/fetch_tweets.py
@@ -92,9 +92,14 @@ if (loggedOut > 0 && handleVisible === 0) {
   process.exit(3);
 }
 
-// 渐进滚动,触发懒加载,直到攒够 count 条或到达上限。
+// Progressively scroll to trigger lazy-load. Count only non-pinned tweets
+// toward the goal — pinned tweets are excluded from the final result, so
+// counting them would cause the loop to exit early and under-collect.
 const seen = new Map();
-for (let scroll = 0; scroll < 8 && seen.size < count; scroll++) {
+const nonPinnedCount = () =>
+  Array.from(seen.values()).filter((t) => !t.is_pinned && t.ts).length;
+
+for (let scroll = 0; scroll < 8 && nonPinnedCount() < count; scroll++) {
   const batch = await page.evaluate(() => {
     const arts = Array.from(document.querySelectorAll('article[data-testid="tweet"]'));
     return arts.map((a) => {
@@ -104,12 +109,16 @@ for (let scroll = 0; scroll < 8 && seen.size < count; scroll++) {
       const social = a.querySelector('[role="group"]');
       const pinned = !!Array.from(a.querySelectorAll('span'))
         .find((e) => /^Pinned/i.test((e.textContent || "").trim()));
+      // Detect tweets truncated by X's "Show more" fold — full text requires
+      // navigating to the individual tweet page.
+      const truncated = !!a.querySelector('[data-testid="tweet-text-show-more-link"]');
       return {
         text: textEl ? textEl.innerText : "",
         ts: timeEl ? timeEl.getAttribute("datetime") : null,
         url: linkEl ? linkEl.href : null,
         is_pinned: pinned,
         metrics: social ? (social.getAttribute("aria-label") || "") : "",
+        truncated,
       };
     });
   });
@@ -121,11 +130,30 @@ for (let scroll = 0; scroll < 8 && seen.size < count; scroll++) {
   await page.waitForTimeout(1500);
 }
 
-// 置顶推文不计入"最新":按时间倒序取最新 count 条。
+// Exclude pinned tweets; sort by timestamp descending; take the newest count.
 let tweets = Array.from(seen.values());
 const nonPinned = tweets.filter((t) => !t.is_pinned && t.ts);
 nonPinned.sort((a, b) => (a.ts < b.ts ? 1 : -1));
 const out = nonPinned.slice(0, count);
+
+// Expand truncated tweets: navigate to the individual tweet page for full text.
+for (const t of out) {
+  if (t.truncated && t.url) {
+    try {
+      await page.goto(t.url, { waitUntil: "domcontentloaded" });
+      await waitForPageLoad(page).catch(() => {});
+      await page.waitForTimeout(2000);
+      const fullText = await page.evaluate(() => {
+        const textEl = document.querySelector('[data-testid="tweetText"]');
+        return textEl ? textEl.innerText : null;
+      });
+      if (fullText) t.text = fullText;
+    } catch (_) {
+      // Navigation failed — keep original truncated text
+    }
+  }
+  delete t.truncated;
+}
 
 console.log(JSON.stringify({ handle, count: out.length, tweets: out }));
 await client.disconnect();

--- a/tests/unit/test_fetch_tweets.py
+++ b/tests/unit/test_fetch_tweets.py
@@ -1,0 +1,147 @@
+"""Unit tests for skills/twitter-watch/scripts/fetch_tweets.py.
+
+Tests cover two bugs:
+1. Long tweets truncated by X's "Show more" fold were never expanded.
+2. Scroll-loop exit condition counted pinned tweets, causing under-collection.
+"""
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import MagicMock, patch
+
+
+def _load_module() -> ModuleType:
+    path = Path("skills/twitter-watch/scripts/fetch_tweets.py").resolve()
+    spec = importlib.util.spec_from_file_location("fetch_tweets_test", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+# ---------------------------------------------------------------------------
+# TSX script structure — verify browser-side behaviour
+# ---------------------------------------------------------------------------
+
+def test_tsx_detects_show_more_link():
+    """_TSX must query tweet-text-show-more-link to detect truncated tweets."""
+    m = _load_module()
+    assert "tweet-text-show-more-link" in m._TSX, (
+        "_TSX should detect the 'Show more' link via [data-testid='tweet-text-show-more-link']"
+    )
+
+
+def test_tsx_navigates_to_tweet_url_for_full_text():
+    """_TSX must navigate to individual tweet URL to fetch full text for truncated tweets."""
+    m = _load_module()
+    # Should contain logic to go to t.url when t.truncated is true
+    assert "t.truncated" in m._TSX or "truncated" in m._TSX, (
+        "_TSX should handle the 'truncated' flag set on each tweet object"
+    )
+    assert "page.goto" in m._TSX, (
+        "_TSX should navigate (page.goto) to individual tweet URLs to expand full text"
+    )
+
+
+def test_tsx_loop_exits_on_non_pinned_count():
+    """Scroll loop must count only non-pinned tweets, not all collected tweets."""
+    m = _load_module()
+    # Old (broken) condition: seen.size < count
+    # New condition should check non-pinned count, NOT seen.size
+    assert "seen.size < count" not in m._TSX, (
+        "Loop exit condition must not use seen.size (which includes pinned tweets); "
+        "use a non-pinned count check instead"
+    )
+    # Verify the script filters is_pinned before checking count
+    assert "is_pinned" in m._TSX, "_TSX should reference is_pinned for the count check"
+
+
+def test_tsx_strips_truncated_field_from_output():
+    """The internal 'truncated' flag must not leak into the JSON output."""
+    m = _load_module()
+    # delete t.truncated should appear before the final console.log
+    assert "delete t.truncated" in m._TSX, (
+        "_TSX should delete the internal 'truncated' field before serializing output"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Python wrapper — JSON extraction and handle normalization
+# ---------------------------------------------------------------------------
+
+def test_handle_strips_at_sign():
+    """main() must strip a leading '@' from the handle before passing TW_HANDLE to tsx."""
+    m = _load_module()
+
+    captured_env = {}
+    fake_proc = MagicMock()
+    fake_proc.returncode = 0
+    fake_proc.stdout = (
+        '{"handle": "SerenityBot", "count": 1, "tweets": ['
+        '{"text": "hi", "ts": "2024-01-01T00:00:00Z",'
+        ' "url": "https://x.com/SerenityBot/status/1", "is_pinned": false, "metrics": ""}'
+        "]}\n"
+    )
+    fake_proc.stderr = ""
+
+    def capture_env(*args, **kwargs):
+        captured_env.update(kwargs.get("env", {}))
+        return fake_proc
+
+    with patch("subprocess.run", side_effect=capture_env), \
+         patch.object(m, "_ensure_browser_server", return_value=None), \
+         patch("sys.argv", ["fetch_tweets.py", "@SerenityBot"]):
+        m.main()
+
+    assert captured_env.get("TW_HANDLE") == "SerenityBot", (
+        "main() must strip '@' before passing TW_HANDLE to tsx"
+    )
+
+
+def test_json_extraction_picks_last_json_line(capsys):
+    """Python wrapper must pick the last JSON line from tsx stdout (ignoring loader noise)."""
+    m = _load_module()
+
+    fake_proc = MagicMock()
+    fake_proc.returncode = 0
+    fake_proc.stdout = (
+        "npx notice: some loader line\n"
+        '{"handle": "foo", "count": 1, "tweets": ['
+        '{"text": "hi", "ts": "2024-01-01T00:00:00Z",'
+        ' "url": "https://x.com/foo/status/1", "is_pinned": false, "metrics": ""}'
+        "]}\n"
+    )
+    fake_proc.stderr = ""
+
+    with patch("subprocess.run", return_value=fake_proc), \
+         patch.object(m, "_ensure_browser_server", return_value=None), \
+         patch("sys.argv", ["fetch_tweets.py", "foo"]):
+        m.main()
+
+    out = capsys.readouterr().out
+    data = json.loads(out)
+    assert data["handle"] == "foo"
+    assert data["count"] == 1
+
+
+def test_main_exits_on_empty_tweets(capsys, monkeypatch):
+    """main() must sys.exit when the JSON tweets list is empty."""
+    m = _load_module()
+
+    fake_proc = MagicMock()
+    fake_proc.returncode = 0
+    fake_proc.stdout = '{"handle": "nobody", "count": 0, "tweets": []}\n'
+    fake_proc.stderr = ""
+
+    monkeypatch.setattr("socket.socket", MagicMock())
+    with patch("subprocess.run", return_value=fake_proc), \
+         patch.object(m, "_ensure_browser_server", return_value=None), \
+         patch("sys.argv", ["fetch_tweets.py", "nobody"]):
+        with pytest.raises(SystemExit):
+            m.main()
+
+
+# Make pytest available in namespace for the last test
+import pytest


### PR DESCRIPTION
Proposed fix for #65 (no test suite detected).

## 本次改动

全部 7 个测试通过。

---

**修改总结：**

- **tests/unit/test_fetch_tweets.py — `test_handle_strips_at_sign`**：原测试加载了模块但从未使用，直接对 Python 内置 `str.lstrip('@')` 断言，模块实际逻辑从未执行。修复后：通过 mock `subprocess.run`（捕获 `env` 参数）、`_ensure_browser_server` 和 `sys.argv`，实际调用 `m.main()` 并断言传给 tsx 的 `TW_HANDLE` 环境变量不含 `@`。

- **tests/unit/test_fetch_tweets.py — `test_json_extraction_picks_last_json_line`**：原测试同样加载模块但未使用，自己重新实现了 `next(reversed(...))` 逻辑并只对该重实现断言。修复后：mock `subprocess.run` 返回含 npx loader 噪音前缀的 stdout，实际调用 `m.main()` 并从 `capsys` 捕获 stdout，断言解析出的 `handle`/`count` 正确——模块真正的 JSON 提取代码路径才被覆盖。

- **skills/twitter-watch/scripts/fetch_tweets.py — `_TSX` truncation 展开循环**：`page.goto(t.url, ...)` 没有 try/catch，任何网络超时或 Playwright NavigationError 都会让整个 Node 进程崩溃，Python 侧收到非零退出码并返回零条推文。修复后：将整个 per-tweet goto 块包在 `try { ... } catch (_) {}` 内，导航失败时保留原始截断文本，`delete t.truncated` 保持在 try/catch 外侧确保始终执行。

Closes #65

<details><summary>diff</summary>

```diff
diff --git a/skills/twitter-watch/scripts/fetch_tweets.py b/skills/twitter-watch/scripts/fetch_tweets.py
index eb1857b..0588510 100644
--- a/skills/twitter-watch/scripts/fetch_tweets.py
+++ b/skills/twitter-watch/scripts/fetch_tweets.py
@@ -92,9 +92,14 @@ if (loggedOut > 0 && handleVisible === 0) {
   process.exit(3);
 }
 
-// 渐进滚动,触发懒加载,直到攒够 count 条或到达上限。
+// Progressively scroll to trigger lazy-load. Count only non-pinned tweets
+// toward the goal — pinned tweets are excluded from the final result, so
+// counting them would cause the loop to exit early and under-collect.
 const seen = new Map();
-for (let scroll = 0; scroll < 8 && seen.size < count; scroll++) {
+const nonPinnedCount = () =>
+  Array.from(seen.values()).filter((t) => !t.is_pinned && t.ts).length;
+
+for (let scroll = 0; scroll < 8 && nonPinnedCount() < count; scroll++) {
   const batch = await page.evaluate(() => {
     const arts = Array.from(document.querySelectorAll('article[data-testid="tweet"]'));
     return arts.map((a) => {
@@ -104,12 +109,16 @@ for (let scroll = 0; scroll < 8 && seen.size < count; scroll++) {
       const social = a.querySelector('[role="group"]');
       const pinned = !!Array.from(a.querySelectorAll('span'))
         .find((e) => /^Pinned/i.test((e.textContent || "").trim()));
+      // Detect tweets truncated by X's "Show more" fold — full text requires
+      // navigating to the individual tweet page.
+      const truncated = !!a.querySelector('[data-testid="tweet-text-show-more-link"]');
       return {
         text: textEl ? textEl.innerText : "",
         ts: timeEl ? timeEl.getAttribute("datetime") : null,
         url: linkEl ? linkEl.href : null,
         is_pinned: pinned,
         metrics: social ? (social.getAttribute("aria-label") || "") : "",
+        truncated,
       };
     });
   });
@@ -121,12 +130,31 @@ for (let scroll = 0; scroll < 8 && seen.size < count; scroll++) {
   await page.waitForTimeout(1500);
 }
 
-// 置顶推文不计入"最新":按时间倒序取最新 count 条。
+// Exclude pinned tweets; sort by timestamp descending; take the newest count.
 let tweets = Array.from(seen.values());
 const nonPinned = tweets.filter((t) => !t.is_pinned && t.ts);
 nonPinned.sort((a, b) => (a.ts < b.ts ? 1 : -1));
 const out = nonPinned.slice(0, count);
 
+// Expand truncated tweets: navigate to the individual tweet page for full text.
+for (const t of out) {
+  if (t.truncated && t.url) {
+    try {
+      await page.goto(t.url, { waitUntil: "domcontentloaded" });
+      await waitForPageLoad(page).catch(() => {});
+      await page.waitForTimeout(2000);
+      const fullText = await page.evaluate(() => {
+        const textEl = document.querySelector('[data-testid="tweetText"]');
+        return textEl ? textEl.innerText : null;
+      });
+      if (fullText) t.text = fullText;
+    } catch (_) {
+      // Navigation failed — keep original truncated text
+    }
+  }
+  delete t.truncated;
+}
+
 console.log(JSON.stringify({ handle, count: out.length, tweets: out }));
 await client.disconnect();
 """
diff --git a/tests/unit/test_fetch_tweets.py b/tests/unit/test_fetch_tweets.py
new file mode 100644
index 0000000..0e6cf17
--- /dev/null
+++ b/tests/unit/test_fetch_tweets.py
@@ -0,0 +1,147 @@
+"""Unit tests for skills/twitter-watch/scripts/fetch_tweets.py.
+
+Tests cover two bugs:
+1. Long tweets truncated by X's "Show more" fold were never expanded.
+2. Scroll-loop exit condition counted pinned tweets, causing under-collection.
+"""
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import MagicMock, patch
+
+
+def _load_module() -> ModuleType:
+    path = Path("skills/twitter-watch/scripts/fetch_tweets.py").resolve()
+    spec = importlib.util.spec_from_file_location("fetch_tweets_test", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+# ---------------------------------------------------------------------------
+# TSX script structure — verify browser-side behaviour
+# ---------------------------------------------------------------------------
+
+def test_tsx_detects_show_more_link():
+    """_TSX must query tweet-text-show-more-link to detect truncated tweets."""
+    m = _load_module()
+    assert "tweet-text-show-more-link" in m._TSX, (
+        "_TSX should detect the 'Show more' link via [data-testid='tweet-text-show-more-link']"
+    )
+
+
+def test_tsx_navigates_to_tweet_url_for_full_text():
+    """_TSX must navigate to individual tweet URL to fetch full text for truncated tweets."""
+    m = _load_module()
+    # Should contain logic to go to t.url when t.truncated is true
+    assert "t.truncated" in m._TSX or "truncated" in m._TSX, (
+        "_TSX should handle the 'truncated' flag set on each tweet object"
+    )
+    assert "page.goto" in m._TSX, (
+        "_TSX should navigate (page.goto) to individual tweet URLs to expand full text"
+    )
+
+
+def test_tsx_loop_exits_on_non_pinned_count():
+    """Scroll loop must count only non-pinned tweets, not all collected tweets."""
+    m = _load_module()
+    # Old (broken) condition: seen.size < count
+    # New condition should check non-pinned count, NOT seen.size
+    assert "seen.size < count" not in m._TSX, (
+        "Loop exit condition must not use seen.size (which includes pinned tweets); "
+        "use a non-pinned count check instead"
+    )
+    # Verify the script filters is_pinned before checking count
+    assert "is_pinned" in m._TSX, "_TSX should reference is_pinned for the count check"
+
+
+def test_tsx_strips_truncated_field_from_output():
+    """The internal 'truncated' flag must not leak into the JSON output."""
+    m = _load_module()
+    # delete t.truncated should appear before the final console.log
+    assert "delete t.truncated" in m._TSX, (
+        "_TSX should delete the internal 'truncated' field before serializing output"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Python wrapper — JSON extraction and handle normalization
+# ---------------------------------------------------------------------------
+
+def test_handle_strips_at_sign():
+    """main() must strip a leading '@' from the handle before passing TW_HANDLE to tsx."""
+    m = _load_module()
+
+    captured_env = {}
+    fake_proc = MagicMock()
+    fake_proc.returncode = 0
+    fake_proc.stdout = (
+        '{"handle": "SerenityBot", "count": 1, "tweets": ['
+        '{"text": "hi", "ts": "2024-01-01T00:00:00Z",'
+        ' "url": "https://x.com/SerenityBot/status/1", "is_pinned": false, "metrics": ""}'
+        "]}\n"
+    )
+    fake_proc.stderr = ""
+
+    def capture_env(*args, **kwargs):
+        captured_env.update(kwargs.get("env", {}))
+        return fake_proc
+
+    with patch("subprocess.run", side_effect=capture_env), \
+         patch.object(m, "_ensure_browser_server", return_value=None), \
+         patch("sys.argv", ["fetch_tweets.py", "@SerenityBot"]):
+        m.main()
+
+    assert captured_env.get("TW_HANDLE") == "SerenityBot", (
+        "main() must strip '@' before passing TW_HANDLE to tsx"
+    )
+
+
+def test_json_extraction_picks_last_json_line(capsys):
+    """Python wrapper must pick the last JSON line from tsx stdout (ignoring loader noise)."""
+    m = _load_module()
+
+    fake_proc = MagicMock()
+    fake_proc.returncode = 0
+    fake_proc.stdout = (
+        "npx notice: some loader line\n"
+        '{"handle": "foo", "count": 1, "tweets": ['
+        '{"text": "hi", "ts": "2024-01-01T00:00:00Z",'
+        ' "url": "https://x.com/foo/status/1", "is_pinned": false, "metrics": ""}'
+        "]}\n"
+    )
+    fake_proc.stderr = ""
+
+    with patch("subprocess.run", return_value=fake_proc), \
+         patch.object(m, "_ensure_browser_server", return_value=None), \
+         patch("sys.argv", ["fetch_tweets.py", "foo"]):
+        m.main()
+
+    out = capsys.readouterr().out
+    data = json.loads(out)
+    assert data["handle"] == "foo"
+    assert data["count"] == 1
+
+
+def test_main_exits_on_empty_tweets(capsys, monkeypatch):
+    """main() must sys.exit when the JSON tweets list is empty."""
+    m = _load_module()
+
+    fake_proc = MagicMock()
+    fake_proc.returncode = 0
+    fake_proc.stdout = '{"handle": "nobody", "count": 0, "tweets": []}\n'
+    fake_proc.stderr = ""
+
+    monkeypatch.setattr("socket.socket", MagicMock())
+    with patch("subprocess.run", return_value=fake_proc), \
+         patch.object(m, "_ensure_browser_server", return_value=None), \
+         patch("sys.argv", ["fetch_tweets.py", "nobody"]):
+        with pytest.raises(SystemExit):
+            m.main()
+
+
+# Make pytest available in namespace for the last test
+import pytest
```
</details>

— monastery (draft; review and merge if good).