### PR TITLE
feat(doctor): native deps 探针(node_bin 实测 require)— #91 件2 [stacked on #96]

### DIFF
--- a/src/everbot/cli/doctor.py
+++ b/src/everbot/cli/doctor.py
@@ -85,17 +85,28 @@ def collect_doctor_report(
     node_bin 由 WARN 升级为 ERROR)—— #91 件3。
     """
     # 延迟 import 破循环:milkie_preflight 复用本模块的 DoctorItem。
-    from .milkie_preflight import check_node_bin
+    from .milkie_preflight import check_node_bin, probe_native_deps
 
     user_data = UserDataManager(alfred_home=alfred_home)
     items: List[DoctorItem] = []
 
     # milkie node_bin 是否显式钉死(#91 件3):非绝对路径走 PATH → ABI 漂移风险。
     cfg = parse_yaml_file(user_data.config_path) if user_data.config_path.exists() else {}
-    node_bin = (
-        (((cfg.get("everbot") or {}).get("milkie") or {}).get("node_bin")) or "node"
-    )
+    milkie_cfg = ((cfg.get("everbot") or {}).get("milkie") or {})
+    node_bin = milkie_cfg.get("node_bin") or "node"
     items.append(check_node_bin(node_bin, service_mode=service_mode))
+
+    # milkie native deps 实测探针(#91 件2):用同款 node_bin 跑 require('better-sqlite3'),
+    # 覆盖 node_modules 缺失 / ABI 不匹配 / 动态库加载失败。milkie 未安装 → 返回 None 跳过。
+    dist = milkie_cfg.get("dist_path")
+    milkie_root = (
+        Path(dist).expanduser().parents[2]  # …/milkie/dist/cli/index.js → …/milkie
+        if dist
+        else (project_root.parent / "milkie")
+    )
+    probe_item = probe_native_deps(node_bin, milkie_root)
+    if probe_item is not None:
+        items.append(probe_item)
 
     # EverBot config
     if user_data.config_path.exists():

--- a/src/everbot/cli/milkie_preflight.py
+++ b/src/everbot/cli/milkie_preflight.py
@@ -13,9 +13,13 @@ from __future__ import annotations
 import os
 import shutil
 import subprocess
-from typing import Optional
+from pathlib import Path
+from typing import List, Optional, Tuple
 
 from .doctor import DoctorItem
+
+# 诊断尾部保留行数(与 sidecar 诊断对齐)。
+_DIAG_TAIL_LINES = 20
 
 _PIN_HINT = (
     "在 ~/.alfred/config.yaml 的 everbot.milkie.node_bin 填**绝对路径**"
@@ -72,4 +76,105 @@ def check_node_bin(node_bin: str, *, service_mode: bool = False) -> DoctorItem:
             f"当前解析到:{resolved}。daemon 与 shell 的 PATH 可能解析到不同 node。"
         ),
         hint=_PIN_HINT.format(suggest=suggest),
+    )
+
+
+# --- 件2:native deps 探针 ----------------------------------------------------
+#
+# 用 daemon 同款 node_bin 实测在 milkie 包上下文 require('better-sqlite3')。一条探针
+# 同时覆盖:node_modules 缺失(Cannot find module)、ABI 不匹配(NODE_MODULE_VERSION)、
+# 动态库加载失败(dlopen/.node/image not found)。比"只扫目录"或"抽象比版本号"更真。
+
+# require 解析相对 cwd 的 node_modules;故 _run_probe 以 milkie 包根为 cwd。
+_PROBE_JS = (
+    "console.log('MILKIE_DEPS_ABI ' + process.version + ' ' + process.versions.modules);"
+    "require('better-sqlite3');"
+    "console.log('MILKIE_DEPS_OK');"
+)
+
+_PROBE_TITLE = "milkie native deps"
+
+
+def _run_probe(node_bin: str, cwd: str) -> Tuple[int, str, str]:
+    """跑一次 node -e 探针,返回 (returncode, stdout, stderr)。seam:测试可 monkeypatch。"""
+    out = subprocess.run(
+        [node_bin, "-e", _PROBE_JS],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+    return out.returncode, out.stdout, out.stderr
+
+
+def _tail(text: str) -> str:
+    lines = [ln for ln in text.splitlines() if ln.strip()]
+    return "\n".join(lines[-_DIAG_TAIL_LINES:])
+
+
+def probe_native_deps(node_bin: str, milkie_root) -> Optional[DoctorItem]:
+    """实测 better-sqlite3 能否被 node_bin 加载。
+
+    milkie 目录整体不存在 → 返回 None(provider 未用 milkie,无需探测)。
+    成功 → OK(带 node 版本/ABI);失败 → ERROR,按 stderr 给可执行修复命令。
+    """
+    root = Path(milkie_root)
+    if not root.exists():
+        return None
+
+    try:
+        rc, out, err = _run_probe(node_bin, str(root))
+    except Exception as e:  # node 不存在 / 无法执行
+        return DoctorItem(
+            level="ERROR",
+            title=_PROBE_TITLE,
+            details=f"native deps 探针无法执行({node_bin}):{e}",
+            hint="确认 everbot.milkie.node_bin 指向可用的 node 可执行(见上一项 node_bin 检查)。",
+        )
+
+    blob = f"{out}\n{err}"
+
+    if rc == 0 and "MILKIE_DEPS_OK" in out:
+        abi = next(
+            (ln for ln in out.splitlines() if ln.startswith("MILKIE_DEPS_ABI")),
+            "MILKIE_DEPS_ABI ?",
+        )
+        return DoctorItem(
+            level="OK",
+            title=_PROBE_TITLE,
+            details=f"better-sqlite3 加载正常({abi.replace('MILKIE_DEPS_ABI ', 'node ')})",
+        )
+
+    if "NODE_MODULE_VERSION" in blob:
+        return DoctorItem(
+            level="ERROR",
+            title=_PROBE_TITLE,
+            details=_tail(err) or _tail(blob),
+            hint=(
+                f"原生模块 ABI 与 {node_bin} 不匹配 → 用该 node 对应的 npm 跑:"
+                f"(cd {root} && npm rebuild better-sqlite3)"
+            ),
+        )
+
+    if "Cannot find module" in blob:
+        return DoctorItem(
+            level="ERROR",
+            title=_PROBE_TITLE,
+            details=_tail(err) or _tail(blob),
+            hint=f"milkie 依赖缺失/不全 → 用 {node_bin} 对应的 npm 跑:(cd {root} && npm ci)",
+        )
+
+    if any(k in blob for k in ("dlopen", ".node", "image not found", "dylib", "shared library", "undefined symbol")):
+        return DoctorItem(
+            level="ERROR",
+            title=_PROBE_TITLE,
+            details=_tail(err) or _tail(blob),
+            hint=f"原生模块动态库加载失败 → 用 {node_bin} 重装/重编:(cd {root} && npm rebuild better-sqlite3)",
+        )
+
+    return DoctorItem(
+        level="ERROR",
+        title=_PROBE_TITLE,
+        details=_tail(blob) or f"探针非零退出(exit {rc}),无 stderr 输出。",
+        hint=f"手动复现:(cd {root} && {node_bin} -e \"require('better-sqlite3')\")",
     )

--- a/tests/unit/test_doctor.py
+++ b/tests/unit/test_doctor.py
@@ -4,8 +4,29 @@ from pathlib import Path
 import sys
 import tempfile
 
-from src.everbot.cli.doctor import collect_doctor_report
+from src.everbot.cli.doctor import collect_doctor_report, DoctorItem
 from src.everbot.infra.user_data import UserDataManager
+
+
+def test_doctor_wires_native_deps_probe(tmp_path, monkeypatch):
+    """#91 件2:doctor 调 probe_native_deps,其产出的 item 进报告。"""
+    home = tmp_path / ".alfred"
+    home.mkdir(parents=True)
+    (home / "config.yaml").write_text(
+        f"everbot:\n  milkie:\n    node_bin: {sys.executable}\n", encoding="utf-8"
+    )
+    from src.everbot.cli import milkie_preflight
+
+    monkeypatch.setattr(
+        milkie_preflight,
+        "probe_native_deps",
+        lambda node_bin, milkie_root: DoctorItem(
+            level="OK", title="milkie native deps", details="probed"
+        ),
+    )
+    items = collect_doctor_report(project_root=tmp_path, alfred_home=home)
+    probe_items = [i for i in items if i.title == "milkie native deps"]
+    assert len(probe_items) == 1 and probe_items[0].details == "probed"
 
 
 def test_doctor_includes_node_bin_check_ok_for_absolute(tmp_path):

--- a/tests/unit/test_milkie_preflight.py
+++ b/tests/unit/test_milkie_preflight.py
@@ -9,7 +9,7 @@ daemon(launchd)与交互 shell 的 PATH 不同,裸 ``node`` 会解析到不同 n
 """
 import sys
 
-from src.everbot.cli.milkie_preflight import check_node_bin
+from src.everbot.cli.milkie_preflight import check_node_bin, probe_native_deps
 from src.everbot.cli.doctor import DoctorItem
 
 
@@ -55,3 +55,72 @@ def test_bare_node_bin_unresolvable_is_error(monkeypatch):
     item = check_node_bin("node", service_mode=False)
     assert item.level == "ERROR"
     assert item.hint and "node_bin" in item.hint
+
+
+# --- #91 件2:native deps 探针(用 node_bin 实测 require('better-sqlite3'))-------
+#
+# 用 monkeypatch 替换 _run_probe(避免依赖真 node / 真 better-sqlite3),聚焦
+# "退出码+stdout+stderr → DoctorItem" 的映射逻辑。
+
+def _patch_probe(monkeypatch, rc, out, err):
+    monkeypatch.setattr(
+        "src.everbot.cli.milkie_preflight._run_probe",
+        lambda node_bin, cwd: (rc, out, err),
+    )
+
+
+def test_probe_ok(monkeypatch, tmp_path):
+    _patch_probe(monkeypatch, 0, "MILKIE_DEPS_ABI v23.11.0 131\nMILKIE_DEPS_OK\n", "")
+    item = probe_native_deps("/opt/homebrew/bin/node", tmp_path)
+    assert item.level == "OK"
+    assert "131" in item.details  # ABI 进 details
+
+
+def test_probe_abi_mismatch_hints_rebuild(monkeypatch, tmp_path):
+    err = (
+        "Error: The module 'better_sqlite3.node' was compiled against a different "
+        "Node.js version using NODE_MODULE_VERSION 127. This version of Node.js "
+        "requires NODE_MODULE_VERSION 131."
+    )
+    _patch_probe(monkeypatch, 1, "", err)
+    item = probe_native_deps("/opt/homebrew/bin/node", tmp_path)
+    assert item.level == "ERROR"
+    assert "NODE_MODULE_VERSION" in item.details          # 真实 stderr 进诊断
+    assert item.hint and "npm rebuild better-sqlite3" in item.hint
+
+
+def test_probe_missing_module_hints_npm_ci(monkeypatch, tmp_path):
+    _patch_probe(monkeypatch, 1, "", "Error: Cannot find module 'better-sqlite3'")
+    item = probe_native_deps("/opt/homebrew/bin/node", tmp_path)
+    assert item.level == "ERROR"
+    assert item.hint and "npm ci" in item.hint
+
+
+def test_probe_dylib_load_failure_is_error(monkeypatch, tmp_path):
+    err = "dlopen(.../better_sqlite3.node): Library not loaded: ... image not found"
+    _patch_probe(monkeypatch, 1, "", err)
+    item = probe_native_deps("/opt/homebrew/bin/node", tmp_path)
+    assert item.level == "ERROR"
+    assert "image not found" in item.details
+
+
+def test_probe_generic_nonzero_is_error(monkeypatch, tmp_path):
+    _patch_probe(monkeypatch, 1, "", "some unexpected failure")
+    item = probe_native_deps("/opt/homebrew/bin/node", tmp_path)
+    assert item.level == "ERROR"
+
+
+def test_probe_skipped_when_milkie_root_absent(tmp_path):
+    # milkie 整个目录不存在(provider 未用 milkie)→ 跳过,不产 item。
+    item = probe_native_deps("/opt/homebrew/bin/node", tmp_path / "no_such_milkie")
+    assert item is None
+
+
+def test_probe_runner_exception_is_error(monkeypatch, tmp_path):
+    def _boom(node_bin, cwd):
+        raise FileNotFoundError("node not found")
+
+    monkeypatch.setattr("src.everbot.cli.milkie_preflight._run_probe", _boom)
+    item = probe_native_deps("/opt/homebrew/bin/node", tmp_path)
+    assert item.level == "ERROR"
+    assert "node not found" in item.details


### PR DESCRIPTION
## 这是什么

#91(鲁棒性 A)的 **PR3 / 件2** —— native deps 实测探针。

⚠️ **Stacked on #96(件3)** —— base 分支是 `feat/91-pin-node-bin`,**请先合 #96 再合本 PR**(否则 diff 会包含 #96 的提交)。复用 #96 新建的 `milkie_preflight.py`。

## 背景

2026-06-21 demo_agent 改模型后 sidecar 全崩,根因是 `better-sqlite3` 的 `NODE_MODULE_VERSION` 与 daemon 所用 node 不匹配 —— 当时只能手动 `node -e "require('better-sqlite3')"` 才看到。本 PR 把这个"一句话定位"的手段固化成自检。

## 改动

- **`milkie_preflight.probe_native_deps(node_bin, milkie_root)`**:用 **daemon 同款 node_bin** 在 milkie 包上下文实跑 `require('better-sqlite3')`(`node -e`,cwd=milkie 根),按结果映射:
  - 成功 → **OK**(附 node 版本 + ABI);
  - `NODE_MODULE_VERSION` → **ERROR**,hint `npm rebuild better-sqlite3`;
  - `Cannot find module` → **ERROR**,hint `npm ci`;
  - 动态库加载失败(`dlopen`/`.node`/`image not found`/…)→ **ERROR**;
  - 其它非零 → **ERROR**(带手动复现命令);
  - milkie 未安装(目录不存在)→ **跳过**(返回 None)。
  - `_run_probe` 为测试 seam。
- `doctor.collect_doctor_report` 接入(`milkie_root` 取 config `dist_path` 或默认 `../milkie`)。

一条探针同时覆盖 **node_modules 缺失 / ABI 不匹配 / 动态库加载失败** —— 比只扫目录或抽象比版本号更真。

## 验收(对应 #91 件2)

真实验证(同一磁盘 better-sqlite3,不同 node):
```
nvm node v22.22.3   → OK  better-sqlite3 加载正常(node v22.22.3 127)
homebrew node v23.11 → OK  better-sqlite3 加载正常(node v23.11.0 131)
```
探针给出**每个 node 的真实可加载性**(多 ABI prebuild 各取所需)。当初崩溃正是某一刻只有 127 产物、node 23 无匹配 —— 该探针在场即一眼命中。

## 测试(TDD)

先写测试 → RED(`probe_native_deps` 缺失 / doctor 未接入)→ 实现 → GREEN。
- probe 7 例:OK、ABI 不匹配(hint rebuild)、缺模块(hint npm ci)、动态库失败、通用非零、milkie 缺失跳过、runner 抛异常。
- doctor 接入 1 例(monkeypatch 注入 probe,断言 item 进报告)。

结果:**全 unit 1809 passed**,无回归。

## 范围说明

daemon boot 以 `service_mode=True` 调 doctor + fail-fast 归 **PR4(preflight 接入 boot)**。

关联 #91(件2)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
