### PR TITLE
fix(#70): 测试全局隔离 ALFRED_HOME —— 杜绝单测直写生产 ~/.alfred

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,8 +3,26 @@
 import sys
 from pathlib import Path
 
+import pytest
+
 # Ensure project root is on sys.path so that `from src.everbot...` works
 # regardless of how pytest is invoked (run_tests.sh, bare pytest, CI, etc.).
 _project_root = str(Path(__file__).resolve().parent.parent)
 if _project_root not in sys.path:
     sys.path.insert(0, _project_root)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_alfred_home(tmp_path, monkeypatch):
+    """#70:把 ALFRED_HOME 隔离到 tmp_path 并重置 user_data 单例。
+
+    任何测例经全局 get_user_data_manager() 的写入(如 cron._write_event)都不得
+    落到真实 ~/.alfred —— 曾把数百条 test_agent 假事件写进生产
+    heartbeat_events.jsonl,且可触发真实日志轮转。守卫见 test_user_data_isolation.py。
+    """
+    from src.everbot.infra.user_data import reset_user_data_manager
+
+    monkeypatch.setenv("ALFRED_HOME", str(tmp_path / "alfred-home"))
+    reset_user_data_manager()
+    yield
+    reset_user_data_manager()

--- a/tests/integration/test_heartbeat_token_optimizations.py
+++ b/tests/integration/test_heartbeat_token_optimizations.py
@@ -402,19 +402,13 @@ class TestAgentCreationSkip:
         runner.session_manager.release_session = MagicMock()
         monkeypatch.setattr(runner, "_probe_llm", AsyncMock(return_value=True))
 
-        # Inspector.agent_factory creates a separate agent for reflection.
-        # Its continue_chat must return an async iterator, not a coroutine.
-        async def _fake_continue_chat(**kwargs):
-            # Yield a minimal LLM-style progress event with valid JSON
-            # so Inspector._run_llm can parse a reflection response.
-            yield {"_progress": [{"stage": "llm", "delta": '{"action": "none"}'}]}
-
-        reflect_agent = SimpleNamespace(continue_chat=_fake_continue_chat)
-
-        async def _fake_agent_factory(*args, **kwargs):
-            return reflect_agent
-
-        runner._inspector.agent_factory = _fake_agent_factory
+        # #38 后 Inspector 不再读 agent_factory(恒走 _run_llm → 真 provider/真 LLM),
+        # 原 agent_factory 假件是死接线 —— 此前一直依赖宿主机生产配置实打 LLM 而侥幸
+        # 通过,#70 隔离后暴露。直接桩 _run_llm,用例 hermetic。
+        monkeypatch.setattr(
+            runner._inspector, "_run_llm",
+            AsyncMock(return_value='{"action": "none"}'),
+        )
 
         await runner._execute_once()
         get_agent_mock.assert_awaited_once()

--- a/tests/unit/test_user_data_isolation.py
+++ b/tests/unit/test_user_data_isolation.py
@@ -1,0 +1,44 @@
+"""#70:守卫测试 —— 测试进程中的 user_data 单例必须与真实 ~/.alfred 隔离。
+
+历史教训:单测经 cron._write_event → 全局 get_user_data_manager() 直写生产
+~/.alfred/logs/heartbeat_events.jsonl(475+ 条 test_agent 假事件),并可触发
+真实日志轮转。隔离由 tests/conftest.py 的 autouse fixture 提供,本文件守卫其生效。
+"""
+from pathlib import Path
+
+
+def test_user_data_singleton_isolated_from_real_home():
+    from src.everbot.infra.user_data import get_user_data_manager
+    real_home = Path("~/.alfred").expanduser()
+    assert get_user_data_manager().alfred_home != real_home
+
+
+def test_heartbeat_events_file_not_under_real_home():
+    from src.everbot.infra.user_data import get_user_data_manager
+    real_home = Path("~/.alfred").expanduser()
+    events = get_user_data_manager().heartbeat_events_file
+    assert not str(events).startswith(str(real_home))
+
+
+def test_cron_write_event_lands_in_isolated_home(tmp_path):
+    """行为级守卫:CronExecutor._write_event 落盘隔离目录,而非真实 ~/.alfred。"""
+    import json
+    from src.everbot.infra.user_data import get_user_data_manager
+
+    from src.everbot.core.runtime.cron import CronExecutor
+
+    real_events = Path("~/.alfred/logs/heartbeat_events.jsonl").expanduser()
+    real_size_before = real_events.stat().st_size if real_events.exists() else 0
+
+    executor = CronExecutor.__new__(CronExecutor)
+    executor.agent_name = "isolation-probe"
+    executor._write_event("job_skipped", skill="isolation-probe-skill", reason="guard")
+
+    events_file = get_user_data_manager().heartbeat_events_file
+    assert events_file != real_events
+    assert events_file.exists()
+    lines = [json.loads(l) for l in events_file.read_text().splitlines()]
+    assert any(e.get("agent") == "isolation-probe" for e in lines)
+    # 生产日志在本测例期间必须零增长
+    real_size_after = real_events.stat().st_size if real_events.exists() else 0
+    assert real_size_after == real_size_before


### PR DESCRIPTION
Closes #70。

## 改动

1. **`tests/conftest.py` autouse fixture**:每测例把 `ALFRED_HOME` 指到 `tmp_path` 并前后重置 `user_data` 单例(复用既有 `reset_user_data_manager`)。一次性隔离全部 1800+ 测例,含子进程(env 继承)。
2. **守卫测试**(`test_user_data_isolation.py`,3 条):单例不指向真实 `~/.alfred`;`heartbeat_events_file` 不在真实 home 下;行为级——`CronExecutor._write_event` 落隔离目录且生产日志在测例期间零增长。
3. **修复隔离暴露的死接线**:`test_reflect_runs_after_file_change` 给 `Inspector.agent_factory` 装假件,但 #38 后该属性已废弃恒 None——实际每次运行都真拉 milkie sidecar + 真打 LLM(读宿主机生产配置才侥幸通过;隔离后退回默认 kimi-code 撞 402 会员校验暴露)。改桩 `_run_llm`,用例 hermetic,运行 9s→1s。

## TDD

守卫测试先红(单例指向真实 `~/.alfred`,且 RED 阶段的探针事件真实写入了生产日志——活体复现 bug 本身)后绿。

## 回归

全量 1807 passed,14 个失败与基线(干净树)完全一致,零新增。

## 运维清理(已执行,不在 diff 内)

生产 `heartbeat_events.jsonl` 已剔除 508 条假事件(`test_agent`/`isolation-probe`),32978 → 32470 行,备份 `*.bak-70`。

## 关联

- issue:#70(发现于 #59 深度调研)

🤖 Generated with [Claude Code](https://claude.com/claude-code)