### PR TITLE
feat(doctor): node_bin 钉死自检(非绝对 WARN / service ERROR)— #91 件3

### DIFF
--- a/config/everbot.example.yaml
+++ b/config/everbot.example.yaml
@@ -9,7 +9,11 @@ everbot:
   # milkie:                 # provider=milkie（或任一 agent provider=milkie）时生效：
   #   dist_path: ~/dev/github/milkie/dist/cli/index.js  # milkie serve CLI 入口；默认 ../milkie/dist/cli/index.js（相对 alfred 仓库）
   #   data_dir_root: ~/.alfred/milkie  # 每个 agent 的 milkie 会话/状态持久化根目录
-  #   node_bin: node        # 启动 milkie serve 的 node 可执行（默认走 PATH 的 node）
+  #   node_bin: /opt/homebrew/bin/node  # 启动 milkie serve 的 node 可执行。
+  #                         # ⚠️ 强烈建议填**绝对路径**(#91):daemon(launchd)与交互 shell 的
+  #                         # PATH 常解析到不同 node,原生模块(better-sqlite3)按某 node 编译后,
+  #                         # 另一 node 加载即 NODE_MODULE_VERSION 不匹配崩溃。裸 `node` 走 PATH
+  #                         # → `bin/everbot doctor` 报 WARN(daemon/service 模式 ERROR)。
   #   ready_timeout: 20.0   # 等待 serve 打印 MILKIE_SERVE_READY 就绪信号的超时（秒）
 
   # Web UI 配置

--- a/src/everbot/cli/doctor.py
+++ b/src/everbot/cli/doctor.py
@@ -77,10 +77,25 @@ def collect_doctor_report(
     *,
     project_root: Path,
     alfred_home: Optional[Path] = None,
+    service_mode: bool = False,
 ) -> List[DoctorItem]:
-    """Collect doctor report items."""
+    """Collect doctor report items.
+
+    service_mode=True(daemon/service boot)对部分检查更严格(如未钉死的
+    node_bin 由 WARN 升级为 ERROR)—— #91 件3。
+    """
+    # 延迟 import 破循环:milkie_preflight 复用本模块的 DoctorItem。
+    from .milkie_preflight import check_node_bin
+
     user_data = UserDataManager(alfred_home=alfred_home)
     items: List[DoctorItem] = []
+
+    # milkie node_bin 是否显式钉死(#91 件3):非绝对路径走 PATH → ABI 漂移风险。
+    cfg = parse_yaml_file(user_data.config_path) if user_data.config_path.exists() else {}
+    node_bin = (
+        (((cfg.get("everbot") or {}).get("milkie") or {}).get("node_bin")) or "node"
+    )
+    items.append(check_node_bin(node_bin, service_mode=service_mode))
 
     # EverBot config
     if user_data.config_path.exists():

--- a/src/everbot/cli/milkie_preflight.py
+++ b/src/everbot/cli/milkie_preflight.py
@@ -1,0 +1,75 @@
+"""milkie 运行时启动期自检(#91 A)。
+
+被 ``bin/everbot doctor`` 与 daemon boot 复用,产出 :class:`DoctorItem`。本文件先落
+**件3:node_bin 显式钉死** —— 件2(native deps 探针)后续补入同一模块。
+
+为何钉死 node_bin:daemon(launchd PATH)与交互 shell(nvm 等)解析到的 ``node``
+往往不同版本,原生模块(better-sqlite3)按某个 node 编译后,另一 node 加载即
+``NODE_MODULE_VERSION`` 不匹配崩溃 —— 2026-06-21 demo_agent 改模型后 sidecar 全崩即此根因。
+裸 ``node`` 走 PATH = 只检查"当下碰巧解析到的 node",没消掉根因。
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from typing import Optional
+
+from .doctor import DoctorItem
+
+_PIN_HINT = (
+    "在 ~/.alfred/config.yaml 的 everbot.milkie.node_bin 填**绝对路径**"
+    "(如 {suggest}),确保 daemon 与重装依赖用同一个 node,避免 ABI 漂移。"
+)
+
+
+def _node_version(path: str) -> Optional[str]:
+    """best-effort 取 node 版本字符串;失败返回 None(不阻塞自检)。"""
+    try:
+        out = subprocess.run(
+            [path, "--version"], capture_output=True, text=True, timeout=5
+        )
+    except Exception:
+        return None
+    return (out.stdout or out.stderr or "").strip() or None
+
+
+def check_node_bin(node_bin: str, *, service_mode: bool = False) -> DoctorItem:
+    """校验 milkie 用的 ``node_bin`` 是否显式钉死(绝对路径)。
+
+    service_mode=True(daemon/service)对"未钉死"更严格 —— 升级为 ERROR。
+    """
+    title = "milkie node_bin"
+
+    if os.path.isabs(node_bin):
+        if os.path.isfile(node_bin) and os.access(node_bin, os.X_OK):
+            ver = _node_version(node_bin)
+            details = f"已钉死绝对路径:{node_bin}" + (f"(版本 {ver})" if ver else "")
+            return DoctorItem(level="OK", title=title, details=details)
+        return DoctorItem(
+            level="ERROR",
+            title=title,
+            details=f"配置的绝对路径 node_bin 不存在或不可执行:{node_bin}",
+            hint=_PIN_HINT.format(suggest=shutil.which("node") or "/opt/homebrew/bin/node"),
+        )
+
+    # 非绝对路径:走 PATH 解析 —— 根因未消除。
+    resolved = shutil.which(node_bin)
+    suggest = resolved or "/opt/homebrew/bin/node"
+    if resolved is None:
+        return DoctorItem(
+            level="ERROR",
+            title=title,
+            details=f"node_bin '{node_bin}' 非绝对路径,且当前 PATH 中找不到。",
+            hint=_PIN_HINT.format(suggest=suggest),
+        )
+    level = "ERROR" if service_mode else "WARN"
+    return DoctorItem(
+        level=level,
+        title=title,
+        details=(
+            f"node_bin '{node_bin}' 未钉死(走 PATH 解析)。"
+            f"当前解析到:{resolved}。daemon 与 shell 的 PATH 可能解析到不同 node。"
+        ),
+        hint=_PIN_HINT.format(suggest=suggest),
+    )

--- a/tests/unit/test_doctor.py
+++ b/tests/unit/test_doctor.py
@@ -1,10 +1,39 @@
 """Doctor report tests."""
 
 from pathlib import Path
+import sys
 import tempfile
 
 from src.everbot.cli.doctor import collect_doctor_report
 from src.everbot.infra.user_data import UserDataManager
+
+
+def test_doctor_includes_node_bin_check_ok_for_absolute(tmp_path):
+    """#91 件3:doctor 报告 milkie node_bin;绝对可执行路径 → OK。"""
+    home = tmp_path / ".alfred"
+    home.mkdir(parents=True)
+    (home / "config.yaml").write_text(
+        f"everbot:\n  milkie:\n    node_bin: {sys.executable}\n", encoding="utf-8"
+    )
+    items = collect_doctor_report(project_root=tmp_path, alfred_home=home)
+    node_items = [i for i in items if i.title == "milkie node_bin"]
+    assert len(node_items) == 1
+    assert node_items[0].level == "OK"
+    assert sys.executable in node_items[0].details
+
+
+def test_doctor_service_mode_errors_on_unpinned_node_bin(tmp_path):
+    """#91 件3:service 模式下未钉死(裸 node)→ ERROR。"""
+    home = tmp_path / ".alfred"
+    home.mkdir(parents=True)
+    (home / "config.yaml").write_text(
+        "everbot:\n  milkie:\n    node_bin: node\n", encoding="utf-8"
+    )
+    items = collect_doctor_report(
+        project_root=tmp_path, alfred_home=home, service_mode=True
+    )
+    node_items = [i for i in items if i.title == "milkie node_bin"]
+    assert node_items and node_items[0].level == "ERROR"
 
 
 def test_doctor_reports_missing_config_and_agents_dir():

--- a/tests/unit/test_milkie_preflight.py
+++ b/tests/unit/test_milkie_preflight.py
@@ -1,0 +1,57 @@
+"""TDD #91 件3:node_bin 必须显式钉死(绝对路径)。
+
+daemon(launchd)与交互 shell 的 PATH 不同,裸 ``node`` 会解析到不同 node →
+原生模块 ABI 漂移(2026-06-21 demo_agent 崩因)。doctor 据此校验:
+- 绝对路径且可执行 → OK;
+- 绝对路径但不存在 → ERROR;
+- 非绝对路径(走 PATH)→ 交互 WARN / service 模式 ERROR,并报告当前解析到的绝对路径;
+- 非绝对路径且 PATH 里找不到 → ERROR。
+"""
+import sys
+
+from src.everbot.cli.milkie_preflight import check_node_bin
+from src.everbot.cli.doctor import DoctorItem
+
+
+def test_absolute_existing_node_bin_is_ok():
+    # 用 sys.executable 充当"绝对路径且可执行的二进制"
+    item = check_node_bin(sys.executable, service_mode=False)
+    assert isinstance(item, DoctorItem)
+    assert item.level == "OK"
+    assert sys.executable in item.details
+
+
+def test_absolute_missing_node_bin_is_error():
+    item = check_node_bin("/no/such/path/node", service_mode=False)
+    assert item.level == "ERROR"
+    assert "/no/such/path/node" in item.details
+    assert item.hint and "node_bin" in item.hint
+
+
+def test_bare_node_bin_warns_in_interactive_mode(monkeypatch):
+    monkeypatch.setattr(
+        "src.everbot.cli.milkie_preflight.shutil.which", lambda n: "/usr/local/bin/node"
+    )
+    item = check_node_bin("node", service_mode=False)
+    assert item.level == "WARN"
+    assert "/usr/local/bin/node" in item.details   # 报告当前解析到的绝对路径
+    assert item.hint and "node_bin" in item.hint    # 提示去 config 钉死
+
+
+def test_bare_node_bin_errors_in_service_mode(monkeypatch):
+    monkeypatch.setattr(
+        "src.everbot.cli.milkie_preflight.shutil.which", lambda n: "/usr/local/bin/node"
+    )
+    # service 模式下即便能解析到,也必须 ERROR —— 根因(未钉死)没消掉。
+    item = check_node_bin("node", service_mode=True)
+    assert item.level == "ERROR"
+    assert "/usr/local/bin/node" in item.details
+
+
+def test_bare_node_bin_unresolvable_is_error(monkeypatch):
+    monkeypatch.setattr(
+        "src.everbot.cli.milkie_preflight.shutil.which", lambda n: None
+    )
+    item = check_node_bin("node", service_mode=False)
+    assert item.level == "ERROR"
+    assert item.hint and "node_bin" in item.hint


### PR DESCRIPTION
## 这是什么

#91(鲁棒性 A)的 **PR2 / 件3** —— node_bin 显式钉死自检。独立于 PR1(#95,件1),可单独合。

后续:件2(node_bin native deps 探针,复用本 PR 新建的 `milkie_preflight.py`)、preflight 接入 daemon boot(以 `service_mode=True` 调 doctor)。

## 背景

daemon(launchd PATH)与交互 shell(nvm 等)常解析到**不同版本的 node**。原生模块 `better-sqlite3` 按某个 node 编译后,另一个 node 加载即 `NODE_MODULE_VERSION` 不匹配崩溃 —— 2026-06-21 demo_agent 改模型后 sidecar 全崩的根因。裸 `node` 走 PATH = 只检查"当下碰巧解析到的 node",根因没消掉。

## 改动

- **新增 `src/everbot/cli/milkie_preflight.py`** —— `check_node_bin(node_bin, *, service_mode)`,产出 `DoctorItem`:
  - 绝对路径且可执行 → **OK**(附 node 版本);
  - 绝对路径但不存在/不可执行 → **ERROR**;
  - 非绝对路径(走 PATH)→ 交互 **WARN** / service 模式 **ERROR**,诊断输出**当前解析到的绝对路径** + 钉死建议;
  - 非绝对且 PATH 找不到 → **ERROR**。
- `doctor.collect_doctor_report` 增 `service_mode` 参数并接入该检查(延迟 import 破 `milkie_preflight ↔ doctor` 循环)。
- `config/everbot.example.yaml`:`node_bin` 注释改为推荐**绝对路径**并说明 ABI 漂移风险。

## 验收(对应 #91 件3)

`bin/everbot doctor` 真实输出(本机):
```
! [WARN] milkie node_bin: node_bin 'node' 未钉死(走 PATH 解析)。
    当前解析到:/Users/…/.nvm/versions/node/v22.22.3/bin/node。daemon 与 shell 的 PATH 可能解析到不同 node。
    Hint: 在 ~/.alfred/config.yaml 的 everbot.milkie.node_bin 填绝对路径(如 …),确保 daemon 与重装依赖用同一个 node,避免 ABI 漂移。
```
注:doctor 在交互 shell 解析到 nvm v22,而 daemon 会解析到 homebrew v23 —— 正是这次崩溃的漂移。该检查在场即可一眼定位。

## 测试(TDD)

先写测试 → RED(模块缺失 / `service_mode` 参数缺失)→ 实现 → GREEN。
- `check_node_bin` 5 例:绝对存在/缺失、裸名交互 WARN / service ERROR / 不可解析。
- doctor 2 例:绝对路径 OK、service 模式裸名 ERROR。

结果:**全 unit 1801 passed**,无回归。

## 范围说明

daemon boot 以 `service_mode=True` 实际调用 doctor(把未钉死升级为 ERROR + fail-fast)归 **PR4(preflight 接入 boot)**。本 PR 只落地检查能力 + 交互 doctor 接入。

关联 #91(件3)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
