### PR TITLE
fix(milkie): 技能发现缩水重试 —— 目录瞬时消失不再丢技能 (#81 F2)

### DIFF
--- a/src/everbot/core/agent/provider/milkie/skills.py
+++ b/src/everbot/core/agent/provider/milkie/skills.py
@@ -107,6 +107,71 @@ def parse_skill_metadata(skill_dir: Path) -> Optional[Dict[str, Any]]:
     }
 
 
+# #81 F2:每个 workspace 上一次成功发现的技能名集合(原始,未过滤),用于"缩水"检测。
+# git checkout / 软链接装卸期间,技能目录会整个瞬时消失,F1 的逐文件读重试兜不住
+# (目录列举那一刻它就不在)——靠与上次比对发现缩水、重扫整轮骑过瞬时窗口来覆盖。
+_DISCOVERY_SHRINK_RETRIES = 2
+_last_good_discovery: Dict[str, set] = {}
+
+
+def _scan_skills_once(workspace_path: Path):
+    """扫一遍所有 skill 目录 → ``(技能 meta 列表, 见到 SKILL.md 的目录名集合)``。
+
+    纯单次扫描,不告警/不重试/不碰缓存;供 :func:`_discover_stable` 包装。
+    """
+    skills: List[Dict[str, Any]] = []
+    seen: set[str] = set()
+    saw_skill_md: set[str] = set()  # 含 SKILL.md(本应是技能)的目录名
+    for skills_dir in resolve_skill_dirs(workspace_path):
+        for item in sorted(skills_dir.iterdir()):
+            if not item.is_dir() or item.name.startswith("."):
+                continue
+            if item.name in seen:
+                continue
+            if (item / "SKILL.md").exists():
+                saw_skill_md.add(item.name)
+            meta = parse_skill_metadata(item)
+            if meta:
+                seen.add(item.name)
+                skills.append(meta)
+    return skills, saw_skill_md
+
+
+def _discover_stable(workspace_path: Path):
+    """单次扫描 + 缩水重试,返回 ``(skills, saw_skill_md, names)``(均为原始未过滤)。
+
+    与上次成功发现比对:若本次"缩水"(少了曾出现过的技能),疑似目录变更中途,
+    重扫整轮(取技能最多的一次)以骑过瞬时窗口;**真删除**会跨重试持续缩水 → 接受
+    并 WARNING。无论瞬时与否,缩水都不再被静默吞掉。
+    """
+    skills, saw = _scan_skills_once(workspace_path)
+    names = {s["name"] for s in skills}
+
+    key = str(workspace_path)
+    prev = _last_good_discovery.get(key)
+    if prev is not None and not prev <= names:
+        best, best_saw, best_names = skills, saw, names
+        for _ in range(_DISCOVERY_SHRINK_RETRIES):
+            time.sleep(_SKILL_MD_RETRY_DELAY_S)
+            s2, saw2 = _scan_skills_once(workspace_path)
+            n2 = {s["name"] for s in s2}
+            if len(n2) > len(best_names):
+                best, best_saw, best_names = s2, saw2, n2
+            if prev <= n2:
+                break
+        skills, saw, names = best, best_saw, best_names
+        still_missing = prev - names
+        if still_missing:
+            logger.warning(
+                "discover_skills: 技能数较上次缩水(疑似发现期目录变更或确有删除),"
+                "重试 %d 次后仍缺: %s",
+                _DISCOVERY_SHRINK_RETRIES, sorted(still_missing),
+            )
+
+    _last_good_discovery[key] = names
+    return skills, saw, names
+
+
 def discover_skills(
     workspace_path: Path,
     *,
@@ -121,32 +186,18 @@ def discover_skills(
     - include/exclude 里出现**未发现**的 skill 名 → ``ValueError``(fail-loud,防配置笔误,
       与 dolphin 行为一致)。
     """
-    skills: List[Dict[str, Any]] = []
-    seen: set[str] = set()
-    saw_skill_md: set[str] = set()  # 含 SKILL.md(本应是技能)的目录名,用于丢弃告警(#81)
-    for skills_dir in resolve_skill_dirs(workspace_path):
-        for item in sorted(skills_dir.iterdir()):
-            if not item.is_dir() or item.name.startswith("."):
-                continue
-            if item.name in seen:
-                continue
-            if (item / "SKILL.md").exists():
-                saw_skill_md.add(item.name)
-            meta = parse_skill_metadata(item)
-            if meta:
-                seen.add(item.name)
-                skills.append(meta)
+    skills, saw_skill_md, names = _discover_stable(workspace_path)
 
-    # #81:有 SKILL.md 却没能纳入(且无更低优先级目录兜住)的技能,聚合 WARNING ——
+    # #81 F1:有 SKILL.md 却没能纳入(且无更低优先级目录兜住)的技能,聚合 WARNING ——
     # 让"发现期目录变更导致静默丢技能"从隐形变可见,不再只有 debug。
-    dropped = saw_skill_md - seen
+    dropped = saw_skill_md - names
     if dropped:
         logger.warning(
             "discover_skills: %d 个技能含 SKILL.md 却未能纳入(读取/解析失败),已被跳过: %s",
             len(dropped), sorted(dropped),
         )
 
-    available = {s["name"] for s in skills}
+    available = names
     if include:
         unknown = [n for n in include if n not in available]
         if unknown:

--- a/tests/unit/test_milkie_skills.py
+++ b/tests/unit/test_milkie_skills.py
@@ -1,7 +1,17 @@
 """milkie skill 发现单测(#38 E 能力层 alfred 侧)。"""
 from pathlib import Path
 
+import pytest
+
 from src.everbot.core.agent.provider.milkie import skills as msk
+
+
+@pytest.fixture(autouse=True)
+def _clear_discovery_cache():
+    """每例清空 #81 F2 的"上次成功发现"缓存,避免跨例污染。"""
+    msk._last_good_discovery.clear()
+    yield
+    msk._last_good_discovery.clear()
 
 
 def _make_skill(dir_: Path, name: str, title: str, desc: str) -> Path:
@@ -393,6 +403,97 @@ def test_discover_skills_deterministic_on_stable_fs(tmp_path, monkeypatch):
     runs = [tuple(sorted(s["name"] for s in msk.discover_skills(tmp_path))) for _ in range(50)]
     assert len(set(runs)) == 1
     assert runs[0] == ("alpha", "trace-review", "twitter-watch")
+
+
+# ── F2(#81):缩水重试 —— 目录瞬时消失(git checkout 中途)不丢、真删除接受 ──
+
+def test_discover_retries_on_transient_shrink_and_recovers(tmp_path, monkeypatch):
+    """上次见过 c,本次首扫缺 c(瞬时)→ 重扫整轮恢复,不误报缩水。"""
+    monkeypatch.setattr(msk, "_SKILL_MD_RETRY_DELAY_S", 0)
+    d = tmp_path / "d"
+    for n in ("a", "b", "c"):
+        _make_skill(d, n, n, n)
+    monkeypatch.setattr(msk, "resolve_skill_dirs", lambda _ws: [d])
+    assert sorted(s["name"] for s in msk.discover_skills(tmp_path)) == ["a", "b", "c"]  # 播种缓存
+
+    real = msk._scan_skills_once
+    calls = {"n": 0}
+
+    def flaky(ws):
+        calls["n"] += 1
+        skills, saw = real(ws)
+        if calls["n"] == 1:  # 首次扫描:c 目录"瞬时消失"
+            skills = [s for s in skills if s["name"] != "c"]
+        return skills, saw
+
+    monkeypatch.setattr(msk, "_scan_skills_once", flaky)
+    mock_logger = MagicMock()
+    monkeypatch.setattr(msk, "logger", mock_logger)
+
+    found = sorted(s["name"] for s in msk.discover_skills(tmp_path))
+    assert found == ["a", "b", "c"]            # 重试恢复,不丢 c
+    assert calls["n"] >= 2                       # 确实重扫了整轮
+    assert not mock_logger.warning.called        # 恢复了 → 不告警缩水
+
+
+def test_discover_persistent_shrink_accepted_warns_and_no_reretry(tmp_path, monkeypatch):
+    """c 真删除(每次都缺)→ 重试后接受、WARNING;缓存更新后下次不再重试。"""
+    monkeypatch.setattr(msk, "_SKILL_MD_RETRY_DELAY_S", 0)
+    d = tmp_path / "d"
+    for n in ("a", "b", "c"):
+        _make_skill(d, n, n, n)
+    monkeypatch.setattr(msk, "resolve_skill_dirs", lambda _ws: [d])
+    assert len(msk.discover_skills(tmp_path)) == 3  # 播种缓存 {a,b,c}
+
+    real = msk._scan_skills_once
+
+    def shrunk(ws):
+        skills, saw = real(ws)
+        return [s for s in skills if s["name"] != "c"], {x for x in saw if x != "c"}
+
+    monkeypatch.setattr(msk, "_scan_skills_once", shrunk)
+    mock_logger = MagicMock()
+    monkeypatch.setattr(msk, "logger", mock_logger)
+
+    found = sorted(s["name"] for s in msk.discover_skills(tmp_path))
+    assert found == ["a", "b"]               # 真删除被接受
+    assert mock_logger.warning.called        # 缩水出声
+
+    # 缓存已更新为 {a,b};下一次无缩水 → 只扫一次,不再重试
+    calls = {"n": 0}
+
+    def counted(ws):
+        calls["n"] += 1
+        return shrunk(ws)
+
+    monkeypatch.setattr(msk, "_scan_skills_once", counted)
+    msk.discover_skills(tmp_path)
+    assert calls["n"] == 1
+
+
+def test_discover_transient_shrink_does_not_raise_spurious_include_error(tmp_path, monkeypatch):
+    """include 命中的技能首扫瞬时缺失,不应误判 unknown 而 raise —— 校验跑在稳定全集上。"""
+    monkeypatch.setattr(msk, "_SKILL_MD_RETRY_DELAY_S", 0)
+    d = tmp_path / "d"
+    for n in ("a", "b"):
+        _make_skill(d, n, n, n)
+    monkeypatch.setattr(msk, "resolve_skill_dirs", lambda _ws: [d])
+    assert len(msk.discover_skills(tmp_path)) == 2  # 播种 {a,b}
+
+    real = msk._scan_skills_once
+    calls = {"n": 0}
+
+    def flaky(ws):
+        calls["n"] += 1
+        skills, saw = real(ws)
+        if calls["n"] == 1:           # 首扫瞬时缺 b
+            skills = [s for s in skills if s["name"] != "b"]
+        return skills, saw
+
+    monkeypatch.setattr(msk, "_scan_skills_once", flaky)
+    # include=[b]:若用首扫结果校验会 raise;重试恢复后应正常返回 b
+    found = msk.discover_skills(tmp_path, include=["b"])
+    assert [s["name"] for s in found] == ["b"]
 
 
 def test_resolve_skill_dirs_orders_workspace_first_and_dedups(tmp_path, monkeypatch):


### PR DESCRIPTION
接 #82(F1)落地 #81 的 **F2**(评审定向:原子快照 + 缩水重试)。

## 问题(F1 兜不住的部分)

F1 让"读 `SKILL.md` 失败"出声,但 `git checkout` / 软链接装卸期间**技能目录整个瞬时消失**——目录列举那一刻它就不在,F1 的逐文件读重试兜不住。这是 #81 中 ~37% 缩水的主因。

## 改动

- 抽出 `_scan_skills_once`:纯单次扫描,返回 `(skills, 见到 SKILL.md 的目录名)`。
- `_discover_stable`:缓存每个 workspace 上次成功发现的技能名集;本次若**缩水**(少了曾出现过的技能)→ 重扫整轮(取技能最多的一次)骑过瞬时窗口。
  - 瞬时缩水 → 某次重扫恢复,**不误报**。
  - 真删除 → 跨重试持续缩水 → 接受并 **WARNING**(顺带覆盖 F3 的"技能数异常下降即告警")。缓存更新后下次无缩水、不再重试。
- `include`/`exclude` 校验改在**稳定后的全集**上跑,避免瞬时缩水把 include 误判为 unknown 而 spurious `raise ValueError`。

## 测试

`tests/unit/test_milkie_skills.py` 新增 3 例 + autouse 清缓存 fixture:瞬时缩水重试恢复且不误报、真删除接受+告警+不再重试、瞬时缺失不触发 spurious include 报错。

```
test_milkie_skills.py                              32 passed
provider/launcher/loader/pool/whitelist            85 passed
```

## 未做(留与 #43 协同)

彻底去耦合——发现不再实时扫开发者 git 工作树、改用原子维护的已安装注册表。本 PR 仍扫现有三目录,只是对"扫描撞上目录变更中途"做了缩水重试 + 出声。

推进 #81(F2);F1=#82(已合并)。深层去耦合跟踪在 #81 / #43。

🤖 Generated with [Claude Code](https://claude.com/claude-code)