### PR TITLE
fix(milkie): 技能发现去 fail-silent —— 读失败重试 + 丢弃告警 (#81 F1)

### DIFF
--- a/src/everbot/core/agent/provider/milkie/skills.py
+++ b/src/everbot/core/agent/provider/milkie/skills.py
@@ -12,12 +12,41 @@ from __future__ import annotations
 
 import logging
 import re
+import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 
 _MAX_DESC_CHARS = 150
+
+# 读 SKILL.md 的瞬时失败重试(#81):git checkout / 写入中途文件会短暂不可读,
+# 重试一次挡掉绝大多数;仍失败才放弃并 WARNING(绝不静默丢技能)。
+_SKILL_MD_READ_RETRIES = 1
+_SKILL_MD_RETRY_DELAY_S = 0.05
+
+
+def _read_skill_md(skill_md: Path) -> Optional[str]:
+    """读 SKILL.md 文本;瞬时不可读(git checkout / 写入中途)重试一次。
+
+    彻底失败 → DEBUG + None。这里只记 DEBUG 不 WARNING:此刻还不知该技能是否会被
+    更低优先级目录兜住,过早 WARNING 会在 fallback 命中时误报能力丢失。真正的"能力被
+    跳过"判定与告警集中在 :func:`discover_skills`(它掌握最终全貌)——这是 #81 的核心:
+    去 fail-silent,但把"出声"放在能区分"瞬时/可恢复"与"真丢失"的那一层。
+    """
+    last_exc: Optional[Exception] = None
+    for attempt in range(_SKILL_MD_READ_RETRIES + 1):
+        try:
+            return skill_md.read_text(encoding="utf-8")
+        except Exception as exc:
+            last_exc = exc
+            if attempt < _SKILL_MD_READ_RETRIES:
+                time.sleep(_SKILL_MD_RETRY_DELAY_S)
+    logger.debug(
+        "SKILL.md 读取失败(重试 %d 次后): %s — [%s] %r",
+        _SKILL_MD_READ_RETRIES, skill_md, type(last_exc).__name__, last_exc,
+    )
+    return None
 
 
 def resolve_skill_dirs(workspace_path: Path) -> List[Path]:
@@ -44,12 +73,10 @@ def parse_skill_metadata(skill_dir: Path) -> Optional[Dict[str, Any]]:
     """解析 SKILL.md 取元数据(name/title/description/abs_path)。无 SKILL.md → None。"""
     skill_md = skill_dir / "SKILL.md"
     if not skill_md.exists():
-        return None
-    try:
-        content = skill_md.read_text(encoding="utf-8")
-    except Exception:
-        logger.debug("读取 SKILL.md 失败: %s", skill_md, exc_info=True)
-        return None
+        return None  # 合法:非 skill 目录,静默跳过(避免噪声)
+    content = _read_skill_md(skill_md)
+    if content is None:
+        return None  # 有 SKILL.md 却读失败 —— _read_skill_md 已 WARNING
 
     title_match = re.search(r"^#\s+(.+)$", content, re.MULTILINE)
     title = title_match.group(1).strip() if title_match else skill_dir.name
@@ -96,16 +123,28 @@ def discover_skills(
     """
     skills: List[Dict[str, Any]] = []
     seen: set[str] = set()
+    saw_skill_md: set[str] = set()  # 含 SKILL.md(本应是技能)的目录名,用于丢弃告警(#81)
     for skills_dir in resolve_skill_dirs(workspace_path):
         for item in sorted(skills_dir.iterdir()):
             if not item.is_dir() or item.name.startswith("."):
                 continue
             if item.name in seen:
                 continue
+            if (item / "SKILL.md").exists():
+                saw_skill_md.add(item.name)
             meta = parse_skill_metadata(item)
             if meta:
                 seen.add(item.name)
                 skills.append(meta)
+
+    # #81:有 SKILL.md 却没能纳入(且无更低优先级目录兜住)的技能,聚合 WARNING ——
+    # 让"发现期目录变更导致静默丢技能"从隐形变可见,不再只有 debug。
+    dropped = saw_skill_md - seen
+    if dropped:
+        logger.warning(
+            "discover_skills: %d 个技能含 SKILL.md 却未能纳入(读取/解析失败),已被跳过: %s",
+            len(dropped), sorted(dropped),
+        )
 
     available = {s["name"] for s in skills}
     if include:

--- a/tests/unit/test_milkie_skills.py
+++ b/tests/unit/test_milkie_skills.py
@@ -278,6 +278,123 @@ def test_telegram_agent_gets_attachment_instruction(tmp_path, monkeypatch):
     assert "send_file" not in other_prompt   # 非 telegram agent 无
 
 
+# ── F1(#81):去 fail-silent —— 有 SKILL.md 却读失败必须重试 + 出声,不静默丢 ──
+
+import pathlib
+from unittest.mock import MagicMock
+
+
+def _fail_read_for(monkeypatch, fail_names, times=None):
+    """让路径名含 fail_names 之一的 SKILL.md read_text 抛错。
+
+    times=None → 每次都抛;times=N → 仅前 N 次抛(之后回落真实读取,模拟瞬时不可读)。
+    """
+    orig = pathlib.Path.read_text
+    counts: dict[str, int] = {}
+
+    def fake(self, *a, **k):
+        s = str(self)
+        for nm in fail_names:
+            if f"/{nm}/" in s:
+                counts[nm] = counts.get(nm, 0) + 1
+                if times is None or counts[nm] <= times:
+                    raise OSError("transient read failure")
+        return orig(self, *a, **k)
+
+    monkeypatch.setattr(pathlib.Path, "read_text", fake)
+
+
+def test_parse_skill_metadata_retries_then_succeeds(tmp_path, monkeypatch):
+    """SKILL.md 瞬时不可读(读一次抛、再读成功)→ 重试命中,技能不丢。"""
+    monkeypatch.setattr(msk, "_SKILL_MD_RETRY_DELAY_S", 0)
+    sd = _make_skill(tmp_path, "ops", "Ops", "运维脚本")
+    _fail_read_for(monkeypatch, ["ops"], times=1)  # 仅首次抛
+    meta = msk.parse_skill_metadata(sd)
+    assert meta is not None and meta["name"] == "ops"
+
+
+def test_parse_skill_metadata_read_failure_returns_none_gracefully(tmp_path, monkeypatch):
+    """SKILL.md 存在却始终读失败 → 重试后优雅返回 None(不抛、不崩)。
+
+    "出声"由 discover_skills 在掌握全貌后负责(见 warns_on_dropped),parse 层只
+    DEBUG 不 WARNING——避免 fallback 命中时误报(见 no_warning_when_fallback)。
+    """
+    monkeypatch.setattr(msk, "_SKILL_MD_RETRY_DELAY_S", 0)
+    sd = _make_skill(tmp_path, "ops", "Ops", "运维脚本")
+    _fail_read_for(monkeypatch, ["ops"])  # 每次都抛
+    mock_logger = MagicMock()
+    monkeypatch.setattr(msk, "logger", mock_logger)
+    meta = msk.parse_skill_metadata(sd)
+    assert meta is None
+    assert not mock_logger.warning.called  # parse 层不告警(留给 discover)
+
+
+def test_parse_skill_metadata_missing_md_is_silent(tmp_path, monkeypatch):
+    """无 SKILL.md 是合法的"非 skill 目录" → None 且不告警(避免噪声)。"""
+    d = tmp_path / "plain"
+    d.mkdir()
+    mock_logger = MagicMock()
+    monkeypatch.setattr(msk, "logger", mock_logger)
+    assert msk.parse_skill_metadata(d) is None
+    assert not mock_logger.warning.called
+
+
+def test_discover_skills_warns_on_dropped_skill_with_skill_md(tmp_path, monkeypatch):
+    """有 SKILL.md 却没能纳入结果的技能,discover 必须聚合告警(含技能名)。"""
+    monkeypatch.setattr(msk, "_SKILL_MD_RETRY_DELAY_S", 0)
+    d = tmp_path / "d"
+    _make_skill(d, "good", "Good", "正常技能")
+    _make_skill(d, "trace-review", "Trace", "读失败的技能")
+    monkeypatch.setattr(msk, "resolve_skill_dirs", lambda _ws: [d])
+    _fail_read_for(monkeypatch, ["trace-review"])  # 这个始终读失败
+    mock_logger = MagicMock()
+    monkeypatch.setattr(msk, "logger", mock_logger)
+
+    found = msk.discover_skills(tmp_path)
+    assert [s["name"] for s in found] == ["good"]  # trace-review 被丢
+    # 丢弃必须出声,且日志里点名 trace-review
+    assert mock_logger.warning.called
+    warned = " ".join(str(c) for c in mock_logger.warning.call_args_list)
+    assert "trace-review" in warned
+
+
+def test_discover_skills_no_warning_when_fallback_dir_provides_skill(tmp_path, monkeypatch):
+    """高优先级目录该技能读失败,但低优先级目录提供了它 → 技能在,不应误报丢弃。"""
+    monkeypatch.setattr(msk, "_SKILL_MD_RETRY_DELAY_S", 0)
+    hi = tmp_path / "hi"
+    lo = tmp_path / "lo"
+    _make_skill(hi, "shared", "高版", "hi 版(将读失败)")
+    _make_skill(lo, "shared", "低版", "lo 版(可读)")
+    monkeypatch.setattr(msk, "resolve_skill_dirs", lambda _ws: [hi, lo])
+
+    orig = pathlib.Path.read_text
+
+    def fake(self, *a, **k):
+        s = str(self)
+        if "/hi/" in s and "shared" in s:
+            raise OSError("transient")
+        return orig(self, *a, **k)
+
+    monkeypatch.setattr(pathlib.Path, "read_text", fake)
+    mock_logger = MagicMock()
+    monkeypatch.setattr(msk, "logger", mock_logger)
+
+    found = msk.discover_skills(tmp_path)
+    assert [s["name"] for s in found] == ["shared"]  # 低优先级兜住
+    assert not mock_logger.warning.called  # 最终有这个技能 → 不误报
+
+
+def test_discover_skills_deterministic_on_stable_fs(tmp_path, monkeypatch):
+    """静止文件系统上多次发现结果必须完全一致(固化 #81 的 200× 复现为回归)。"""
+    d = tmp_path / "d"
+    for n in ("alpha", "trace-review", "twitter-watch"):
+        _make_skill(d, n, n, f"{n} skill")
+    monkeypatch.setattr(msk, "resolve_skill_dirs", lambda _ws: [d])
+    runs = [tuple(sorted(s["name"] for s in msk.discover_skills(tmp_path))) for _ in range(50)]
+    assert len(set(runs)) == 1
+    assert runs[0] == ("alpha", "trace-review", "twitter-watch")
+
+
 def test_resolve_skill_dirs_orders_workspace_first_and_dedups(tmp_path, monkeypatch):
     ws = tmp_path / "ws"
     (ws / "skills").mkdir(parents=True)


### PR DESCRIPTION
落地 #81 的 **F1**(最小、独立于 F2 走向)。

## 问题(详见 #81)

`parse_skill_metadata` 把读 `SKILL.md` 的异常 `except: debug; return None` 全吞,目录变更(`git checkout`/软链接装卸)中途扫描会**静默丢已存在技能**,全链路只有 debug 日志 → 问题长期不可见(实测 ~37% 的 run 丢 `trace-review`)。

## 改动

- 抽出 `_read_skill_md`:瞬时不可读**重试一次**(挡 checkout/写入中途),彻底失败记 **DEBUG** 返回 None。
- **不在读层 WARNING**:此刻还不知是否被更低优先级目录兜住,过早告警会在 fallback 命中时误报。
- `discover_skills`:聚合"有 `SKILL.md` 却未纳入(且无 fallback 兜住)"的技能,**WARNING 点名** —— 把静默丢技能从隐形变可见。告警集中在能区分"可恢复/真丢失"的这一层。

## 测试

`tests/unit/test_milkie_skills.py` 新增 6 例:重试命中、彻底失败优雅返回、无 SKILL.md 静默跳过、丢弃告警点名、fallback 不误报、**静止 FS 50× 结果一致**(把 #81 的 200× 复现固化为回归)。

```
tests/unit/test_milkie_skills.py            29 passed
provider/launcher/system_prompt_loader/whitelist  78 passed
```

## 未做(待 #81 评审)

F2(原子快照 / 改用稳定注册表源,代替实时扫 git 工作树)、F3(完整性断言)。本 PR 先让发现层"出声",不改发现的数据源。

Closes #81 的 F1 部分(F2/F3 仍跟踪在 #81)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)