### PR TITLE
chore(#74): 模型路由配置正名 models.yaml —— 偿还 dolphin.yaml 命名债

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ HEARTBEAT.md
 
 # Sensitive config (use example files as templates)
 config/dolphin.yaml
+config/dolphin.yaml.bak-74
+config/models.yaml
 .env.secrets
 
 # Node.js

--- a/src/everbot/cli/daemon.py
+++ b/src/everbot/cli/daemon.py
@@ -638,7 +638,7 @@ class EverBotDaemon:
                 import yaml as _yaml
                 with open(model_cfg_path, "r", encoding="utf-8") as f:
                     model_cfg = _yaml.safe_load(f) or {}
-                _walk(model_cfg, "dolphin.yaml")
+                _walk(model_cfg, "models.yaml")
             except Exception:
                 pass  # non-critical
 

--- a/src/everbot/cli/doctor.py
+++ b/src/everbot/cli/doctor.py
@@ -26,16 +26,22 @@ class DoctorItem:
     hint: Optional[str] = None
 
 
-def resolve_dolphin_config_path(user_data: UserDataManager, project_root: Path) -> Tuple[str, Optional[Path]]:
+def resolve_model_config_source(user_data: UserDataManager, project_root: Path) -> Tuple[str, Optional[Path]]:
     """
-    Resolve which Dolphin config file is effectively used.
+    Resolve which model-routing config file is effectively used.
+
+    #74:正名 models.yaml,同位置内旧名 dolphin.yaml 兜底(与
+    model_config.find_model_config_path 同语义)。
 
     Returns:
         (source_label, path or None)
     """
     candidates = [
+        ("alfred", user_data.models_config_path),
         ("alfred", user_data.dolphin_config_path),
+        ("project", (project_root / "config" / "models.yaml").resolve()),
         ("project", (project_root / "config" / "dolphin.yaml").resolve()),
+        ("cwd", Path("./config/models.yaml").resolve()),
         ("cwd", Path("./config/dolphin.yaml").resolve()),
     ]
 
@@ -54,17 +60,6 @@ def parse_yaml_file(path: Path) -> Dict[str, Any]:
     return data if isinstance(data, dict) else {}
 
 
-def dolphin_has_system_skillkit(config: Dict[str, Any]) -> bool:
-    """Check if system_skillkit is enabled in Dolphin config."""
-    tool = config.get("tool", {}) if isinstance(config.get("tool", {}), dict) else {}
-    skill = config.get("skill", {}) if isinstance(config.get("skill", {}), dict) else {}
-    enabled = tool.get("enabled_tools")
-    if enabled is None:
-        enabled = skill.get("enabled_skills", [])
-    if not isinstance(enabled, list):
-        return False
-    return any(str(x).strip() == "system_skillkit" for x in enabled)
-
 
 def detect_agent_dph_format(agent_dph_content: str) -> str:
     """Detect whether agent.dph looks like DPH or legacy YAML."""
@@ -76,15 +71,6 @@ def detect_agent_dph_format(agent_dph_content: str) -> str:
         return "legacy_yaml"
     return "unknown"
 
-
-def dph_declares_read_file_tool(agent_dph_content: str) -> bool:
-    """Heuristic: check if _read_file is declared in tools=[...] in DPH."""
-    raw = agent_dph_content or ""
-    m = re.search(r"tools\s*=\s*\[([^\]]*)\]", raw)
-    if not m:
-        return False
-    tools = m.group(1)
-    return "_read_file" in tools
 
 
 def collect_doctor_report(
@@ -126,43 +112,24 @@ def collect_doctor_report(
             )
         )
 
-    # Dolphin config
-    source, dolphin_path = resolve_dolphin_config_path(user_data, project_root)
-    if dolphin_path is None:
+    # Model routing config(#74:正名 models.yaml;skillkit 检查随死配置移除 ——
+    # tool.enabled_tools 自 #38 去 dolphin 后无 runtime 消费方,体检它只产噪音)
+    source, models_path = resolve_model_config_source(user_data, project_root)
+    if models_path is None:
         items.append(
             DoctorItem(
                 level="WARN",
-                title="Dolphin config",
-                details="No Dolphin YAML config found; using Dolphin defaults.",
-                hint=f"Create {user_data.dolphin_config_path} (copy from config/dolphin.yaml).",
-            )
-        )
-        dolphin_cfg: Dict[str, Any] = {}
-    else:
-        items.append(
-            DoctorItem(
-                level="OK",
-                title="Dolphin config",
-                details=f"Using {source} config: {dolphin_path}",
-            )
-        )
-        dolphin_cfg = parse_yaml_file(dolphin_path)
-
-    if dolphin_path is not None and not dolphin_has_system_skillkit(dolphin_cfg):
-        items.append(
-            DoctorItem(
-                level="WARN",
-                title="system_skillkit",
-                details="system_skillkit is not enabled in Dolphin config.",
-                hint='Add "system_skillkit" under tool.enabled_tools (or legacy skill.enabled_skills) in dolphin.yaml.',
+                title="Model routing config",
+                details="No model routing YAML found (models.yaml / legacy dolphin.yaml).",
+                hint=f"Create {user_data.models_config_path} (copy from config/models.yaml).",
             )
         )
     else:
         items.append(
             DoctorItem(
                 level="OK",
-                title="system_skillkit",
-                details="system_skillkit enabled (or Dolphin defaults assumed).",
+                title="Model routing config",
+                details=f"Using {source} config: {models_path}",
             )
         )
 
@@ -266,20 +233,10 @@ def collect_doctor_report(
                 )
             )
 
-        if dolphin_path is not None and dolphin_has_system_skillkit(dolphin_cfg):
-            if not dph_declares_read_file_tool(content):
-                items.append(
-                    DoctorItem(
-                        level="WARN",
-                        title=f"Agent {agent_name} tools",
-                        details="agent.dph does not declare _read_file in tools=[...].",
-                        hint="Add _read_file/_read_folder to tools list in agent.dph.",
-                    )
-                )
-
         # Basic env check for Aliyun model config
-        if dolphin_path is not None:
-            clouds = dolphin_cfg.get("clouds", {}) if isinstance(dolphin_cfg.get("clouds", {}), dict) else {}
+        if models_path is not None:
+            models_cfg = parse_yaml_file(models_path)
+            clouds = models_cfg.get("clouds", {}) if isinstance(models_cfg.get("clouds", {}), dict) else {}
             default_cloud = (clouds.get("default") if isinstance(clouds, dict) else None) or ""
             if str(default_cloud).strip() == "aliyun":
                 if not os.getenv("ALIYUN_API_KEY"):

--- a/src/everbot/core/agent/provider/__init__.py
+++ b/src/everbot/core/agent/provider/__init__.py
@@ -71,7 +71,7 @@ def oneshot_llm_provider() -> "AgentProvider":
     """Provider for stateless one-shot ``call_llm`` (memory extraction / history compression).
 
     ``call_llm`` is NOT agent-relative(单 prompt → 单回复)。改用 dolphin-free 的
-    :class:`OneshotLLMProvider`(直连 OpenAI 兼容端点,模型路由读 config/dolphin.yaml),
+    :class:`OneshotLLMProvider`(直连 OpenAI 兼容端点,模型路由读 config/models.yaml),
     去掉对 dolphin in-process LLMClient 的依赖(#38 去 dolphin)。
     """
     cached = _provider_by_name.get("oneshot")

--- a/src/everbot/core/agent/provider/milkie/provider.py
+++ b/src/everbot/core/agent/provider/milkie/provider.py
@@ -198,7 +198,7 @@ class MilkieProvider:
         self._system_prompt_loader = system_prompt_loader or _default_system_prompt_loader
 
     def _get_pool(self):
-        """惰性装配 pool:首次 create_agent 时才读 config + dolphin.yaml + factory。"""
+        """惰性装配 pool:首次 create_agent 时才读 config + models.yaml + factory。"""
         if self._pool is None:
             self._pool = self._build_pool()
         return self._pool
@@ -221,7 +221,7 @@ class MilkieProvider:
         data_dir_root = Path(milkie_cfg.get("data_dir_root") or "~/.alfred/milkie").expanduser()
         node_bin = milkie_cfg.get("node_bin") or "node"
 
-        # 模型路由读 config/dolphin.yaml(纯 YAML),经 model_config 定位 —— 不再经
+        # 模型路由读 config/models.yaml(纯 YAML),经 model_config 定位 —— 不再经
         # dolphin factory 的 global_config_path(去 dolphin 耦合,#38)。
         from ..model_config import load_model_config
         mc = load_model_config()

--- a/src/everbot/core/agent/provider/model_config.py
+++ b/src/everbot/core/agent/provider/model_config.py
@@ -54,10 +54,15 @@ class ModelRoute:
     api_key: str
     model: str
     headers: Dict[str, str] = None  # type: ignore[assignment]
+    # #71:随请求透传的 provider 私有参数(如 volcengine ark 的
+    # ``thinking: {type: disabled}``),cloud 级与 llm 级合并、llm 覆盖(同 headers)。
+    extra_body: Dict[str, Any] = None  # type: ignore[assignment]
 
     def __post_init__(self):
         if self.headers is None:
             self.headers = {}
+        if self.extra_body is None:
+            self.extra_body = {}
 
 
 @dataclass
@@ -83,11 +88,13 @@ class ModelConfig:
         cloud = self.clouds[llm["cloud"]]
         base = llm.get("api") or cloud["api"]
         headers = {**(cloud.get("headers") or {}), **(llm.get("headers") or {})}
+        extra_body = {**(cloud.get("extra_body") or {}), **(llm.get("extra_body") or {})}
         return ModelRoute(
             base_url=_expand(base).rstrip("/"),
             api_key=_expand(llm.get("api_key") or cloud.get("api_key", "")) or "",
             model=llm["model_name"],
             headers={k: _expand(v) for k, v in headers.items()},
+            extra_body=extra_body,
         )
 
 

--- a/src/everbot/core/agent/provider/model_config.py
+++ b/src/everbot/core/agent/provider/model_config.py
@@ -1,10 +1,10 @@
 """模型路由配置(dolphin-free)。
 
-从 ``config/dolphin.yaml``(纯 YAML,非 dolphin 代码)读取 llms/clouds + 默认/快速档。
+从 ``models.yaml``(#74 正名;legacy ``dolphin.yaml`` 兜底)读取 llms/clouds + 默认/快速档。
 此前 milkie pool 经 dolphin factory 的 ``global_config_path`` 取这份配置,导致 milkie
 仍耦合 dolphin;本模块用同样的查找顺序独立定位,去掉该耦合(#38 去 dolphin)。
 
-文件 schema(``config/dolphin.yaml``):
+文件 schema(``config/models.yaml``):
     default: <llm-name>        # 默认档(亦兼容旧键 default_model)
     fast:    <llm-name>        # 快速档(亦兼容旧键 fast_llm)
     clouds:  {name: {api, api_key}}
@@ -21,16 +21,31 @@ from typing import Any, Dict, Optional
 import yaml
 
 
-def find_model_config_path() -> Optional[Path]:
-    """定位模型配置 yaml(同 dolphin 的查找顺序,但不依赖 dolphin)。"""
-    candidates = [
-        Path("~/.alfred/dolphin.yaml").expanduser(),
-        Path("./config/dolphin.yaml").resolve(),
-        Path(__file__).resolve().parents[5] / "config" / "dolphin.yaml",  # repo config/
-    ]
-    for p in candidates:
-        if p.exists():
-            return p
+# #74:正名 models.yaml(dolphin 已于 #38 移除,旧名误导);同位置内新名优先、
+# 旧名兜底 —— 用户 home 级 dolphin.yaml 覆盖仍优先于 cwd/repo 的新名,改名不悄换生效配置。
+_CONFIG_NAMES = ("models.yaml", "dolphin.yaml")
+
+
+def find_model_config_path(
+    *,
+    home: Optional[Path] = None,
+    cwd_config: Optional[Path] = None,
+    repo_config: Optional[Path] = None,
+) -> Optional[Path]:
+    """定位模型配置 yaml。位置优先级:~/.alfred → ./config → repo config/。
+
+    kwargs 仅供测试注入;生产调用零参。
+    """
+    bases = (
+        home or Path("~/.alfred").expanduser(),
+        cwd_config or Path("./config").resolve(),
+        repo_config or Path(__file__).resolve().parents[5] / "config",  # repo config/
+    )
+    for base in bases:
+        for name in _CONFIG_NAMES:
+            p = base / name
+            if p.exists():
+                return p
     return None
 
 
@@ -106,7 +121,7 @@ def load_model_config(path: Optional[Path] = None) -> ModelConfig:
         raw = yaml.safe_load(p.read_text(encoding="utf-8")) or {}
     llms = raw.get("llms", {}) or {}
     clouds = raw.get("clouds", {}) or {}
-    # 兼容两套键:config/dolphin.yaml 用 default/fast;旧代码用 default_model/fast_llm。
+    # 兼容两套键:models.yaml 用 default/fast;旧代码用 default_model/fast_llm。
     default_model = raw.get("default_model") or raw.get("default") or next(iter(llms), "")
     fast_model = raw.get("fast_llm") or raw.get("fast") or default_model
     return ModelConfig(llms=llms, clouds=clouds, default_model=default_model, fast_model=fast_model)

--- a/src/everbot/core/agent/provider/oneshot_llm.py
+++ b/src/everbot/core/agent/provider/oneshot_llm.py
@@ -1,7 +1,7 @@
 """一次性无状态 LLM(dolphin-free)—— 记忆抽取 / 历史压缩用。
 
 ``call_llm`` 与 agent runtime 无关(单 prompt → 单回复),此前经 dolphin 的 LLMClient
-实现。本模块改为直连 OpenAI 兼容端点(httpx),模型路由读 ``config/dolphin.yaml``
+实现。本模块改为直连 OpenAI 兼容端点(httpx),模型路由读 ``config/models.yaml``
 (见 :mod:`model_config`),去掉对 dolphin 的依赖(#38)。
 
 ``raise_on_error`` 双语义保持与原 DolphinProvider.call_llm 一致:

--- a/src/everbot/core/runtime/cron.py
+++ b/src/everbot/core/runtime/cron.py
@@ -234,7 +234,7 @@ class CronExecutor:
     def _resolve_skill_model(self) -> str:
         """Resolve the model for skill LLM calls.
 
-        Uses the 'fast' model from Dolphin GlobalConfig — skill jobs
+        Uses the 'fast' model from models.yaml (model_config) — skill jobs
         (eval, reflection) are simple scoring tasks that don't need
         a reasoning model.  Falls back to agent model if 'fast' is unset.
         """

--- a/src/everbot/core/runtime/heartbeat.py
+++ b/src/everbot/core/runtime/heartbeat.py
@@ -1658,7 +1658,7 @@ If not, reply with `HEARTBEAT_OK`.
 
 
 def _resolve_skill_model_route(model_name: str):
-    """解析 skill LLM 的 {base_url, api_key, model}(dolphin-free,读 config/dolphin.yaml)。"""
+    """解析 skill LLM 的 {base_url, api_key, model}(dolphin-free,读 config/models.yaml)。"""
     from ..agent.provider.model_config import load_model_config
     return load_model_config().route_for(model_name)
 
@@ -1694,7 +1694,7 @@ def _probe_timeout_s() -> float:
 class _SkillLLMClient:
     """Lightweight LLM client for reflection skills.
 
-    Uses Dolphin GlobalConfig to resolve model endpoint/credentials,
+    Resolves model endpoint/credentials from models.yaml (model_config),
     then calls AsyncOpenAI directly.  No litellm dependency.
     """
 
@@ -1713,7 +1713,7 @@ class _SkillLLMClient:
             import os
             model = os.environ.get("ALFRED_SKILL_MODEL", "deepseek-chat")
 
-        # 解析模型 endpoint/凭证(dolphin-free,读 config/dolphin.yaml)
+        # 解析模型 endpoint/凭证(dolphin-free,读 config/models.yaml)
         route = _resolve_skill_model_route(model)
 
         base_url = route.base_url

--- a/src/everbot/core/runtime/heartbeat.py
+++ b/src/everbot/core/runtime/heartbeat.py
@@ -1737,6 +1737,9 @@ class _SkillLLMClient:
             "temperature": kwargs.get("temperature", 0.3),
             "max_tokens": kwargs.get("max_tokens", 8192),  # 恢复原 dolphin 默认上限(原 2000 会截断长输出)
         }
+        # #71:透传路由级 provider 私有参数(如 fast 档对 ark 关 thinking)。
+        if route.extra_body:
+            call_kwargs["extra_body"] = route.extra_body
         # Pass through DPH-extracted params accepted by the OpenAI API
         for k, v in kwargs.items():
             if k not in ("mode", "output_format", "system_prompt", "model"):

--- a/src/everbot/infra/user_data.py
+++ b/src/everbot/infra/user_data.py
@@ -37,8 +37,13 @@ class UserDataManager:
         return self.alfred_home / "config.yaml"
 
     @property
+    def models_config_path(self) -> Path:
+        """模型路由配置文件路径(#74 正名)"""
+        return self.alfred_home / "models.yaml"
+
+    @property
     def dolphin_config_path(self) -> Path:
-        """Dolphin 配置文件路径"""
+        """legacy 模型配置路径(#38 去 dolphin 后旧名残留,仅兜底查找用)"""
         return self.alfred_home / "dolphin.yaml"
 
     @property

--- a/tests/unit/test_doctor.py
+++ b/tests/unit/test_doctor.py
@@ -3,7 +3,7 @@
 from pathlib import Path
 import tempfile
 
-from src.everbot.cli.doctor import collect_doctor_report, dolphin_has_system_skillkit
+from src.everbot.cli.doctor import collect_doctor_report
 from src.everbot.infra.user_data import UserDataManager
 
 
@@ -19,15 +19,40 @@ def test_doctor_reports_missing_config_and_agents_dir():
         assert "WARN" in levels
 
 
-def test_dolphin_has_system_skillkit_supports_tool_enabled_tools():
-    """Doctor should recognize the renamed tool.enabled_tools config key."""
-    assert dolphin_has_system_skillkit(
-        {"tool": {"enabled_tools": ["system_skillkit", "resource_skillkit"]}}
-    )
+# #74:dolphin_has_system_skillkit 已随死配置 tool.enabled_tools 移除,
+# 原两条钉住该函数的用例一并撤销。
 
 
-def test_dolphin_has_system_skillkit_supports_legacy_skill_enabled_skills():
-    """Doctor should keep accepting the legacy skill.enabled_skills key."""
-    assert dolphin_has_system_skillkit(
-        {"skill": {"enabled_skills": ["system_skillkit"]}}
-    )
+# ── #74: doctor 同步改名(models.yaml 优先、dolphin.yaml 兜底、撤 skillkit 残留检查) ──
+
+
+def test_doctor_resolves_models_yaml_first(tmp_path):
+    from src.everbot.cli.doctor import resolve_model_config_source
+    home = tmp_path / ".alfred"
+    home.mkdir(parents=True)
+    (home / "models.yaml").write_text("default: x\n", encoding="utf-8")
+    (home / "dolphin.yaml").write_text("default: y\n", encoding="utf-8")
+    ud = UserDataManager(alfred_home=home)
+    label, path = resolve_model_config_source(ud, tmp_path)
+    assert label == "alfred"
+    assert path == home / "models.yaml"
+
+
+def test_doctor_legacy_dolphin_still_resolves(tmp_path):
+    from src.everbot.cli.doctor import resolve_model_config_source
+    home = tmp_path / ".alfred"
+    home.mkdir(parents=True)
+    proj_cfg = tmp_path / "config"
+    proj_cfg.mkdir(parents=True)
+    (proj_cfg / "dolphin.yaml").write_text("default: y\n", encoding="utf-8")
+    ud = UserDataManager(alfred_home=home)
+    label, path = resolve_model_config_source(ud, tmp_path)
+    assert label == "project"
+    assert path == proj_cfg / "dolphin.yaml"
+
+
+def test_doctor_report_drops_dead_skillkit_check(tmp_path):
+    """tool.enabled_tools 已无 runtime 消费方,doctor 不应再为它产报告项。"""
+    home = tmp_path / ".alfred"
+    items = collect_doctor_report(project_root=tmp_path, alfred_home=home)
+    assert not any("skillkit" in (i.title or "").lower() for i in items)

--- a/tests/unit/test_model_config.py
+++ b/tests/unit/test_model_config.py
@@ -156,3 +156,50 @@ def test_route_merges_cloud_and_llm_extra_body_llm_wins(tmp_path):
     # 未配 extra_body 的 llm 仅继承 cloud 级
     r2 = mc.route_for("deepseek-chat")
     assert r2.extra_body == {"cloud_flag": True, "thinking": {"type": "enabled"}}
+
+
+# ── #74: models.yaml 正名,dolphin.yaml legacy 兜底(同位置新名优先) ────
+
+
+from src.everbot.core.agent.provider.model_config import find_model_config_path
+
+
+def _mk_cfg(base: Path, name: str) -> Path:
+    base.mkdir(parents=True, exist_ok=True)
+    p = base / name
+    p.write_text("default: x\n", encoding="utf-8")
+    return p
+
+
+def test_find_prefers_models_over_dolphin_in_same_location(tmp_path):
+    home = tmp_path / "home"
+    models = _mk_cfg(home, "models.yaml")
+    _mk_cfg(home, "dolphin.yaml")
+    got = find_model_config_path(
+        home=home, cwd_config=tmp_path / "n1", repo_config=tmp_path / "n2")
+    assert got == models
+
+
+def test_find_legacy_home_dolphin_beats_lower_priority_models(tmp_path):
+    """用户 home 级旧名覆盖必须仍优先于 cwd/repo 的新名 —— 改名不得悄换生效配置。"""
+    home = tmp_path / "home"
+    cwdc = tmp_path / "cwdc"
+    legacy = _mk_cfg(home, "dolphin.yaml")
+    _mk_cfg(cwdc, "models.yaml")
+    got = find_model_config_path(home=home, cwd_config=cwdc, repo_config=tmp_path / "n")
+    assert got == legacy
+
+
+def test_find_falls_back_cwd_then_repo(tmp_path):
+    cwdc = tmp_path / "cwdc"
+    repoc = tmp_path / "repoc"
+    _mk_cfg(repoc, "models.yaml")
+    cwd_models = _mk_cfg(cwdc, "models.yaml")
+    got = find_model_config_path(home=tmp_path / "n", cwd_config=cwdc, repo_config=repoc)
+    assert got == cwd_models
+
+
+def test_find_returns_none_when_nothing_exists(tmp_path):
+    got = find_model_config_path(
+        home=tmp_path / "a", cwd_config=tmp_path / "b", repo_config=tmp_path / "c")
+    assert got is None

--- a/tests/unit/test_model_config.py
+++ b/tests/unit/test_model_config.py
@@ -100,3 +100,59 @@ def test_legacy_default_model_key_still_works(tmp_path):
                  "clouds:\n  c:\n    api: http://x\n    api_key: k\n", encoding="utf-8")
     mc = load_model_config(p)
     assert mc.default_model == "m" and mc.fast_model == "m"
+
+
+# ── #71: extra_body 解析与合并(fast 档关 thinking 的承载机制) ────
+
+
+_YAML_EXTRA = """
+default: deepseek-chat
+fast: doubao-nothink
+clouds:
+  volcengine:
+    api: https://ark.example.com/v3
+    api_key: sk-ark
+    extra_body:
+      cloud_flag: true
+      thinking:
+        type: enabled
+llms:
+  deepseek-chat:
+    cloud: volcengine
+    model_name: deepseek-chat
+  doubao-nothink:
+    cloud: volcengine
+    model_name: doubao-seed-2-0-pro
+    extra_body:
+      thinking:
+        type: disabled
+"""
+
+
+def _write_extra(tmp_path) -> Path:
+    p = tmp_path / "dolphin_extra.yaml"
+    p.write_text(_YAML_EXTRA, encoding="utf-8")
+    return p
+
+
+def test_route_extra_body_defaults_empty(tmp_path):
+    mc = load_model_config(_write(tmp_path))
+    r = mc.route_for("qwen-turbo")
+    assert r.extra_body == {}
+
+
+def test_route_parses_llm_extra_body(tmp_path):
+    mc = load_model_config(_write_extra(tmp_path))
+    r = mc.route_for("doubao-nothink")
+    assert r.extra_body["thinking"] == {"type": "disabled"}
+
+
+def test_route_merges_cloud_and_llm_extra_body_llm_wins(tmp_path):
+    mc = load_model_config(_write_extra(tmp_path))
+    r = mc.route_for("doubao-nothink")
+    # cloud 级键保留,llm 级同名键覆盖(同 headers 惯例)
+    assert r.extra_body["cloud_flag"] is True
+    assert r.extra_body["thinking"] == {"type": "disabled"}
+    # 未配 extra_body 的 llm 仅继承 cloud 级
+    r2 = mc.route_for("deepseek-chat")
+    assert r2.extra_body == {"cloud_flag": True, "thinking": {"type": "enabled"}}

--- a/tests/unit/test_self_reflection.py
+++ b/tests/unit/test_self_reflection.py
@@ -955,3 +955,50 @@ class TestSkillLLMTimeouts:
                 assert await runner._probe_llm() is False
             with um.patch.dict(os.environ, {"ALFRED_SKILL_LLM_PROBE_TIMEOUT": "5"}):
                 assert await runner._probe_llm() is True
+
+
+# ── #71: _SkillLLMClient 透传路由级 extra_body(关 thinking 的执行端) ──
+
+
+class TestSkillLLMExtraBody:
+    """#71:fast 档应急切到深思模型后,skill 任务承受 thinking 延迟方差与计费溢价。
+    路由层声明 extra_body(如 {thinking: {type: disabled}}),client 端透传给 create。"""
+
+    async def _create_call_kwargs(self, route):
+        import unittest.mock as um
+
+        from src.everbot.core.runtime.heartbeat import _SkillLLMClient
+
+        fake_response = MagicMock()
+        fake_response.choices = [MagicMock()]
+        fake_response.choices[0].message.content = "ok"
+        with um.patch(
+            "src.everbot.core.runtime.heartbeat._resolve_skill_model_route",
+            return_value=route,
+        ), um.patch(
+            "src.everbot.core.runtime.heartbeat.AsyncOpenAI",
+        ) as mock_openai_cls:
+            mock_client = AsyncMock()
+            mock_client.chat.completions.create.return_value = fake_response
+            mock_openai_cls.return_value = mock_client
+            await _SkillLLMClient(model="test-model").complete("hello")
+        return mock_client.chat.completions.create.call_args[1]
+
+    @pytest.mark.asyncio
+    async def test_route_extra_body_passed_through(self):
+        from src.everbot.core.agent.provider.model_config import ModelRoute
+
+        route = ModelRoute(
+            base_url="https://fake.example.com/v1", api_key="k", model="m",
+            extra_body={"thinking": {"type": "disabled"}},
+        )
+        kwargs = await self._create_call_kwargs(route)
+        assert kwargs.get("extra_body") == {"thinking": {"type": "disabled"}}
+
+    @pytest.mark.asyncio
+    async def test_empty_extra_body_not_sent(self):
+        from src.everbot.core.agent.provider.model_config import ModelRoute
+
+        route = ModelRoute(base_url="https://fake.example.com/v1", api_key="k", model="m")
+        kwargs = await self._create_call_kwargs(route)
+        assert "extra_body" not in kwargs


### PR DESCRIPTION
Closes #74。

## 改动

1. **`find_model_config_path`**（model_config.py）：候选改为按位置（`~/.alfred` → `./config` → repo `config/`）×按名（`models.yaml` 优先、`dolphin.yaml` 兜底）。**同位置内新名优先**的语义保证：用户 home 级旧名覆盖仍优先于 cwd/repo 的新名——改名不会悄换任何现有部署的生效配置。签名增测试注入 kwargs，生产调用零参不变。
2. **doctor**：`resolve_dolphin_config_path` → `resolve_model_config_source`（同语义双名查找）；撤掉 `dolphin_has_system_skillkit` 与 `_read_file` 工具声明两个残留检查——`tool.enabled_tools` 自 #38 去 dolphin 起无任何 runtime 消费方，体检它只产噪音；aliyun env 自检改读新解析路径。
3. **user_data**：增 `models_config_path`；`dolphin_config_path` 保留并标注 legacy（兜底查找用）。
4. **注释/标签同步**：heartbeat / cron / provider(oneshot、milkie) / daemon 中 8 处 "dolphin.yaml" 文案更新；daemon 的 env 占位符自检标签同步。
5. **本地配置**（gitignored，不在 diff）：`config/dolphin.yaml` → `config/models.yaml`，仅迁移活跃四段（`default/fast/clouds/llms`），死段（`context_engineer/memory/tool/resource_tools`）不迁移；旧文件备份 `.bak-74`；`.gitignore` 增两行。

## TDD

7 个新用例先红后绿：同位置新名优先、home 级旧名覆盖优先于低优先级新名、cwd→repo 兜底、全无返回 None（`test_model_config.py`×4）；doctor 双名解析×2 + 报告不再含 skillkit 项（`test_doctor.py`×3）。钉住已删函数的 2 条旧用例随函数撤销。

## 验证

- 全量回归 1814 passed，14 失败与基线一致，零新增。
- `bin/everbot doctor` 活体：`Model routing config: Using project config: .../config/models.yaml`，无 skillkit 项。
- 路由活体：`find_model_config_path()` → `models.yaml`，fast 档 `doubao-nothink` + `thinking disabled`（#71 行为无回归）。

## 关联

- issue：#74（源头 #38 最小迁移遗留；触发讨论 #71）

🤖 Generated with [Claude Code](https://claude.com/claude-code)