### PR TITLE
fix(#59): skill LLM 超时可配且禁 SDK 内层重试 —— 最坏 182s 压回 120s;probe 假阴性修复

### DIFF
--- a/src/everbot/core/runtime/heartbeat.py
+++ b/src/everbot/core/runtime/heartbeat.py
@@ -1057,7 +1057,7 @@ If not, reply with `HEARTBEAT_OK`.
             client = self._create_skill_llm_client()
             await asyncio.wait_for(
                 client.complete("ping", max_tokens=1),
-                timeout=15,
+                timeout=_probe_timeout_s(),
             )
             return True
         except Exception as e:
@@ -1666,6 +1666,30 @@ def _resolve_skill_model_route(model_name: str):
 # Re-export for patching in tests; actual import deferred to complete().
 from openai import AsyncOpenAI
 
+# #59:skill LLM 超时默认 120s(原 60s 对 fast 档实际指向的深思模型偏紧,P90+ 单调用
+# 可达 60-112s);probe 默认 30s(原 15s 假阴性致心跳误判"LLM 不可用"暂停)。均 env 可配。
+_DEFAULT_SKILL_LLM_TIMEOUT_S = 120.0
+_DEFAULT_PROBE_TIMEOUT_S = 30.0
+
+
+def _env_float(name: str, default: float) -> float:
+    import os
+    raw = (os.environ.get(name) or "").strip()
+    if not raw:
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        return default
+
+
+def _skill_llm_timeout_s() -> float:
+    return _env_float("ALFRED_SKILL_LLM_TIMEOUT", _DEFAULT_SKILL_LLM_TIMEOUT_S)
+
+
+def _probe_timeout_s() -> float:
+    return _env_float("ALFRED_SKILL_LLM_PROBE_TIMEOUT", _DEFAULT_PROBE_TIMEOUT_S)
+
 
 class _SkillLLMClient:
     """Lightweight LLM client for reflection skills.
@@ -1703,7 +1727,10 @@ class _SkillLLMClient:
             base_url=base_url,
             api_key=route.api_key or "dummy",
             default_headers=route.headers or None,  # 透传 cloud headers(如 kimi User-Agent)
-            timeout=60.0,
+            timeout=_skill_llm_timeout_s(),
+            # #59:job 层已有 LLMTransientError→job_degraded→下轮重试语义,SDK 内层
+            # retry(默认 2 次)与之叠加是双重重试——单次卡死调用最坏被放大到 3×timeout。
+            max_retries=0,
         )
 
         call_kwargs = {

--- a/tests/unit/test_self_reflection.py
+++ b/tests/unit/test_self_reflection.py
@@ -867,3 +867,91 @@ class TestSkillLLMClient:
             await self._run_with_side_effect(openai.AuthenticationError(
                 message="invalid api key", response=MagicMock(status_code=401), body=None,
             ))
+
+
+# ── #59: _SkillLLMClient 超时/重试 与 _probe_llm 超时 ────────────
+
+
+class TestSkillLLMTimeouts:
+    """#59:60s 硬编码超时 × SDK 隐藏 retry(默认 max_retries=2)把单次慢调用最坏放大到
+    ~182s(实测 6/8 两次 job_degraded 182.0s/181.9s);probe 15s 对慢模型产生假阴性。
+    修复:max_retries=0(job 层已有 degraded→下轮重试语义,SDK 内层 retry 是双重重试)、
+    超时默认 120s 且 env 可配、probe 默认 30s 且 env 可配。"""
+
+    async def _capture_openai_kwargs(self, env=None):
+        import os
+        import unittest.mock as um
+        from src.everbot.core.runtime.heartbeat import _SkillLLMClient
+
+        fake_response = MagicMock()
+        fake_response.choices = [MagicMock()]
+        fake_response.choices[0].message.content = "ok"
+        env_patch = {"ALFRED_SKILL_LLM_TIMEOUT": "", "ALFRED_SKILL_LLM_PROBE_TIMEOUT": ""}
+        env_patch.update(env or {})
+        with um.patch.dict(os.environ, env_patch), \
+             um.patch(
+                 "src.everbot.core.runtime.heartbeat._resolve_skill_model_route",
+                 return_value=TestSkillLLMClient._route(model="test-model"),
+             ), um.patch(
+                 "src.everbot.core.runtime.heartbeat.AsyncOpenAI",
+             ) as mock_openai_cls:
+            mock_client = AsyncMock()
+            mock_client.chat.completions.create.return_value = fake_response
+            mock_openai_cls.return_value = mock_client
+            await _SkillLLMClient(model="test-model").complete("hello")
+        return mock_openai_cls.call_args[1]
+
+    @pytest.mark.asyncio
+    async def test_no_sdk_inner_retries(self):
+        kwargs = await self._capture_openai_kwargs()
+        assert kwargs.get("max_retries") == 0
+
+    @pytest.mark.asyncio
+    async def test_default_timeout_120s(self):
+        kwargs = await self._capture_openai_kwargs()
+        assert kwargs.get("timeout") == 120.0
+
+    @pytest.mark.asyncio
+    async def test_timeout_env_override(self):
+        kwargs = await self._capture_openai_kwargs(env={"ALFRED_SKILL_LLM_TIMEOUT": "45"})
+        assert kwargs.get("timeout") == 45.0
+
+    @pytest.mark.asyncio
+    async def test_timeout_env_invalid_falls_back_to_default(self):
+        kwargs = await self._capture_openai_kwargs(env={"ALFRED_SKILL_LLM_TIMEOUT": "abc"})
+        assert kwargs.get("timeout") == 120.0
+
+    def test_probe_timeout_default_and_env(self):
+        import os
+        import unittest.mock as um
+        from src.everbot.core.runtime.heartbeat import _probe_timeout_s
+
+        with um.patch.dict(os.environ, {"ALFRED_SKILL_LLM_PROBE_TIMEOUT": ""}):
+            assert _probe_timeout_s() == 30.0
+        with um.patch.dict(os.environ, {"ALFRED_SKILL_LLM_PROBE_TIMEOUT": "12.5"}):
+            assert _probe_timeout_s() == 12.5
+        with um.patch.dict(os.environ, {"ALFRED_SKILL_LLM_PROBE_TIMEOUT": "nope"}):
+            assert _probe_timeout_s() == 30.0
+
+    @pytest.mark.asyncio
+    async def test_probe_llm_honors_env_timeout(self):
+        """慢 complete(0.2s):probe 超时 0.05s → False;5s → True(假阴性来源即此)。"""
+        import asyncio
+        import os
+        import unittest.mock as um
+        from src.everbot.core.runtime.heartbeat import HeartbeatRunner
+
+        runner = HeartbeatRunner.__new__(HeartbeatRunner)
+        runner.agent_name = "test-agent"
+        stub = MagicMock()
+
+        async def slow_complete(*args, **kwargs):
+            await asyncio.sleep(0.2)
+            return "OK"
+
+        stub.complete = slow_complete
+        with um.patch.object(HeartbeatRunner, "_create_skill_llm_client", return_value=stub):
+            with um.patch.dict(os.environ, {"ALFRED_SKILL_LLM_PROBE_TIMEOUT": "0.05"}):
+                assert await runner._probe_llm() is False
+            with um.patch.dict(os.environ, {"ALFRED_SKILL_LLM_PROBE_TIMEOUT": "5"}):
+                assert await runner._probe_llm() is True


### PR DESCRIPTION
Closes #59。深度调研结论与方案变更见 issue 留档评论。

## 改动（heartbeat.py）

1. `_SkillLLMClient` 的 `AsyncOpenAI`：`timeout` 60s → 默认 **120s**（env `ALFRED_SKILL_LLM_TIMEOUT` 可配），并显式 **`max_retries=0`**——job 层已有 `LLMTransientError → job_degraded → 下轮重试`语义（cron.py:770），SDK 内层 retry（默认 2 次）与之叠加是双重重试，单次卡死调用最坏被放大到 3×60s≈182s（6/8 两次 job_degraded 182.0s/181.9s 实锤）。修后单调用最坏 120s，memory-review 双调用最坏 240s < 300s 任务预算。
2. `_probe_llm`：15s → 默认 **30s**（env `ALFRED_SKILL_LLM_PROBE_TIMEOUT` 可配）——原 15s 对 fast 档实际指向的深思模型（doubao-seed-2-0-pro）产生假阴性，致心跳误判"LLM 不可用"暂停（实测 probe 超时 2 秒后直连 200 OK）。

非法/空 env 值回退默认。

## 测试（TDD，先红后绿）

新增 6 个用例（`TestSkillLLMTimeouts`）：max_retries=0、默认 120s、env 覆盖、非法值回退、probe 默认/覆盖/非法值、probe 行为测试（慢 complete 0.2s：超时 0.05s→False，5s→True）。先全红（timeout=60.0、无 max_retries、`_probe_timeout_s` 不存在）后全绿。

回归：1804 passed；14 个存量失败与干净树完全一致（real-LLM/网络依赖类），零新增。

## 不在本 PR（已在 issue 留档）

- 原 issue 提案 2（两 LLM 调用并发）作废：compress 依赖 consolidation 落盘后的 entries，真串行。
- fast 档名实不符（指向深思模型）→ 另立跟进。
- 单测事件污染生产 `heartbeat_events.jsonl` 的隔离 bug → 另立跟进。

🤖 Generated with [Claude Code](https://claude.com/claude-code)