### PR TITLE
feat(sidecar): 启动失败带诊断(command/exit code/stderr·stdout tail)— #91 件1

### DIFF
--- a/src/everbot/core/agent/provider/milkie/sidecar.py
+++ b/src/everbot/core/agent/provider/milkie/sidecar.py
@@ -5,23 +5,71 @@
 
 命令由调用方注入(``cmd``)而非硬编码,便于测试喂 fake 子进程、e2e 喂真
 ``milkie serve``。
+
+#91 件1:启动失败(就绪前退出 / 就绪超时)必须可诊断 —— stderr 单独捕获,异常
+``SidecarStartError`` 携带 command、exit code、stdout/stderr 末 N 行。ABI mismatch、
+``node_modules`` 缺失、native addon load failure 都打在 stderr;不捕获 → 排查时只能
+手动复现。
 """
 from __future__ import annotations
 
 import asyncio
 import logging
 import re
-from typing import List, Optional
+from collections import deque
+from typing import Deque, List, Optional
 
 logger = logging.getLogger(__name__)
 
 _READY_RE = re.compile(r"^MILKIE_SERVE_READY\s+(\d+)$")
+
+# 诊断尾部保留的行数(stdout / stderr 各自末 N 行)。
+SIDECAR_DIAG_TAIL_LINES = 20
 
 
 def parse_ready_signal(line: str) -> Optional[int]:
     """Extract the port from a ``MILKIE_SERVE_READY <port>`` line, else ``None``."""
     m = _READY_RE.match(line.strip())
     return int(m.group(1)) if m else None
+
+
+class SidecarStartError(RuntimeError):
+    """milkie serve 启动失败(就绪前退出 / 就绪超时),携带可执行诊断。
+
+    ``str(self)`` 含 command、exit code、stderr/stdout 末 N 行 —— 直接进日志即可定位
+    ABI mismatch / 依赖缺失,无需手动复现。注意:目前该 message 也会经
+    telegram_channel 透传给用户(#92 负责做用户侧降级映射)。
+    """
+
+    def __init__(
+        self,
+        reason: str,
+        *,
+        cmd: List[str],
+        returncode: Optional[int],
+        stdout_tail: List[str],
+        stderr_tail: List[str],
+    ) -> None:
+        self.reason = reason
+        self.cmd = list(cmd)
+        self.returncode = returncode
+        self.stdout_tail = list(stdout_tail)
+        self.stderr_tail = list(stderr_tail)
+        super().__init__(self._format())
+
+    def _format(self) -> str:
+        parts = [
+            self.reason,
+            f"  command: {' '.join(self.cmd)}",
+            f"  exit code: {self.returncode}",
+        ]
+        if self.stderr_tail:
+            parts.append(f"  stderr (last {len(self.stderr_tail)} lines):")
+            parts.extend(f"    {ln}" for ln in self.stderr_tail)
+        if self.stdout_tail:
+            parts.append(f"  stdout (last {len(self.stdout_tail)} lines):")
+            parts.extend(f"    {ln}" for ln in self.stdout_tail)
+        return "\n".join(parts)
 
 
 class MilkieSidecar:
@@ -39,9 +87,12 @@ class MilkieSidecar:
         self._ready_timeout = ready_timeout
         self._proc: Optional[asyncio.subprocess.Process] = None
         self.port: Optional[int] = None
-        # 就绪后持续排空 stdout 的后台任务:milkie serve 就绪后仍往 stdout 写请求日志,
+        # 就绪前读到的 stdout 行(非 ready 信号)保留末 N 行用于失败诊断。
+        self._stdout_tail: Deque[str] = deque(maxlen=SIDECAR_DIAG_TAIL_LINES)
+        # 就绪后持续排空 stdout/stderr 的后台任务:milkie serve 就绪后仍往管道写日志,
         # 不排空 → OS pipe 缓冲(~64KB)填满 → 子进程 write 阻塞 → /chat 挂死。
         self._drain_task: Optional[asyncio.Task] = None
+        self._drain_stderr_task: Optional[asyncio.Task] = None
 
     @property
     def base_url(self) -> str:
@@ -56,26 +107,40 @@ class MilkieSidecar:
             *self._cmd,
             stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,  # #91:单独捕获,失败时进诊断
             env=self._env,
         )
-        self.port = await asyncio.wait_for(self._await_ready(), self._ready_timeout)
-        # 就绪后:持续排空 stdout 到 EOF,防 pipe 缓冲填满阻塞子进程。
-        self._drain_task = asyncio.create_task(self._drain_stdout())
+        try:
+            self.port = await asyncio.wait_for(self._await_ready(), self._ready_timeout)
+        except (asyncio.TimeoutError, TimeoutError):
+            # 就绪信号超时:进程多半仍存活,kill 后采集诊断(returncode/stderr)。
+            proc = self._proc
+            if proc is not None and proc.returncode is None:
+                proc.kill()
+            raise await self._build_start_error(
+                f"milkie serve did not emit ready signal within {self._ready_timeout}s"
+            )
+        # 就绪后:持续排空 stdout/stderr 到 EOF,防 pipe 缓冲填满阻塞子进程。
+        self._drain_task = asyncio.create_task(self._drain(self._proc.stdout, "stdout"))
+        stderr = getattr(self._proc, "stderr", None)
+        if stderr is not None:
+            self._drain_stderr_task = asyncio.create_task(self._drain(stderr, "stderr"))
 
-    async def _drain_stdout(self) -> None:
-        """就绪后持续读 stdout 至 EOF(丢弃,debug 留痕)。
+    async def _drain(self, stream, label: str) -> None:
+        """就绪后持续读 stream 至 EOF(丢弃,debug 留痕)。
 
         子进程退出 → pipe EOF → readline 返回 b"" → 自然结束;close() 也会主动
         cancel。CancelledError 静默吞(正常关停路径)。"""
-        proc = self._proc
-        if proc is None or proc.stdout is None:
+        if stream is None:
             return
         try:
             while True:
-                line = await proc.stdout.readline()
+                line = await stream.readline()
                 if not line:  # EOF — 子进程已退出
                     break
-                logger.debug("milkie serve stdout: %s", line.decode("utf-8", "replace").rstrip())
+                logger.debug(
+                    "milkie serve %s: %s", label, line.decode("utf-8", "replace").rstrip()
+                )
         except asyncio.CancelledError:
             pass
 
@@ -83,22 +148,56 @@ class MilkieSidecar:
         assert self._proc is not None and self._proc.stdout is not None
         while True:
             line = await self._proc.stdout.readline()
-            if not line:  # EOF — process exited without ever signalling ready
-                raise RuntimeError("milkie serve exited before emitting ready signal")
-            port = parse_ready_signal(line.decode("utf-8", "replace"))
+            if not line:  # EOF — 进程在发出就绪信号前退出
+                raise await self._build_start_error(
+                    "milkie serve exited before emitting ready signal"
+                )
+            decoded = line.decode("utf-8", "replace")
+            port = parse_ready_signal(decoded)
             if port is not None:
                 return port
+            self._stdout_tail.append(decoded.rstrip("\n"))  # 非 ready 行 → 诊断尾部
+
+    async def _build_start_error(self, reason: str) -> SidecarStartError:
+        """采集 returncode + stderr 末 N 行,构造可诊断异常。"""
+        proc = self._proc
+        rc: Optional[int] = None
+        if proc is not None:
+            try:
+                rc = await asyncio.wait_for(proc.wait(), 2.0)
+            except (asyncio.TimeoutError, TimeoutError):
+                rc = proc.returncode
+        return SidecarStartError(
+            reason,
+            cmd=self._cmd,
+            returncode=rc,
+            stdout_tail=list(self._stdout_tail),
+            stderr_tail=await self._read_stderr_tail(),
+        )
+
+    async def _read_stderr_tail(self) -> List[str]:
+        proc = self._proc
+        stream = getattr(proc, "stderr", None) if proc is not None else None
+        if stream is None:
+            return []
+        try:
+            data = await asyncio.wait_for(stream.read(), 2.0)  # 进程已退出 → EOF,不阻塞
+        except (asyncio.TimeoutError, TimeoutError):
+            data = b""
+        lines = data.decode("utf-8", "replace").splitlines()
+        return lines[-SIDECAR_DIAG_TAIL_LINES:]
 
     async def close(self) -> None:
-        # 先停排空任务(robust:可能从未 start 过 → _drain_task is None)。
-        task = self._drain_task
-        self._drain_task = None
-        if task is not None and not task.done():
-            task.cancel()
-            try:
-                await task
-            except asyncio.CancelledError:
-                pass
+        # 先停排空任务(robust:可能从未 start 过 → task is None)。
+        for attr in ("_drain_task", "_drain_stderr_task"):
+            task = getattr(self, attr)
+            setattr(self, attr, None)
+            if task is not None and not task.done():
+                task.cancel()
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
 
         proc = self._proc
         if proc is None or proc.returncode is not None:

--- a/tests/unit/test_milkie_sidecar.py
+++ b/tests/unit/test_milkie_sidecar.py
@@ -11,7 +11,12 @@ import sys
 
 import pytest
 
-from src.everbot.core.agent.provider.milkie.sidecar import MilkieSidecar, parse_ready_signal
+from src.everbot.core.agent.provider.milkie.sidecar import (
+    MilkieSidecar,
+    SidecarStartError,
+    SIDECAR_DIAG_TAIL_LINES,
+    parse_ready_signal,
+)
 
 
 def _py(script: str) -> list[str]:
@@ -50,22 +55,97 @@ async def test_start_reads_port_from_ready_signal():
         await sc.close()
 
 
-async def test_start_times_out_when_no_ready_signal():
+async def test_start_timeout_raises_start_error_with_command_and_reason():
+    # #91 件1:就绪信号迟迟不来 → 统一抛 SidecarStartError(RuntimeError 子类),
+    # message 带 command 与「未就绪」原因。不再裸抛无信息的 TimeoutError。
     sc = MilkieSidecar(_py("import time;time.sleep(30)"), ready_timeout=0.5)
     try:
-        with pytest.raises((asyncio.TimeoutError, TimeoutError)):
+        with pytest.raises(SidecarStartError) as ei:
             await sc.start()
     finally:
         await sc.close()
+    msg = str(ei.value)
+    assert sys.executable in msg          # command 在 message 里
+    assert "ready" in msg.lower()         # 原因:未发出 ready 信号
 
 
 async def test_start_raises_if_process_exits_before_ready():
     sc = MilkieSidecar(_py("import sys;sys.exit(0)"), ready_timeout=5)
     try:
-        with pytest.raises(RuntimeError):
+        with pytest.raises(RuntimeError):  # SidecarStartError 仍是 RuntimeError 子类
             await sc.start()
     finally:
         await sc.close()
+
+
+# --- #91 件1:启动失败必须带 command / exit code / stdout·stderr tail ----------
+
+_CRASH_WITH_STDERR = (
+    "import sys;"
+    "sys.stderr.write('NODE_MODULE_VERSION 127 vs 131\\n');sys.stderr.flush();"
+    "sys.exit(3)"
+)
+
+
+async def test_start_failure_carries_command_exitcode_and_stderr_tail():
+    """ABI mismatch 场景:进程崩在 stderr、非零退出 → 异常带 command/exit code/stderr。"""
+    sc = MilkieSidecar(_py(_CRASH_WITH_STDERR), ready_timeout=5)
+    try:
+        with pytest.raises(SidecarStartError) as ei:
+            await sc.start()
+    finally:
+        await sc.close()
+    err = ei.value
+    assert err.returncode == 3
+    assert any("NODE_MODULE_VERSION 127 vs 131" in ln for ln in err.stderr_tail)
+    msg = str(err)
+    assert "NODE_MODULE_VERSION 127 vs 131" in msg   # stderr 进了 message
+    assert "exit code: 3" in msg                      # exit code 进了 message
+    assert sys.executable in msg                      # command 进了 message
+
+
+_STDOUT_THEN_CRASH = (
+    "import sys;"
+    "print('booting milkie');print('loading config');sys.stdout.flush();"
+    "sys.exit(1)"
+)
+
+
+async def test_start_failure_carries_stdout_tail():
+    """崩溃前写到 stdout 的行(非 ready 信号)也要进诊断。"""
+    sc = MilkieSidecar(_py(_STDOUT_THEN_CRASH), ready_timeout=5)
+    try:
+        with pytest.raises(SidecarStartError) as ei:
+            await sc.start()
+    finally:
+        await sc.close()
+    err = ei.value
+    assert any("loading config" in ln for ln in err.stdout_tail)
+    assert "loading config" in str(err)
+
+
+_MANY_STDERR_THEN_CRASH = (
+    "import sys\n"
+    "for i in range(100):\n"
+    "    sys.stderr.write('err line %d\\n' % i)\n"
+    "sys.stderr.flush()\n"
+    "sys.exit(2)\n"
+)
+
+
+async def test_start_failure_tail_is_bounded_to_last_n_lines():
+    """边界:海量 stderr 只保留末 N 行,丢最旧的。"""
+    sc = MilkieSidecar(_py(_MANY_STDERR_THEN_CRASH), ready_timeout=5)
+    try:
+        with pytest.raises(SidecarStartError) as ei:
+            await sc.start()
+    finally:
+        await sc.close()
+    tail = ei.value.stderr_tail
+    assert len(tail) == SIDECAR_DIAG_TAIL_LINES
+    assert tail[-1] == "err line 99"          # 最新一行在
+    assert all("err line 0\n" not in ln for ln in tail)
+    assert "err line 0" not in tail            # 最旧一行被丢弃
 
 
 async def test_close_terminates_process():


### PR DESCRIPTION
## 这是什么

#91(鲁棒性 A:sidecar 启动期 fail-fast)的 **PR1 / 件1** —— 让 milkie sidecar 启动失败可诊断。

后续 PR:件3(node_bin 绝对路径 + doctor WARN/ERROR)、件2(node_bin native deps 探针)、preflight 接入 doctor/boot。

## 背景

2026-06-21 给 demo_agent 改模型后重启,sidecar 全面起不来,telegram 连续回 `Failed to create agent: milkie serve exited before emitting ready signal`。根因是 milkie `node_modules` 被删后用错 node 版本重装,`better-sqlite3` ABI 不匹配(`NODE_MODULE_VERSION 127 vs 131`)—— 但**真正的报错在 stderr 里被冲散**,`sidecar.py` 只抛一句无信息的通用错误,排查只能手动复现。

## 改动

`src/everbot/core/agent/provider/milkie/sidecar.py`:
- 新增 **`SidecarStartError(RuntimeError)`**,携带 `cmd / returncode / stdout_tail / stderr_tail`,`str()` 输出可执行诊断(reason + command + exit code + stderr/stdout 末 N 行)。
- spawn 加 `stderr=PIPE` **单独捕获**;就绪前退出 / 就绪超时**统一**抛 `SidecarStartError`(超时先 kill 再采集 returncode + stderr)。
- `_await_ready` 记录就绪前 stdout 末 N 行入诊断;就绪后 **stdout + stderr 双排空**(防新引入的 stderr 管道填满阻塞子进程);`close()` 取消两个排空任务。
- `SIDECAR_DIAG_TAIL_LINES = 20`。

## 验收(对应 #91 件1)

启动失败异常 message 必含 **command + exit code + stdout/stderr 末 N 行** ✓

诊断 message 实样(真实崩溃命令):
```
milkie serve exited before emitting ready signal
  command: /…/node /…/milkie/dist/cli/index.js serve --agent … --port 0 …
  exit code: 3
  stderr (last N lines):
    Error: NODE_MODULE_VERSION 127 vs 131 …
```

## 测试(TDD)

先写测试 → RED(`ImportError: SidecarStartError` 功能缺失)→ 实现 → GREEN。新增覆盖:
- stderr tail / exit code / command 进异常
- 崩溃前 stdout 行进诊断
- 海量 stderr 只保留末 N 行(边界)
- 就绪超时统一抛 `SidecarStartError` 带 command 与原因

结果:`test_milkie_sidecar.py` 15 passed;上游 provider/pool/daemon_shutdown 99 passed;**全 unit 1797 passed**,无回归。

## 已知边界(留给 #92)

`str(exc)` 目前仍经 `telegram_channel.py` 透传给终端用户 —— 用户侧降级映射是 #92(运行时降级 + 带外告警)的范围。本 PR 只负责把诊断做出来(对日志正向)。

Closes #91 件1(issue 整体待件2/件3/preflight 完成后再关)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
