### PR TITLE
fix(#71): 路由级 extra_body 透传 —— fast 档对 ark 关 thinking，消除深思模型的延迟方差与计费溢价

### DIFF
--- a/src/everbot/core/agent/provider/model_config.py
+++ b/src/everbot/core/agent/provider/model_config.py
@@ -54,10 +54,15 @@ class ModelRoute:
     api_key: str
     model: str
     headers: Dict[str, str] = None  # type: ignore[assignment]
+    # #71:随请求透传的 provider 私有参数(如 volcengine ark 的
+    # ``thinking: {type: disabled}``),cloud 级与 llm 级合并、llm 覆盖(同 headers)。
+    extra_body: Dict[str, Any] = None  # type: ignore[assignment]
 
     def __post_init__(self):
         if self.headers is None:
             self.headers = {}
+        if self.extra_body is None:
+            self.extra_body = {}
 
 
 @dataclass
@@ -83,11 +88,13 @@ class ModelConfig:
         cloud = self.clouds[llm["cloud"]]
         base = llm.get("api") or cloud["api"]
         headers = {**(cloud.get("headers") or {}), **(llm.get("headers") or {})}
+        extra_body = {**(cloud.get("extra_body") or {}), **(llm.get("extra_body") or {})}
         return ModelRoute(
             base_url=_expand(base).rstrip("/"),
             api_key=_expand(llm.get("api_key") or cloud.get("api_key", "")) or "",
             model=llm["model_name"],
             headers={k: _expand(v) for k, v in headers.items()},
+            extra_body=extra_body,
         )
 
 

--- a/src/everbot/core/runtime/heartbeat.py
+++ b/src/everbot/core/runtime/heartbeat.py
@@ -1737,6 +1737,9 @@ class _SkillLLMClient:
             "temperature": kwargs.get("temperature", 0.3),
             "max_tokens": kwargs.get("max_tokens", 8192),  # 恢复原 dolphin 默认上限(原 2000 会截断长输出)
         }
+        # #71:透传路由级 provider 私有参数(如 fast 档对 ark 关 thinking)。
+        if route.extra_body:
+            call_kwargs["extra_body"] = route.extra_body
         # Pass through DPH-extracted params accepted by the OpenAI API
         for k, v in kwargs.items():
             if k not in ("mode", "output_format", "system_prompt", "model"):

--- a/tests/unit/test_model_config.py
+++ b/tests/unit/test_model_config.py
@@ -100,3 +100,59 @@ def test_legacy_default_model_key_still_works(tmp_path):
                  "clouds:\n  c:\n    api: http://x\n    api_key: k\n", encoding="utf-8")
     mc = load_model_config(p)
     assert mc.default_model == "m" and mc.fast_model == "m"
+
+
+# ── #71: extra_body 解析与合并(fast 档关 thinking 的承载机制) ────
+
+
+_YAML_EXTRA = """
+default: deepseek-chat
+fast: doubao-nothink
+clouds:
+  volcengine:
+    api: https://ark.example.com/v3
+    api_key: sk-ark
+    extra_body:
+      cloud_flag: true
+      thinking:
+        type: enabled
+llms:
+  deepseek-chat:
+    cloud: volcengine
+    model_name: deepseek-chat
+  doubao-nothink:
+    cloud: volcengine
+    model_name: doubao-seed-2-0-pro
+    extra_body:
+      thinking:
+        type: disabled
+"""
+
+
+def _write_extra(tmp_path) -> Path:
+    p = tmp_path / "dolphin_extra.yaml"
+    p.write_text(_YAML_EXTRA, encoding="utf-8")
+    return p
+
+
+def test_route_extra_body_defaults_empty(tmp_path):
+    mc = load_model_config(_write(tmp_path))
+    r = mc.route_for("qwen-turbo")
+    assert r.extra_body == {}
+
+
+def test_route_parses_llm_extra_body(tmp_path):
+    mc = load_model_config(_write_extra(tmp_path))
+    r = mc.route_for("doubao-nothink")
+    assert r.extra_body["thinking"] == {"type": "disabled"}
+
+
+def test_route_merges_cloud_and_llm_extra_body_llm_wins(tmp_path):
+    mc = load_model_config(_write_extra(tmp_path))
+    r = mc.route_for("doubao-nothink")
+    # cloud 级键保留,llm 级同名键覆盖(同 headers 惯例)
+    assert r.extra_body["cloud_flag"] is True
+    assert r.extra_body["thinking"] == {"type": "disabled"}
+    # 未配 extra_body 的 llm 仅继承 cloud 级
+    r2 = mc.route_for("deepseek-chat")
+    assert r2.extra_body == {"cloud_flag": True, "thinking": {"type": "enabled"}}

--- a/tests/unit/test_self_reflection.py
+++ b/tests/unit/test_self_reflection.py
@@ -955,3 +955,50 @@ class TestSkillLLMTimeouts:
                 assert await runner._probe_llm() is False
             with um.patch.dict(os.environ, {"ALFRED_SKILL_LLM_PROBE_TIMEOUT": "5"}):
                 assert await runner._probe_llm() is True
+
+
+# ── #71: _SkillLLMClient 透传路由级 extra_body(关 thinking 的执行端) ──
+
+
+class TestSkillLLMExtraBody:
+    """#71:fast 档应急切到深思模型后,skill 任务承受 thinking 延迟方差与计费溢价。
+    路由层声明 extra_body(如 {thinking: {type: disabled}}),client 端透传给 create。"""
+
+    async def _create_call_kwargs(self, route):
+        import unittest.mock as um
+
+        from src.everbot.core.runtime.heartbeat import _SkillLLMClient
+
+        fake_response = MagicMock()
+        fake_response.choices = [MagicMock()]
+        fake_response.choices[0].message.content = "ok"
+        with um.patch(
+            "src.everbot.core.runtime.heartbeat._resolve_skill_model_route",
+            return_value=route,
+        ), um.patch(
+            "src.everbot.core.runtime.heartbeat.AsyncOpenAI",
+        ) as mock_openai_cls:
+            mock_client = AsyncMock()
+            mock_client.chat.completions.create.return_value = fake_response
+            mock_openai_cls.return_value = mock_client
+            await _SkillLLMClient(model="test-model").complete("hello")
+        return mock_client.chat.completions.create.call_args[1]
+
+    @pytest.mark.asyncio
+    async def test_route_extra_body_passed_through(self):
+        from src.everbot.core.agent.provider.model_config import ModelRoute
+
+        route = ModelRoute(
+            base_url="https://fake.example.com/v1", api_key="k", model="m",
+            extra_body={"thinking": {"type": "disabled"}},
+        )
+        kwargs = await self._create_call_kwargs(route)
+        assert kwargs.get("extra_body") == {"thinking": {"type": "disabled"}}
+
+    @pytest.mark.asyncio
+    async def test_empty_extra_body_not_sent(self):
+        from src.everbot.core.agent.provider.model_config import ModelRoute
+
+        route = ModelRoute(base_url="https://fake.example.com/v1", api_key="k", model="m")
+        kwargs = await self._create_call_kwargs(route)
+        assert "extra_body" not in kwargs


### PR DESCRIPTION
Closes #71。

## 改动

1. **`ModelRoute.extra_body`**（`model_config.py`）：cloud 级与 llm 级合并、llm 覆盖（同 `headers` 惯例），承载 provider 私有请求参数。
2. **`_SkillLLMClient` 透传**（`heartbeat.py`）：`route.extra_body` 非空时传给 `chat.completions.create`，空时不发该参数。
3. **配置**（`config/dolphin.yaml`，gitignored，本地已生效）：新增 `doubao-nothink` 条目（同 `doubao-seed-2-0-pro-260215` + `extra_body: {thinking: {type: disabled}}`），`fast:` 指向之。**不动既有 `deepseek-volcengine` 条目**，demo_agent 主对话的思考能力不受影响。

## TDD

5 个新用例先红后绿：extra_body 默认空、llm 级解析、cloud/llm 合并覆盖语义（`test_model_config.py`×3）；透传与空时不发（`test_self_reflection.py` `TestSkillLLMExtraBody`×2）。

## 活体验证（真实链路）

`load_model_config().fast_model` → `doubao-nothink`，`route.extra_body == {thinking: {type: disabled}}`；经 `_SkillLLMClient` 真打 ark："1+1=?" **2.1s** 返回（thinking 开时 4.0s、reasoning 占比 97.5%）。

## 回归

1809 passed，14 失败与基线一致（real-LLM/网络类存量），零新增。

## 关联

- issue：#71（发现于 #59 深度调研；#59 为容忍性修复，本 PR 消除源头）

🤖 Generated with [Claude Code](https://claude.com/claude-code)