### PR TITLE
fix: Telegram 心跳消息超长切分后丢失 markdown entities 格式

### DIFF
--- a/src/everbot/channels/telegram_channel.py
+++ b/src/everbot/channels/telegram_channel.py
@@ -293,15 +293,12 @@ class TelegramChannel:
                 continue
             if target_chat and str(chat_id) != target_chat:
                 continue
-            # Split long heartbeat messages instead of truncating
-            parts = self._split_message(text)
-            if len(parts) <= 1:
-                sent = await self._send_message(chat_id, text, entities)
-            else:
-                sent = True
-                for part in parts:
-                    if not await self._send_message(chat_id, part):
-                        sent = False
+            # Split long heartbeat messages instead of truncating; entities
+            # are sliced per part so formatting survives the split (#76).
+            ok_count, total = await self._send_split_with_entities(
+                chat_id, text, entities,
+            )
+            sent = total > 0 and ok_count == total
             # Deposit heartbeat result into channel session mailbox so the
             # next user turn sees it via "## Background Updates" prefix.
             # This replaces the old inject_history_message approach which
@@ -794,30 +791,10 @@ class TelegramChannel:
 
         # Fallback: batch send (original behavior)
         converted_text, converted_entities = self._convert_markdown(full_reply)
-        sent_any = False
-        parts = self._split_message(converted_text)
-        if len(parts) <= 1:
-            for part in parts:
-                success = await self._send_message(chat_id, part, converted_entities)
-                if success:
-                    sent_any = True
-        else:
-            search_from = 0
-            for part in parts:
-                part_start = converted_text.find(part, search_from)
-                if part_start < 0:
-                    part_start = search_from
-                utf16_offset = self._utf16_len(converted_text[:part_start])
-                utf16_length = self._utf16_len(part)
-                part_entities = self._slice_entities(
-                    converted_entities, utf16_offset, utf16_length,
-                )
-                success = await self._send_message(
-                    chat_id, part, part_entities or None,
-                )
-                if success:
-                    sent_any = True
-                search_from = part_start + len(part)
+        ok_count, _total = await self._send_split_with_entities(
+            chat_id, converted_text, converted_entities,
+        )
+        sent_any = ok_count > 0
 
         if not sent_any:
             fallback = full_reply[:200]
@@ -946,6 +923,37 @@ class TelegramChannel:
             sliced["length"] = new_length
             result.append(sliced)
         return result
+
+    async def _send_split_with_entities(
+        self, chat_id: str, text: str, entities: Optional[list],
+    ) -> tuple:
+        """Send *text* in Telegram-size parts, slicing *entities* per part.
+
+        Entity offsets are re-based to each part in UTF-16 code units (the
+        Telegram API convention), so formatting survives the split (#76).
+        Returns ``(ok_count, total_parts)``; ``(0, 0)`` for empty text.
+        """
+        parts = self._split_message(text)
+        if not parts:
+            return 0, 0
+        if len(parts) == 1:
+            ok = await self._send_message(chat_id, text, entities)
+            return (1 if ok else 0), 1
+        ok_count = 0
+        search_from = 0
+        for part in parts:
+            part_start = text.find(part, search_from)
+            if part_start < 0:
+                part_start = search_from
+            part_entities = self._slice_entities(
+                entities,
+                self._utf16_len(text[:part_start]),
+                self._utf16_len(part),
+            )
+            if await self._send_message(chat_id, part, part_entities or None):
+                ok_count += 1
+            search_from = part_start + len(part)
+        return ok_count, len(parts)
 
     # ------------------------------------------------------------------
     # Telegram Skillkit registration

--- a/tests/unit/test_telegram_channel.py
+++ b/tests/unit/test_telegram_channel.py
@@ -142,6 +142,89 @@ class TestSplitMessage:
 
 
 # ===========================================================================
+# 1b. _send_split_with_entities — split + per-part entity slicing (#76)
+# ===========================================================================
+
+class TestSendSplitWithEntities:
+    @pytest.fixture
+    def channel(self, tmp_path):
+        ch = _make_channel(tmp_path)
+        ch._send_message = AsyncMock(return_value=True)
+        return ch
+
+    @pytest.mark.asyncio
+    async def test_single_part_keeps_entities(self, channel):
+        entities = [{"type": "bold", "offset": 0, "length": 5}]
+        ok, total = await channel._send_split_with_entities("111", "hello world", entities)
+        assert (ok, total) == (1, 1)
+        channel._send_message.assert_awaited_once_with("111", "hello world", entities)
+
+    @pytest.mark.asyncio
+    async def test_empty_text_sends_nothing(self, channel):
+        ok, total = await channel._send_split_with_entities("111", "", None)
+        assert (ok, total) == (0, 0)
+        channel._send_message.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_multipart_slices_entities_per_part(self, channel):
+        p1, p2 = "a" * 3000, "b" * 3000
+        text = f"{p1}\n\n{p2}"
+        # Bold over the first 10 chars of paragraph 2 (offset 3002 in full text)
+        entities = [{"type": "bold", "offset": 3002, "length": 10}]
+
+        ok, total = await channel._send_split_with_entities("111", text, entities)
+
+        assert (ok, total) == (2, 2)
+        calls = channel._send_message.call_args_list
+        assert calls[0].args[1] == p1
+        assert calls[0].args[2] is None  # no entity falls in part 1
+        assert calls[1].args[1] == p2
+        assert calls[1].args[2] == [{"type": "bold", "offset": 0, "length": 10}]
+
+    @pytest.mark.asyncio
+    async def test_entity_spanning_boundary_clamped_into_both_parts(self, channel):
+        p1, p2 = "a" * 3000, "b" * 3000
+        text = f"{p1}\n\n{p2}"
+        # Bold spanning the split point: last 10 a's + "\n\n" + first 8 b's
+        entities = [{"type": "bold", "offset": 2990, "length": 20}]
+
+        await channel._send_split_with_entities("111", text, entities)
+
+        calls = channel._send_message.call_args_list
+        assert calls[0].args[2] == [{"type": "bold", "offset": 2990, "length": 10}]
+        assert calls[1].args[2] == [{"type": "bold", "offset": 0, "length": 8}]
+
+    @pytest.mark.asyncio
+    async def test_emoji_offsets_counted_in_utf16(self, channel):
+        # 📌 is one Python char but two UTF-16 code units; Telegram counts UTF-16.
+        p1, p2 = "a" * 3000, "📌" + "b" * 3000
+        text = f"{p1}\n\n{p2}"
+        # Bold over the first 10 b's: UTF-16 offset = 3002 (prefix) + 2 (emoji)
+        entities = [{"type": "bold", "offset": 3004, "length": 10}]
+
+        await channel._send_split_with_entities("111", text, entities)
+
+        calls = channel._send_message.call_args_list
+        assert calls[1].args[1] == p2
+        assert calls[1].args[2] == [{"type": "bold", "offset": 2, "length": 10}]
+
+    @pytest.mark.asyncio
+    async def test_no_entities_multipart_sends_plain(self, channel):
+        text = "a" * 3000 + "\n\n" + "b" * 3000
+        ok, total = await channel._send_split_with_entities("111", text, None)
+        assert (ok, total) == (2, 2)
+        for call in channel._send_message.call_args_list:
+            assert call.args[2] is None
+
+    @pytest.mark.asyncio
+    async def test_part_failure_reflected_in_counts(self, channel):
+        channel._send_message = AsyncMock(side_effect=[True, False])
+        text = "a" * 3000 + "\n\n" + "b" * 3000
+        ok, total = await channel._send_split_with_entities("111", text, None)
+        assert (ok, total) == (1, 2)
+
+
+# ===========================================================================
 # 2. Command handling
 # ===========================================================================
 
@@ -281,6 +364,50 @@ class TestEventFiltering:
         })
 
         channel._send_message.assert_awaited_once()
+        channel._session_manager.deposit_mailbox_event.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_long_heartbeat_preserves_entities_per_part(self, channel):
+        """#76: heartbeat messages split over TELEGRAM_MSG_LIMIT must carry
+        re-offset entities on every part instead of dropping all formatting."""
+        p1, p2 = "a" * 3000, "b" * 3000
+        converted = f"{p1}\n\n{p2}"
+        entities = [{"type": "bold", "offset": 3002, "length": 10}]
+        channel._convert_markdown = lambda text: (converted, entities)
+
+        await channel._on_background_event("session_1", {
+            "source_type": "heartbeat_delivery",
+            "agent_name": "my_agent",
+            "detail": "long report",
+            "deliver": True,
+            "scope": "agent",
+        })
+
+        calls = channel._send_message.call_args_list
+        assert len(calls) == 2
+        assert calls[0].args[1] == p1
+        assert calls[1].args[1] == p2
+        assert calls[1].args[2] == [{"type": "bold", "offset": 0, "length": 10}]
+        # All parts delivered → mailbox mirror still happens
+        channel._session_manager.deposit_mailbox_event.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_multipart_partial_failure_skips_mailbox_mirror(self, channel):
+        """#76: if any split part fails to send, the heartbeat counts as
+        undelivered and must not be mirrored into the session mailbox."""
+        channel._send_message = AsyncMock(side_effect=[True, False])
+        converted = "a" * 3000 + "\n\n" + "b" * 3000
+        channel._convert_markdown = lambda text: (converted, None)
+
+        await channel._on_background_event("session_1", {
+            "source_type": "heartbeat_delivery",
+            "agent_name": "my_agent",
+            "detail": "long report",
+            "deliver": True,
+            "scope": "agent",
+        })
+
+        assert channel._send_message.await_count == 2
         channel._session_manager.deposit_mailbox_event.assert_not_awaited()
 
     @pytest.mark.asyncio


### PR DESCRIPTION
Closes #76

## 问题

`[Heartbeat]` 推送超过 `TELEGRAM_MSG_LIMIT = 4096` 被 `_split_message` 切分后，分片裸发 `_send_message(chat_id, part)` 没有携带 entities，导致超长巡检报告在 Telegram 中退化为纯文本（无加粗/代码块，表格折行成 ASCII 文本）。回复路径已有正确的「按 UTF-16 偏移切片 entities」逻辑，但心跳/通知路径没有复用。

## 修改

- 新增 `_send_split_with_entities(chat_id, text, entities) -> (ok_count, total)`：切分超长消息，对每个分片用 `_utf16_len` 换算 UTF-16 偏移、`_slice_entities` 重定位 entities 后发送。
- 心跳/通知路径与回复批量发送路径均改为复用该方法，删除重复逻辑：
  - 心跳路径：`ok_count == total` 才镜像进 channel session mailbox（保持 "delivery failed 即 skip mirror" 语义）；
  - 回复路径：`ok_count > 0` 即不触发 `[delivery error]` 兜底（保持原 `sent_any` 语义）。

## 测试

TDD 推进（先写失败测试再实现），新增 9 个用例：

- `TestSendSplitWithEntities`（7 个）：单片保留 entities、空文本、多分片 entity 重定位、entity 跨切分边界 clamp、emoji（UTF-16 代理对）偏移、entities=None 降级、分片失败计数；
- `TestEventFiltering`（2 个）：超长心跳每个分片携带重定位 entities 且全部送达后仍镜像 mailbox、部分分片失败跳过 mailbox 镜像（回归保护）。

`tests/unit` 全套 1727 个测试通过；ruff 对改动文件无新增报错。

设计评审记录见 #76。

🤖 Generated with [Claude Code](https://claude.com/claude-code)