### PR TITLE
chore(cleanup): 归档两处游离 skill 改动 + 修 slm 时间炸弹测试 (#86)

### DIFF
--- a/skills/daily-attractor/scripts/main.py
+++ b/skills/daily-attractor/scripts/main.py
@@ -98,6 +98,17 @@ CASE_TEMPLATES = {
         'signal_long': 'ETF持续净流入，与黄金相关性上升',
         'signal_risk': '监管打压ETF，机构资金外流',
     },
+    '中国移动': {
+        'pricing_shift': '主题博弈资金 → 高股息配置资金',
+        'dimension_old': '5G用户数增长、ARPU值',
+        'dimension_new': '股息率、现金流稳定性、云收入占比',
+        'anchor_old': '成长股PEG（15-20x）',
+        'anchor_new': '高股息公用事业（10-15x + 60%+派息率）',
+        'catalyst': '数字经济基础设施定位，连续提升派息率至60%',
+        'signal_long': '北向资金连续增持且股息率>4%',
+        'signal_risk': '云业务增速不及预期，5G投资超预期',
+    },
+
 }
 
 

--- a/skills/web/package.json
+++ b/skills/web/package.json
@@ -23,5 +23,6 @@
   },
   "optionalDependencies": {
     "@rollup/rollup-linux-x64-gnu": "^4.0.0"
-  }
+  },
+  "packageManager": "pnpm@8.15.0+sha512.ea45517d5285d123eac02c3793505fa1fd6da90a2fc60d1e8d9e0c1e9292886ecfaff513f062b9d1cc8021bb8615033b1ac5bea3b2ee3fc165a6d7034bbe6b03"
 }

--- a/tests/unit/test_slm_segment_logger.py
+++ b/tests/unit/test_slm_segment_logger.py
@@ -1,6 +1,7 @@
 """Tests for SLM SegmentLogger."""
 
 import tempfile
+from datetime import datetime, timezone
 from pathlib import Path
 
 from src.everbot.core.slm.models import EvaluationSegment
@@ -8,10 +9,16 @@ from src.everbot.core.slm.segment_logger import SegmentLogger
 
 
 def _make_segment(skill_id="test-skill", version="1.0", session_id="s1", **kw):
+    # Default to "now" so the age-based cleanup filter (_MAX_AGE_DAYS) never
+    # silently drops fixtures as wall-clock advances. Tests that care about the
+    # timestamp pass triggered_at explicitly.
     return EvaluationSegment(
         skill_id=skill_id,
         skill_version=version,
-        triggered_at=kw.get("triggered_at", "2026-03-17T10:00:00Z"),
+        triggered_at=kw.get(
+            "triggered_at",
+            datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        ),
         context_before=kw.get("context_before", "user: help"),
         skill_output=kw.get("skill_output", "assistant: done"),
         context_after=kw.get("context_after", "user: thanks"),


### PR DESCRIPTION
## 背景

feat/43 收尾时残留的两处与主题无关的工作区改动,先前归档到本分支(#86)。本次顺手把同期发现的一个时间炸弹测试一起修掉,统一收尾。

## 改动

1. **归档两处游离 skill 改动**(commit `0d9ccc2`)
   - `skills/daily-attractor/scripts/main.py` — 新增 `中国移动` CASE_TEMPLATE(高股息重定价主题,与已有 case 同构)。
   - `skills/web/package.json` — 新增 `packageManager: pnpm@8.15.0` 声明。
2. **修 `test_slm_segment_logger` 时间炸弹**(commit `b595dec`)
   - `_make_segment` 默认 `triggered_at` 写死为 `2026-03-17`,过 90 天(`_MAX_AGE_DAYS`)后 `cleanup` 的 age 过滤会先删光全部 fixture,导致 `test_cleanup_max_entries` 断言 `removed==2` 必挂。
   - 改为默认用运行时当前 UTC 时间;关心时间戳的用例仍显式传入。产品代码无需改动。

## 验证

- `tests/unit/test_slm_segment_logger.py` 13/13 通过。
- 完整单测套件 `tests/unit` 1774 passed。

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)