### PR TITLE
fix(scheduler): LLM 断网时 inline cron 退避 + probe 冷却,消除心跳每秒疯转 (#78)

### DIFF
--- a/src/everbot/cli/daemon.py
+++ b/src/everbot/cli/daemon.py
@@ -30,6 +30,7 @@ from ..infra.process import (
 )
 from ..infra.logging_utils import configure_daemon_logging
 from ..core.runtime.scheduler import AgentSchedule, InspectorSchedule, Scheduler, SchedulerTask
+from ..core.jobs.llm_errors import LLMUnavailableError
 from ..channels.telegram_channel import TelegramChannel
 from ..core.models.constants import DAEMON_IDLE_SLEEP
 
@@ -132,6 +133,20 @@ class EverBotDaemon:
         if result == "HEARTBEAT_FAILED":
             raise RuntimeError("Heartbeat returned HEARTBEAT_FAILED")
 
+    async def _dispatch_inline(self, agent_name: str) -> None:
+        """Run one agent's due inline tasks; signal LLM-down to the scheduler.
+
+        Raises LLMUnavailableError when the runner's probe found the LLM
+        unreachable, so the scheduler backs off the inline path instead of
+        spinning every 1s tick (#78).
+        """
+        runner = self.heartbeat_runners.get(agent_name)
+        if runner is None:
+            return
+        await self._run_runner_with_options(runner, include_inline=True, include_isolated=False)
+        if getattr(runner, "is_llm_unavailable", False):
+            raise LLMUnavailableError(f"LLM unavailable for {agent_name}")
+
     # -- Cron task callbacks ------------------------------------------------
 
     def _build_scheduler(self) -> Scheduler:
@@ -175,10 +190,7 @@ class EverBotDaemon:
             return bool(await claim(task_id)) if task_id else False
 
         async def _run_inline(agent_name: str, _tasks: list[SchedulerTask], _ts: datetime) -> None:
-            runner = self.heartbeat_runners.get(agent_name)
-            if runner is None:
-                return
-            await self._run_runner_with_options(runner, include_inline=True, include_isolated=False)
+            await self._dispatch_inline(agent_name)
 
         async def _run_isolated(task: SchedulerTask, ts: datetime) -> None:
             target = isolated_lookup.get(task.id)

--- a/src/everbot/core/jobs/llm_errors.py
+++ b/src/everbot/core/jobs/llm_errors.py
@@ -17,3 +17,12 @@ class LLMConfigError(Exception):
 
     Requires manual intervention to fix.
     """
+
+
+class LLMUnavailableError(Exception):
+    """LLM unreachable at the heartbeat probe layer (network down, endpoint dead).
+
+    Raised by the inline-task runner so the scheduler can back off its inline
+    path (#78) instead of spinning every 1s tick. Kept independent of
+    LLMTransientError so existing job-layer handlers are unaffected.
+    """

--- a/src/everbot/core/runtime/heartbeat.py
+++ b/src/everbot/core/runtime/heartbeat.py
@@ -228,6 +228,7 @@ If not, reply with `HEARTBEAT_OK`.
         self._pending_delivery_details: list[str] = []
         self._llm_unavailable_since: Optional[datetime] = None
         self._llm_unavailable_last_notified_at: Optional[datetime] = None
+        self._last_probe_at: Optional[datetime] = None
         if summary_max_chars is not None:
             self.SUMMARY_MAX_CHARS = max(1, int(summary_max_chars))
 
@@ -1051,8 +1052,30 @@ If not, reply with `HEARTBEAT_OK`.
         model = resolve_agent_model(self.agent_name)
         return _SkillLLMClient(model=model)
 
+    @property
+    def is_llm_unavailable(self) -> bool:
+        """True while the LLM is known-down (set by the probe-fail path).
+
+        The scheduler's inline runner reads this after a heartbeat turn to
+        decide whether to raise LLMUnavailableError and trigger backoff (#78).
+        """
+        return self._llm_unavailable_since is not None
+
     async def _probe_llm(self) -> bool:
         """Quick LLM connectivity check. Returns True if LLM is reachable."""
+        now = datetime.now()
+        # Cooldown (#78): while the LLM is known-down, don't re-probe on every
+        # 1s tick — that turns an outage into a per-second connection storm.
+        # Within the cooldown window since the last actual probe, short-circuit
+        # to "still unavailable" without touching the network.
+        last_probe_at = getattr(self, "_last_probe_at", None)
+        if (
+            getattr(self, "_llm_unavailable_since", None) is not None
+            and last_probe_at is not None
+            and (now - last_probe_at).total_seconds() < _probe_cooldown_s()
+        ):
+            return False
+        self._last_probe_at = now
         try:
             client = self._create_skill_llm_client()
             await asyncio.wait_for(
@@ -1670,6 +1693,9 @@ from openai import AsyncOpenAI
 # 可达 60-112s);probe 默认 30s(原 15s 假阴性致心跳误判"LLM 不可用"暂停)。均 env 可配。
 _DEFAULT_SKILL_LLM_TIMEOUT_S = 120.0
 _DEFAULT_PROBE_TIMEOUT_S = 30.0
+# #78:LLM 不可用期间 probe 冷却,默认 60s(env 可配),把断网期的连接尝试
+# 从每秒一次降到每分钟一次。
+_DEFAULT_PROBE_COOLDOWN_S = 60.0
 
 
 def _env_float(name: str, default: float) -> float:
@@ -1689,6 +1715,11 @@ def _skill_llm_timeout_s() -> float:
 
 def _probe_timeout_s() -> float:
     return _env_float("ALFRED_SKILL_LLM_PROBE_TIMEOUT", _DEFAULT_PROBE_TIMEOUT_S)
+
+
+def _probe_cooldown_s() -> float:
+    # #78: while LLM is known-down, skip network probes within this window.
+    return _env_float("ALFRED_SKILL_LLM_PROBE_COOLDOWN", _DEFAULT_PROBE_COOLDOWN_S)
 
 
 class _SkillLLMClient:

--- a/src/everbot/core/runtime/scheduler.py
+++ b/src/everbot/core/runtime/scheduler.py
@@ -19,7 +19,24 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Awaitable, Callable, Dict, Iterable, List, Optional
 
+from ..jobs.llm_errors import LLMUnavailableError
+
 logger = logging.getLogger(__name__)
+
+
+def _inline_backoff_base_minutes() -> int:
+    """Base interval (minutes) for inline-task exponential backoff (#78).
+
+    Default 1; override with ALFRED_INLINE_BACKOFF_BASE_MIN.
+    """
+    import os
+    raw = (os.environ.get("ALFRED_INLINE_BACKOFF_BASE_MIN") or "").strip()
+    if not raw:
+        return 1
+    try:
+        return max(1, int(raw))
+    except ValueError:
+        return 1
 
 
 @dataclass
@@ -41,6 +58,25 @@ class AgentSchedule:
     night_interval_minutes: Optional[int] = None
     next_heartbeat_at: Optional[datetime] = None
     active_hours: tuple[int, int] = (8, 22)
+    consecutive_failures: int = 0
+    max_backoff_minutes: int = 60
+
+
+@dataclass
+class InlineSchedule:
+    """Per-agent inline-task scheduling state (#78).
+
+    The inline path has no schedule clock of its own — it dispatches whenever a
+    task is due. When the LLM is unreachable the probe-fail path never advances
+    next_run_at, so due inline tasks re-trigger every 1s tick. This adds an
+    exponential backoff gate, symmetric with AgentSchedule / InspectorSchedule:
+    only LLMUnavailableError counts as a failure; other per-task errors are left
+    to the existing swallow semantics so one flaky task can't stall the agent.
+    """
+
+    agent_name: str
+    base_interval_minutes: int = 1
+    next_inline_at: Optional[datetime] = None
     consecutive_failures: int = 0
     max_backoff_minutes: int = 60
 
@@ -91,6 +127,7 @@ class Scheduler:
         # --- Config ---
         agent_schedules: Optional[Dict[str, AgentSchedule]] = None,
         inspector_schedules: Optional[Dict[str, InspectorSchedule]] = None,
+        inline_schedules: Optional[Dict[str, InlineSchedule]] = None,
         tick_interval_seconds: float = 1.0,
         state_file: Optional[Path] = None,
     ):
@@ -102,6 +139,7 @@ class Scheduler:
         self._run_inspector = run_inspector
         self._agent_schedules: Dict[str, AgentSchedule] = dict(agent_schedules or {})
         self._inspector_schedules: Dict[str, InspectorSchedule] = dict(inspector_schedules or {})
+        self._inline_schedules: Dict[str, InlineSchedule] = dict(inline_schedules or {})
         self._tick_interval_seconds = tick_interval_seconds
         self._running = False
         self._state_file = state_file
@@ -131,6 +169,17 @@ class Scheduler:
                 inspectors[name] = ientry
             if inspectors:
                 state["__inspectors__"] = inspectors
+            # Inline schedules (#78): only persist agents that are mid-backoff.
+            inlines: Dict[str, Any] = {}
+            for name, lsched in self._inline_schedules.items():
+                if lsched.next_inline_at is None and lsched.consecutive_failures == 0:
+                    continue
+                lentry: Dict[str, Any] = {"consecutive_failures": lsched.consecutive_failures}
+                if lsched.next_inline_at is not None:
+                    lentry["next_inline_at"] = lsched.next_inline_at.isoformat()
+                inlines[name] = lentry
+            if inlines:
+                state["__inline__"] = inlines
             self._state_file.parent.mkdir(parents=True, exist_ok=True)
             self._state_file.write_text(json.dumps(state, indent=2), encoding="utf-8")
         except Exception:
@@ -178,6 +227,20 @@ class Scheduler:
                         except (ValueError, TypeError):
                             pass
                     isched.consecutive_failures = int(ivalue.get("consecutive_failures", 0) or 0)
+            # Restore inline schedules (#78). Create entries lazily so backoff
+            # survives a restart even for agents not pre-registered.
+            inline_state = state.get("__inline__", {})
+            for name, lvalue in inline_state.items():
+                if not isinstance(lvalue, dict):
+                    continue
+                lsched = self._get_inline_schedule(name)
+                iso_str = lvalue.get("next_inline_at")
+                if iso_str:
+                    try:
+                        lsched.next_inline_at = datetime.fromisoformat(iso_str)
+                    except (ValueError, TypeError):
+                        pass
+                lsched.consecutive_failures = int(lvalue.get("consecutive_failures", 0) or 0)
             logger.debug("Restored scheduler state from %s", self._state_file)
         except Exception:
             logger.debug("Failed to restore scheduler state", exc_info=True)
@@ -197,6 +260,21 @@ class Scheduler:
 
     def unregister_inspector(self, agent_name: str) -> None:
         self._inspector_schedules.pop(agent_name, None)
+
+    def _get_inline_schedule(self, agent_name: str) -> InlineSchedule:
+        """Return the inline backoff schedule for an agent, creating it lazily.
+
+        Inline schedules are keyed by agent and only matter once an agent has
+        due inline tasks, so they are created on demand rather than pre-registered.
+        """
+        schedule = self._inline_schedules.get(agent_name)
+        if schedule is None:
+            schedule = InlineSchedule(
+                agent_name=agent_name,
+                base_interval_minutes=_inline_backoff_base_minutes(),
+            )
+            self._inline_schedules[agent_name] = schedule
+        return schedule
 
     # -- Core tick ----------------------------------------------------------
 
@@ -269,9 +347,41 @@ class Scheduler:
             for task in inline_tasks:
                 inline_by_agent.setdefault(task.agent_name, []).append(task)
             for agent_name, tasks in inline_by_agent.items():
+                schedule = self._get_inline_schedule(agent_name)
+                # Backoff gate: while the LLM is down, skip dispatch until
+                # next_inline_at so 1s ticks don't become 1s LLM probes (#78).
+                next_at = (
+                    self._normalize_ts(schedule.next_inline_at)
+                    if schedule.next_inline_at is not None
+                    else None
+                )
+                if next_at is not None and ts < next_at:
+                    continue
                 try:
                     await self._run_inline(agent_name, tasks, ts)
+                    # Success: clear backoff, resume normal cadence.
+                    schedule.consecutive_failures = 0
+                    schedule.next_inline_at = None
+                    self._save_state()
+                except LLMUnavailableError:
+                    schedule.consecutive_failures += 1
+                    base_interval = max(1, schedule.base_interval_minutes)
+                    backoff_minutes = min(
+                        base_interval * (2 ** schedule.consecutive_failures),
+                        schedule.max_backoff_minutes,
+                    )
+                    schedule.next_inline_at = ts + timedelta(minutes=backoff_minutes)
+                    logger.warning(
+                        "Inline task LLM unavailable for %s (consecutive_failures=%d, "
+                        "next_retry_in=%d min)",
+                        agent_name,
+                        schedule.consecutive_failures,
+                        backoff_minutes,
+                    )
+                    self._save_state()
                 except Exception:
+                    # Non-LLM failures: keep the existing swallow semantics so a
+                    # single flaky task can't stall the whole agent's inline path.
                     logger.exception("Inline task execution failed for %s", agent_name)
 
         # Isolated: claim then dispatch, per-task error isolation

--- a/tests/unit/test_inline_backoff.py
+++ b/tests/unit/test_inline_backoff.py
@@ -1,0 +1,367 @@
+"""Tests for #78: inline cron task backoff on LLM unavailability + probe cooldown.
+
+When the LLM is unreachable, the scheduler's inline task path must back off
+(exponential, symmetric with _tick_heartbeats/_tick_inspector) instead of
+spinning every 1s tick. Probe cooldown caps the LLM connection attempt rate.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from src.everbot.core.jobs.llm_errors import LLMUnavailableError
+from src.everbot.core.runtime.scheduler import (
+    InlineSchedule,
+    Scheduler,
+    SchedulerTask,
+)
+
+
+def _one_inline_task(agent_name: str = "test_agent"):
+    def _get_due(ts):
+        return [SchedulerTask(id="t1", agent_name=agent_name, execution_mode="inline")]
+    return _get_due
+
+
+def _make_hb_runner(tmp_path):
+    from types import SimpleNamespace
+    from unittest.mock import AsyncMock
+    from src.everbot.core.runtime.heartbeat import HeartbeatRunner
+    session_manager = SimpleNamespace(
+        get_primary_session_id=lambda agent_name: f"web_session_{agent_name}",
+        get_heartbeat_session_id=lambda agent_name: f"heartbeat_session_{agent_name}",
+    )
+    return HeartbeatRunner(
+        agent_name="test_agent",
+        workspace_path=tmp_path,
+        session_manager=session_manager,
+        agent_factory=AsyncMock(),
+        interval_minutes=1,
+        active_hours=(0, 24),
+        max_retries=3,
+        on_result=None,
+    )
+
+
+# ── 方向 2: scheduler inline 退避 ──────────────────────────────
+
+
+class TestInlineBackoff:
+    def test_llm_unavailable_increases_backoff(self):
+        async def _run_inline(agent_name, tasks, ts):
+            raise LLMUnavailableError("llm down")
+
+        schedule = InlineSchedule(agent_name="test_agent", base_interval_minutes=1, max_backoff_minutes=60)
+        scheduler = Scheduler(
+            get_due_tasks=_one_inline_task(),
+            run_inline=_run_inline,
+            inline_schedules={"test_agent": schedule},
+        )
+
+        ts = datetime(2026, 2, 15, 12, 0, tzinfo=timezone.utc)
+        asyncio.run(scheduler._tick_tasks(ts))
+        assert schedule.consecutive_failures == 1
+        assert schedule.next_inline_at is not None
+        assert schedule.next_inline_at > ts
+
+    def test_consecutive_failures_grow_exponentially(self):
+        async def _run_inline(agent_name, tasks, ts):
+            raise LLMUnavailableError("llm down")
+
+        schedule = InlineSchedule(agent_name="test_agent", base_interval_minutes=1, max_backoff_minutes=60)
+        scheduler = Scheduler(
+            get_due_tasks=_one_inline_task(),
+            run_inline=_run_inline,
+            inline_schedules={"test_agent": schedule},
+        )
+        ts = datetime(2026, 2, 15, 12, 0, tzinfo=timezone.utc)
+
+        asyncio.run(scheduler._tick_tasks(ts))
+        assert schedule.consecutive_failures == 1
+        first_backoff = schedule.next_inline_at - ts  # base * 2^1 = 2 min
+
+        # Force due again (simulate later tick past next_inline_at)
+        ts2 = schedule.next_inline_at
+        asyncio.run(scheduler._tick_tasks(ts2))
+        assert schedule.consecutive_failures == 2
+        second_backoff = schedule.next_inline_at - ts2  # base * 2^2 = 4 min
+        assert second_backoff > first_backoff
+
+    def test_success_resets_backoff(self):
+        async def _ok_inline(agent_name, tasks, ts):
+            return "HEARTBEAT_OK"
+
+        schedule = InlineSchedule(agent_name="test_agent", consecutive_failures=5)
+        scheduler = Scheduler(
+            get_due_tasks=_one_inline_task(),
+            run_inline=_ok_inline,
+            inline_schedules={"test_agent": schedule},
+        )
+        ts = datetime(2026, 2, 15, 12, 0, tzinfo=timezone.utc)
+        asyncio.run(scheduler._tick_tasks(ts))
+        assert schedule.consecutive_failures == 0
+        assert schedule.next_inline_at is None
+
+    def test_backoff_capped_at_max(self):
+        async def _run_inline(agent_name, tasks, ts):
+            raise LLMUnavailableError("llm down")
+
+        schedule = InlineSchedule(
+            agent_name="test_agent",
+            base_interval_minutes=1,
+            max_backoff_minutes=10,
+            consecutive_failures=99,  # already high
+        )
+        scheduler = Scheduler(
+            get_due_tasks=_one_inline_task(),
+            run_inline=_run_inline,
+            inline_schedules={"test_agent": schedule},
+        )
+        ts = datetime(2026, 2, 15, 12, 0, tzinfo=timezone.utc)
+        asyncio.run(scheduler._tick_tasks(ts))
+        delta = schedule.next_inline_at - ts
+        assert delta <= timedelta(minutes=10, seconds=5)
+
+    def test_next_inline_at_gates_dispatch(self):
+        """While next_inline_at is in the future, _run_inline must NOT be called."""
+        calls = 0
+
+        async def _run_inline(agent_name, tasks, ts):
+            nonlocal calls
+            calls += 1
+
+        ts = datetime(2026, 2, 15, 12, 0, tzinfo=timezone.utc)
+        schedule = InlineSchedule(
+            agent_name="test_agent",
+            next_inline_at=ts + timedelta(minutes=5),
+            consecutive_failures=3,
+        )
+        scheduler = Scheduler(
+            get_due_tasks=_one_inline_task(),
+            run_inline=_run_inline,
+            inline_schedules={"test_agent": schedule},
+        )
+        asyncio.run(scheduler._tick_tasks(ts))
+        assert calls == 0
+        # Backoff state untouched while gated
+        assert schedule.consecutive_failures == 3
+
+    def test_non_llm_exception_does_not_backoff(self):
+        """A generic task error is swallowed and must NOT arm the backoff gate."""
+        async def _run_inline(agent_name, tasks, ts):
+            raise RuntimeError("some flaky task")
+
+        schedule = InlineSchedule(agent_name="test_agent")
+        scheduler = Scheduler(
+            get_due_tasks=_one_inline_task(),
+            run_inline=_run_inline,
+            inline_schedules={"test_agent": schedule},
+        )
+        ts = datetime(2026, 2, 15, 12, 0, tzinfo=timezone.utc)
+        asyncio.run(scheduler._tick_tasks(ts))  # must not raise
+        assert schedule.consecutive_failures == 0
+        assert schedule.next_inline_at is None
+
+    def test_lazy_schedule_created_when_not_registered(self):
+        """Backoff works even without a pre-registered InlineSchedule."""
+        async def _run_inline(agent_name, tasks, ts):
+            raise LLMUnavailableError("llm down")
+
+        scheduler = Scheduler(
+            get_due_tasks=_one_inline_task("agentX"),
+            run_inline=_run_inline,
+        )
+        ts = datetime(2026, 2, 15, 12, 0, tzinfo=timezone.utc)
+        asyncio.run(scheduler._tick_tasks(ts))
+        sched = scheduler._get_inline_schedule("agentX")
+        assert sched.consecutive_failures == 1
+        assert sched.next_inline_at is not None
+
+    def test_multiple_agents_backoff_independently(self):
+        async def _run_inline(agent_name, tasks, ts):
+            if agent_name == "down":
+                raise LLMUnavailableError("llm down")
+            return "HEARTBEAT_OK"
+
+        def _get_due(ts):
+            return [
+                SchedulerTask(id="a", agent_name="down", execution_mode="inline"),
+                SchedulerTask(id="b", agent_name="up", execution_mode="inline"),
+            ]
+
+        down = InlineSchedule(agent_name="down")
+        up = InlineSchedule(agent_name="up")
+        scheduler = Scheduler(
+            get_due_tasks=_get_due,
+            run_inline=_run_inline,
+            inline_schedules={"down": down, "up": up},
+        )
+        ts = datetime(2026, 2, 15, 12, 0, tzinfo=timezone.utc)
+        asyncio.run(scheduler._tick_tasks(ts))
+        assert down.consecutive_failures == 1
+        assert down.next_inline_at is not None
+        assert up.consecutive_failures == 0
+        assert up.next_inline_at is None
+
+    def test_lazy_schedule_base_interval_from_env(self, monkeypatch):
+        """ALFRED_INLINE_BACKOFF_BASE_MIN overrides the lazy default base interval."""
+        monkeypatch.setenv("ALFRED_INLINE_BACKOFF_BASE_MIN", "5")
+        scheduler = Scheduler()
+        sched = scheduler._get_inline_schedule("agentY")
+        assert sched.base_interval_minutes == 5
+
+    def test_state_persistence_round_trip(self, tmp_path):
+        state_file = tmp_path / "scheduler_state.json"
+        schedule = InlineSchedule(
+            agent_name="test_agent",
+            consecutive_failures=3,
+            next_inline_at=datetime(2026, 2, 15, 12, 0, tzinfo=timezone.utc),
+        )
+        Scheduler(inline_schedules={"test_agent": schedule}, state_file=state_file)._save_state()
+
+        # Fresh scheduler restores from disk (lazy-created entry)
+        restored = Scheduler(state_file=state_file)
+        sched2 = restored._get_inline_schedule("test_agent")
+        assert sched2.consecutive_failures == 3
+        assert sched2.next_inline_at == datetime(2026, 2, 15, 12, 0, tzinfo=timezone.utc)
+
+
+    def test_storm_suppressed_then_recovers(self):
+        """Acceptance: many 1s ticks during an outage → few dispatches, not one per tick.
+
+        Then on recovery the inline path resumes immediately.
+        """
+        llm_down = True
+        dispatches = 0
+
+        async def _run_inline(agent_name, tasks, ts):
+            nonlocal dispatches
+            dispatches += 1
+            if llm_down:
+                raise LLMUnavailableError("llm down")
+
+        schedule = InlineSchedule(agent_name="test_agent", base_interval_minutes=1, max_backoff_minutes=60)
+        scheduler = Scheduler(
+            get_due_tasks=_one_inline_task(),
+            run_inline=_run_inline,
+            inline_schedules={"test_agent": schedule},
+        )
+
+        # 600 ticks at 1s cadence over the outage window (10 min).
+        start = datetime(2026, 2, 15, 12, 0, tzinfo=timezone.utc)
+        for i in range(600):
+            asyncio.run(scheduler._tick_tasks(start + timedelta(seconds=i)))
+
+        # Without backoff this would be 600 dispatches; with backoff it's a
+        # handful (exponential: ~2,4,8,... min apart, capped at 60).
+        assert dispatches < 15
+        outage_dispatches = dispatches
+
+        # Network recovers: next tick past next_inline_at dispatches and resets.
+        llm_down = False
+        recover_ts = schedule.next_inline_at + timedelta(seconds=1)
+        asyncio.run(scheduler._tick_tasks(recover_ts))
+        assert dispatches == outage_dispatches + 1
+        assert schedule.consecutive_failures == 0
+        assert schedule.next_inline_at is None
+
+
+# ── 失败信号契约: HeartbeatRunner.is_llm_unavailable ───────────
+
+
+class TestLLMUnavailableSignal:
+    def _runner(self, tmp_path):
+        return _make_hb_runner(tmp_path)
+
+    def test_is_llm_unavailable_false_initially(self, tmp_path):
+        runner = self._runner(tmp_path)
+        assert runner.is_llm_unavailable is False
+
+    def test_is_llm_unavailable_reflects_state(self, tmp_path):
+        runner = self._runner(tmp_path)
+        runner._llm_unavailable_since = datetime(2026, 2, 15, 12, 0)
+        assert runner.is_llm_unavailable is True
+        runner._llm_unavailable_since = None
+        assert runner.is_llm_unavailable is False
+
+
+# ── daemon._dispatch_inline 把信号翻译成 LLMUnavailableError ──
+
+
+class TestDaemonInlineDispatch:
+    def _daemon_with_runner(self, runner):
+        from types import SimpleNamespace
+        from unittest.mock import AsyncMock
+        from src.everbot.cli.daemon import EverBotDaemon
+        daemon = EverBotDaemon.__new__(EverBotDaemon)
+        daemon.heartbeat_runners = {"a": runner}
+        daemon._run_runner_with_options = AsyncMock(return_value=None)
+        return daemon
+
+    def test_raises_when_runner_llm_unavailable(self):
+        from types import SimpleNamespace
+        runner = SimpleNamespace(is_llm_unavailable=True)
+        daemon = self._daemon_with_runner(runner)
+        with pytest.raises(LLMUnavailableError):
+            asyncio.run(daemon._dispatch_inline("a"))
+
+    def test_no_raise_when_runner_available(self):
+        from types import SimpleNamespace
+        runner = SimpleNamespace(is_llm_unavailable=False)
+        daemon = self._daemon_with_runner(runner)
+        asyncio.run(daemon._dispatch_inline("a"))  # must not raise
+
+    def test_missing_runner_is_noop(self):
+        daemon = self._daemon_with_runner(None)
+        daemon.heartbeat_runners = {}
+        asyncio.run(daemon._dispatch_inline("nonexistent"))  # must not raise
+
+
+# ── 方向 3: probe 冷却 ─────────────────────────────────────────
+
+
+class TestProbeCooldown:
+    def _runner_with_client(self, tmp_path, complete_result="ok", side_effect=None):
+        from unittest.mock import AsyncMock
+        runner = _make_hb_runner(tmp_path)
+        mock_client = AsyncMock()
+        if side_effect is not None:
+            mock_client.complete = AsyncMock(side_effect=side_effect)
+        else:
+            mock_client.complete = AsyncMock(return_value=complete_result)
+        runner._create_skill_llm_client = lambda: mock_client
+        return runner, mock_client
+
+    def test_no_cooldown_when_llm_available(self, tmp_path):
+        """When not known-down, every probe hits the network."""
+        runner, client = self._runner_with_client(tmp_path)
+        assert asyncio.run(runner._probe_llm()) is True
+        assert client.complete.await_count == 1
+
+    def test_cooldown_skips_network_when_recently_failed(self, tmp_path):
+        """While known-down and within cooldown, probe returns False with no network call."""
+        runner, client = self._runner_with_client(tmp_path)
+        runner._llm_unavailable_since = datetime.now()
+        runner._last_probe_at = datetime.now()  # just probed
+        assert asyncio.run(runner._probe_llm()) is False
+        assert client.complete.await_count == 0  # network skipped
+
+    def test_probes_again_after_cooldown_window(self, tmp_path):
+        """Once cooldown elapses, the probe hits the network again."""
+        runner, client = self._runner_with_client(tmp_path)
+        runner._llm_unavailable_since = datetime.now() - timedelta(minutes=10)
+        runner._last_probe_at = datetime.now() - timedelta(seconds=120)  # > 60s default
+        assert asyncio.run(runner._probe_llm()) is True
+        assert client.complete.await_count == 1
+
+    def test_cooldown_window_configurable(self, tmp_path, monkeypatch):
+        """ALFRED_SKILL_LLM_PROBE_COOLDOWN controls the cooldown window."""
+        monkeypatch.setenv("ALFRED_SKILL_LLM_PROBE_COOLDOWN", "300")
+        runner, client = self._runner_with_client(tmp_path)
+        runner._llm_unavailable_since = datetime.now() - timedelta(minutes=10)
+        runner._last_probe_at = datetime.now() - timedelta(seconds=120)  # < 300s
+        assert asyncio.run(runner._probe_llm()) is False
+        assert client.complete.await_count == 0


### PR DESCRIPTION
Closes #78

## 问题
断网期间 `_execute_once` 的 probe 失败路径既不推进 `next_run_at` 也不抛异常,而 `scheduler._tick_tasks` 的 inline 路径无任何退避(不像 `_tick_heartbeats`/`_tick_inspector`),导致 1s tick 转化为 1s 一次 LLM 连接 —— 断网 62 分钟刷约 3200 次「开始心跳」+ probe。

## 方案(方向 2 + 3,设计定稿见 #78 正文)

**方向 2(根因)— scheduler inline 路径补对称退避**
- 新增 `InlineSchedule`(per-agent `consecutive_failures` + `next_inline_at` 指数退避),与 heartbeat/inspector 同构,持久化进 `scheduler_state.json` 的 `__inline__`。
- 失败信号:`HeartbeatRunner.is_llm_unavailable` 复用既有 `_llm_unavailable_since`;`daemon._dispatch_inline` 据此抛 `LLMUnavailableError`,scheduler 捕获后退避。
- 仅 LLM 不可用触发退避;其它单任务异常维持吞掉语义,不拖垮整个 agent 的 inline 调度。
- base interval 默认 1min(`ALFRED_INLINE_BACKOFF_BASE_MIN` 可配),封顶同 heartbeat。

**方向 3(止血)— probe 冷却**
- `_probe_llm` 在已知不可用期内,距上次 probe 不足冷却窗则跳过网络调用直接判不可用;默认 60s(`ALFRED_SKILL_LLM_PROBE_COOLDOWN` 可配),把连接尝试从每秒降到每分钟。

## 验收(对齐 #78)
1. ✅ 断网期间 inline 调度按指数退避,不再每秒触发。
2. ✅ 断网期间 LLM 连接尝试 ≤ 1/min。
3. ✅ 网络恢复后首个 tick 成功执行并清零退避。
4. ✅ 用户侧通知行为不变,后台 spin 消除。

## 测试
新增 `tests/unit/test_inline_backoff.py` 20 例:退避增长/重置/封顶/`next_inline_at` gate/非 LLM 异常不退避/懒创建/多 agent 独立/state 持久化往返/**断网风暴抑制全链路(600 ticks → <15 次派发 → 恢复)**/失败信号契约/daemon 派发/probe 冷却。

全量 unit:1793 passed,余 1 个失败为 `test_slm_segment_logger` 预存问题(与本 PR 无关,clean main 同样失败)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)