### PR TITLE
feat(daemon): boot 期 preflight + native deps fail-fast — #91 PR4 [stacked on #97]

### DIFF
--- a/src/everbot/cli/daemon.py
+++ b/src/everbot/cli/daemon.py
@@ -663,6 +663,20 @@ class EverBotDaemon:
 
     # -- Lifecycle ----------------------------------------------------------
 
+    def _run_milkie_boot_preflight(self) -> None:
+        """#91 PR4:启动期全局静态 preflight(node_bin + native deps)。
+
+        native deps 真失败(所有 sidecar 必死)→ raise 拒绝启动(fail-fast,见上方
+        [preflight] 诊断);node_bin 未钉死走 WARN 不阻塞。#92 告警通道就绪后,这里可
+        升级为"单 agent 降级 + 带外告警"而非整体 fail-fast。"""
+        from .milkie_preflight import enforce_boot_preflight
+
+        project_root = Path(
+            os.environ.get("ALFRED_PROJECT_ROOT")
+            or Path(__file__).resolve().parents[3]
+        )
+        enforce_boot_preflight(self.config, project_root, logger)
+
     async def start(self):
         """启动守护进程"""
         # Singleton guard: acquire exclusive file lock before anything else.
@@ -679,6 +693,7 @@ class EverBotDaemon:
 
         try:
             await self._init_components()
+            self._run_milkie_boot_preflight()
             self._validate_env_refs()
             self._enable_fault_handler()
             self._report_previous_unexpected_exit()

--- a/src/everbot/cli/milkie_preflight.py
+++ b/src/everbot/cli/milkie_preflight.py
@@ -178,3 +178,52 @@ def probe_native_deps(node_bin: str, milkie_root) -> Optional[DoctorItem]:
         details=_tail(blob) or f"探针非零退出(exit {rc}),无 stderr 输出。",
         hint=f"手动复现:(cd {root} && {node_bin} -e \"require('better-sqlite3')\")",
     )
+
+
+# --- daemon boot 接入(#91 PR4)----------------------------------------------
+#
+# boot 只做**全局静态 preflight**(node_bin + native deps),不在 boot 全量真 spawn
+# 各 agent sidecar(那会拖慢启动、写 agent.md/data-dir)。fail-fast 策略:仅当 native
+# deps 真失败(deps 加载不了 → 所有 sidecar 必死)才拒绝启动;node_bin 未钉死是
+# advisory(WARN),deps 能加载就说明当前 node 可用,不阻塞 boot。
+
+
+def resolve_node_bin_and_milkie_root(config: dict, project_root) -> Tuple[str, Path]:
+    """从 everbot.milkie 配置解析 (node_bin, milkie 包根) —— 与 provider 装配同源。"""
+    milkie_cfg = ((config.get("everbot") or {}).get("milkie") or {})
+    node_bin = milkie_cfg.get("node_bin") or "node"
+    dist = milkie_cfg.get("dist_path")
+    milkie_root = (
+        Path(dist).expanduser().parents[2]  # …/milkie/dist/cli/index.js → …/milkie
+        if dist
+        else (Path(project_root).parent / "milkie")
+    )
+    return node_bin, milkie_root
+
+
+def run_boot_preflight(node_bin: str, milkie_root) -> Tuple[List[DoctorItem], bool]:
+    """跑全局静态 preflight,返回 (findings, fatal)。
+
+    fatal 仅由 native deps 真失败决定;node_bin 未钉死走 WARN(不致命)。
+    """
+    findings: List[DoctorItem] = [check_node_bin(node_bin, service_mode=False)]
+    probe = probe_native_deps(node_bin, milkie_root)
+    if probe is not None:
+        findings.append(probe)
+    fatal = any(f.title == _PROBE_TITLE and f.level == "ERROR" for f in findings)
+    return findings, fatal
+
+
+def enforce_boot_preflight(config: dict, project_root, log) -> None:
+    """daemon boot 调用:跑 preflight、按级别打日志,native deps 致命则 raise 拒绝启动。"""
+    node_bin, milkie_root = resolve_node_bin_and_milkie_root(config, project_root)
+    findings, fatal = run_boot_preflight(node_bin, milkie_root)
+    for f in findings:
+        emit = {"ERROR": log.error, "WARN": log.warning}.get(f.level, log.info)
+        emit("[preflight] %s: %s", f.title, f.details)
+        if f.hint and f.level != "OK":
+            emit("[preflight]   修复: %s", f.hint)
+    if fatal:
+        raise RuntimeError(
+            "milkie native deps preflight 失败,拒绝启动(见上方 [preflight] 诊断)"
+        )

--- a/tests/unit/test_daemon_boot_preflight.py
+++ b/tests/unit/test_daemon_boot_preflight.py
@@ -1,0 +1,42 @@
+"""#91 PR4:daemon boot 接入 milkie preflight。
+
+验证 daemon._run_milkie_boot_preflight 把 self.config 传给 enforce_boot_preflight,
+且 native deps 致命时异常向上传播(start() 据此拒绝启动 → fail-fast)。
+"""
+import pytest
+
+from src.everbot.cli import daemon as daemon_module
+
+
+def _make_daemon(tmp_path):
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(
+        "everbot:\n  enabled: true\n  milkie:\n    node_bin: /opt/homebrew/bin/node\n",
+        encoding="utf-8",
+    )
+    return daemon_module.EverBotDaemon(config_path=str(cfg))
+
+
+def test_boot_preflight_invoked_with_daemon_config(tmp_path, monkeypatch):
+    d = _make_daemon(tmp_path)
+    captured = {}
+    monkeypatch.setattr(
+        "src.everbot.cli.milkie_preflight.enforce_boot_preflight",
+        lambda config, project_root, log: captured.update(config=config, log=log),
+    )
+    d._run_milkie_boot_preflight()
+    assert captured["config"] is d.config
+    assert captured["log"] is daemon_module.logger
+
+
+def test_boot_preflight_fatal_propagates(tmp_path, monkeypatch):
+    d = _make_daemon(tmp_path)
+
+    def _raise(config, project_root, log):
+        raise RuntimeError("preflight fatal")
+
+    monkeypatch.setattr(
+        "src.everbot.cli.milkie_preflight.enforce_boot_preflight", _raise
+    )
+    with pytest.raises(RuntimeError, match="preflight fatal"):
+        d._run_milkie_boot_preflight()

--- a/tests/unit/test_milkie_preflight.py
+++ b/tests/unit/test_milkie_preflight.py
@@ -124,3 +124,108 @@ def test_probe_runner_exception_is_error(monkeypatch, tmp_path):
     item = probe_native_deps("/opt/homebrew/bin/node", tmp_path)
     assert item.level == "ERROR"
     assert "node not found" in item.details
+
+
+# --- #91 PR4:daemon boot preflight(解析 + 决策 + fail-fast)--------------------
+
+from pathlib import Path as _Path  # noqa: E402
+
+from src.everbot.cli.milkie_preflight import (  # noqa: E402
+    resolve_node_bin_and_milkie_root,
+    run_boot_preflight,
+    enforce_boot_preflight,
+)
+
+
+def test_resolve_defaults_to_node_and_sibling_milkie(tmp_path):
+    node_bin, milkie_root = resolve_node_bin_and_milkie_root({}, tmp_path / "alfred")
+    assert node_bin == "node"
+    assert milkie_root == (tmp_path / "milkie")  # project_root.parent / milkie
+
+
+def test_resolve_reads_config_node_bin_and_dist_path():
+    cfg = {
+        "everbot": {
+            "milkie": {
+                "node_bin": "/opt/homebrew/bin/node",
+                "dist_path": "/x/milkie/dist/cli/index.js",
+            }
+        }
+    }
+    node_bin, milkie_root = resolve_node_bin_and_milkie_root(cfg, _Path("/x/alfred"))
+    assert node_bin == "/opt/homebrew/bin/node"
+    assert milkie_root == _Path("/x/milkie")
+
+
+def test_boot_preflight_fatal_on_native_deps_error(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "src.everbot.cli.milkie_preflight.probe_native_deps",
+        lambda nb, mr: DoctorItem(level="ERROR", title="milkie native deps", details="ABI"),
+    )
+    findings, fatal = run_boot_preflight("/opt/homebrew/bin/node", tmp_path)
+    assert fatal is True
+
+
+def test_boot_preflight_not_fatal_when_unpinned_but_deps_ok(monkeypatch, tmp_path):
+    # node_bin 裸名(WARN)但 deps 能加载 → 不致命(当前 node 可用,只是没钉死)。
+    monkeypatch.setattr(
+        "src.everbot.cli.milkie_preflight.shutil.which", lambda n: "/usr/bin/node"
+    )
+    monkeypatch.setattr(
+        "src.everbot.cli.milkie_preflight.probe_native_deps",
+        lambda nb, mr: DoctorItem(level="OK", title="milkie native deps", details="ok"),
+    )
+    findings, fatal = run_boot_preflight("node", tmp_path)
+    assert fatal is False
+    assert any(f.title == "milkie node_bin" and f.level == "WARN" for f in findings)
+
+
+def test_boot_preflight_not_fatal_when_milkie_absent(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "src.everbot.cli.milkie_preflight.probe_native_deps", lambda nb, mr: None
+    )
+    findings, fatal = run_boot_preflight("/opt/homebrew/bin/node", tmp_path)
+    assert fatal is False
+
+
+class _FakeLog:
+    def __init__(self):
+        self.calls = []
+
+    def error(self, *a):
+        self.calls.append(("error", a))
+
+    def warning(self, *a):
+        self.calls.append(("warning", a))
+
+    def info(self, *a):
+        self.calls.append(("info", a))
+
+
+def test_enforce_boot_preflight_raises_on_fatal(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "src.everbot.cli.milkie_preflight.run_boot_preflight",
+        lambda nb, mr: (
+            [DoctorItem(level="ERROR", title="milkie native deps", details="ABI", hint="rebuild")],
+            True,
+        ),
+    )
+    log = _FakeLog()
+    import pytest as _pytest
+    with _pytest.raises(RuntimeError):
+        enforce_boot_preflight({}, tmp_path / "alfred", log)
+    # 致命诊断必须被 error 出来
+    assert any(lvl == "error" for lvl, _ in log.calls)
+
+
+def test_enforce_boot_preflight_returns_when_not_fatal(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "src.everbot.cli.milkie_preflight.run_boot_preflight",
+        lambda nb, mr: (
+            [DoctorItem(level="WARN", title="milkie node_bin", details="unpinned", hint="pin it")],
+            False,
+        ),
+    )
+    log = _FakeLog()
+    enforce_boot_preflight({}, tmp_path / "alfred", log)  # must NOT raise
+    assert any(lvl == "warning" for lvl, _ in log.calls)


### PR DESCRIPTION
## 这是什么

#91(鲁棒性 A)的 **PR4 / 收尾** —— 把 preflight 接进 daemon 启动,环境问题在 boot 当场拦下。

⚠️ **Stacked on #97 → #96** —— base 分支 `feat/91-native-deps-probe`。**合并顺序:#96 → #97 → 本 PR**。

## 改动

- `milkie_preflight`:
  - `resolve_node_bin_and_milkie_root(config, project_root)` —— 与 provider 装配同源解析。
  - `run_boot_preflight(node_bin, milkie_root) → (findings, fatal)` —— 跑 node_bin 检查 + native deps 探针。
  - `enforce_boot_preflight(config, project_root, log)` —— 按级别打日志,致命则 raise。
- `daemon.start()`:`_init_components()` 后调 `_run_milkie_boot_preflight()`;致命异常经既有 `except` 收敛 → 拒绝进入 serve。

## fail-fast 策略(对评审决策③的细化,请重点看)

只对 **native deps 真失败**(deps 加载不了 → 所有 sidecar 必死)fail-fast;**node_bin 未钉死走 WARN 不阻塞**(deps 能加载就说明当前 node 可用,只是有漂移风险)。

理由:若把"未钉死"也设为 boot-fatal,当前**未设 `node_bin` 的常见配置(含本机)会让 daemon 直接起不来**,把加固变成 brick。native deps 探针用的就是实际 node_bin,真实漂移(node 解析到加载不了 deps 的版本)会被它捕获 → fatal。所以"未钉死"留 advisory 足矣。

> #92 告警通道就绪后,这里可从"整体 fail-fast"升级为"单 agent 降级 + 带外告警"。

## boot 范围(对评审决策④的落实)

boot 只做**全局静态 preflight**(node_bin + native deps,单点无副作用);**不**在 boot 全量真 spawn 各 agent sidecar(那会拖慢启动、写 agent.md/data-dir)。真 spawn 仍走首次 `create_agent` 惰性路径,#95(件1)的诊断在该路径兜底。

## 验收

真实 config dry-run(模拟 daemon 启动那一步):
```
WARNING [preflight] milkie node_bin: node_bin 'node' 未钉死(走 PATH 解析)。当前解析到:…/nvm/…/v22.22.3/bin/node …
WARNING [preflight]   修复: 在 ~/.alfred/config.yaml 的 everbot.milkie.node_bin 填绝对路径 …
INFO    [preflight] milkie native deps: better-sqlite3 加载正常(node v22.22.3 127)
>>> RESULT: boot 会继续(未 fail-fast)
```
即:未钉死告警、deps 正常 → 不 brick;deps 若真坏则 boot 拒绝 + [preflight] 诊断直指修复命令。

## 测试(TDD)

先写测试 → RED → 实现 → GREEN。
- `resolve` 2 例(默认 / 读 config)。
- `run_boot_preflight` 3 例(native deps 致命 / 未钉死但 deps OK 不致命 / milkie 缺失不致命)。
- `enforce_boot_preflight` 2 例(致命 raise + error 日志 / 非致命返回 + warning 日志)。
- daemon wiring 2 例(传 self.config + logger / fatal 异常向上传播)。

结果:**全 unit 1818 passed**,无回归。

至此 #91 四件套(件1 #95 / 件3 #96 / 件2 #97 / boot 接入 本 PR)全部就位。

关联 #91。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
