### PR TITLE
fix(#91): 补合件2(native deps 探针)+ PR4(boot fail-fast)到 main

### DIFF
--- a/src/everbot/cli/daemon.py
+++ b/src/everbot/cli/daemon.py
@@ -663,6 +663,20 @@ class EverBotDaemon:
 
     # -- Lifecycle ----------------------------------------------------------
 
+    def _run_milkie_boot_preflight(self) -> None:
+        """#91 PR4:启动期全局静态 preflight(node_bin + native deps)。
+
+        native deps 真失败(所有 sidecar 必死)→ raise 拒绝启动(fail-fast,见上方
+        [preflight] 诊断);node_bin 未钉死走 WARN 不阻塞。#92 告警通道就绪后,这里可
+        升级为"单 agent 降级 + 带外告警"而非整体 fail-fast。"""
+        from .milkie_preflight import enforce_boot_preflight
+
+        project_root = Path(
+            os.environ.get("ALFRED_PROJECT_ROOT")
+            or Path(__file__).resolve().parents[3]
+        )
+        enforce_boot_preflight(self.config, project_root, logger)
+
     async def start(self):
         """启动守护进程"""
         # Singleton guard: acquire exclusive file lock before anything else.
@@ -679,6 +693,7 @@ class EverBotDaemon:
 
         try:
             await self._init_components()
+            self._run_milkie_boot_preflight()
             self._validate_env_refs()
             self._enable_fault_handler()
             self._report_previous_unexpected_exit()

--- a/src/everbot/cli/doctor.py
+++ b/src/everbot/cli/doctor.py
@@ -85,17 +85,28 @@ def collect_doctor_report(
     node_bin 由 WARN 升级为 ERROR)—— #91 件3。
     """
     # 延迟 import 破循环:milkie_preflight 复用本模块的 DoctorItem。
-    from .milkie_preflight import check_node_bin
+    from .milkie_preflight import check_node_bin, probe_native_deps
 
     user_data = UserDataManager(alfred_home=alfred_home)
     items: List[DoctorItem] = []
 
     # milkie node_bin 是否显式钉死(#91 件3):非绝对路径走 PATH → ABI 漂移风险。
     cfg = parse_yaml_file(user_data.config_path) if user_data.config_path.exists() else {}
-    node_bin = (
-        (((cfg.get("everbot") or {}).get("milkie") or {}).get("node_bin")) or "node"
-    )
+    milkie_cfg = ((cfg.get("everbot") or {}).get("milkie") or {})
+    node_bin = milkie_cfg.get("node_bin") or "node"
     items.append(check_node_bin(node_bin, service_mode=service_mode))
+
+    # milkie native deps 实测探针(#91 件2):用同款 node_bin 跑 require('better-sqlite3'),
+    # 覆盖 node_modules 缺失 / ABI 不匹配 / 动态库加载失败。milkie 未安装 → 返回 None 跳过。
+    dist = milkie_cfg.get("dist_path")
+    milkie_root = (
+        Path(dist).expanduser().parents[2]  # …/milkie/dist/cli/index.js → …/milkie
+        if dist
+        else (project_root.parent / "milkie")
+    )
+    probe_item = probe_native_deps(node_bin, milkie_root)
+    if probe_item is not None:
+        items.append(probe_item)
 
     # EverBot config
     if user_data.config_path.exists():

--- a/src/everbot/cli/milkie_preflight.py
+++ b/src/everbot/cli/milkie_preflight.py
@@ -178,3 +178,52 @@ def probe_native_deps(node_bin: str, milkie_root) -> Optional[DoctorItem]:
         details=_tail(blob) or f"探针非零退出(exit {rc}),无 stderr 输出。",
         hint=f"手动复现:(cd {root} && {node_bin} -e \"require('better-sqlite3')\")",
     )
+
+
+# --- daemon boot 接入(#91 PR4)----------------------------------------------
+#
+# boot 只做**全局静态 preflight**(node_bin + native deps),不在 boot 全量真 spawn
+# 各 agent sidecar(那会拖慢启动、写 agent.md/data-dir)。fail-fast 策略:仅当 native
+# deps 真失败(deps 加载不了 → 所有 sidecar 必死)才拒绝启动;node_bin 未钉死是
+# advisory(WARN),deps 能加载就说明当前 node 可用,不阻塞 boot。
+
+
+def resolve_node_bin_and_milkie_root(config: dict, project_root) -> Tuple[str, Path]:
+    """从 everbot.milkie 配置解析 (node_bin, milkie 包根) —— 与 provider 装配同源。"""
+    milkie_cfg = ((config.get("everbot") or {}).get("milkie") or {})
+    node_bin = milkie_cfg.get("node_bin") or "node"
+    dist = milkie_cfg.get("dist_path")
+    milkie_root = (
+        Path(dist).expanduser().parents[2]  # …/milkie/dist/cli/index.js → …/milkie
+        if dist
+        else (Path(project_root).parent / "milkie")
+    )
+    return node_bin, milkie_root
+
+
+def run_boot_preflight(node_bin: str, milkie_root) -> Tuple[List[DoctorItem], bool]:
+    """跑全局静态 preflight,返回 (findings, fatal)。
+
+    fatal 仅由 native deps 真失败决定;node_bin 未钉死走 WARN(不致命)。
+    """
+    findings: List[DoctorItem] = [check_node_bin(node_bin, service_mode=False)]
+    probe = probe_native_deps(node_bin, milkie_root)
+    if probe is not None:
+        findings.append(probe)
+    fatal = any(f.title == _PROBE_TITLE and f.level == "ERROR" for f in findings)
+    return findings, fatal
+
+
+def enforce_boot_preflight(config: dict, project_root, log) -> None:
+    """daemon boot 调用:跑 preflight、按级别打日志,native deps 致命则 raise 拒绝启动。"""
+    node_bin, milkie_root = resolve_node_bin_and_milkie_root(config, project_root)
+    findings, fatal = run_boot_preflight(node_bin, milkie_root)
+    for f in findings:
+        emit = {"ERROR": log.error, "WARN": log.warning}.get(f.level, log.info)
+        emit("[preflight] %s: %s", f.title, f.details)
+        if f.hint and f.level != "OK":
+            emit("[preflight]   修复: %s", f.hint)
+    if fatal:
+        raise RuntimeError(
+            "milkie native deps preflight 失败,拒绝启动(见上方 [preflight] 诊断)"
+        )

--- a/src/everbot/cli/milkie_preflight.py
+++ b/src/everbot/cli/milkie_preflight.py
@@ -13,9 +13,13 @@ from __future__ import annotations
 import os
 import shutil
 import subprocess
-from typing import Optional
+from pathlib import Path
+from typing import List, Optional, Tuple
 
 from .doctor import DoctorItem
+
+# 诊断尾部保留行数(与 sidecar 诊断对齐)。
+_DIAG_TAIL_LINES = 20
 
 _PIN_HINT = (
     "在 ~/.alfred/config.yaml 的 everbot.milkie.node_bin 填**绝对路径**"
@@ -72,4 +76,105 @@ def check_node_bin(node_bin: str, *, service_mode: bool = False) -> DoctorItem:
             f"当前解析到:{resolved}。daemon 与 shell 的 PATH 可能解析到不同 node。"
         ),
         hint=_PIN_HINT.format(suggest=suggest),
+    )
+
+
+# --- 件2:native deps 探针 ----------------------------------------------------
+#
+# 用 daemon 同款 node_bin 实测在 milkie 包上下文 require('better-sqlite3')。一条探针
+# 同时覆盖:node_modules 缺失(Cannot find module)、ABI 不匹配(NODE_MODULE_VERSION)、
+# 动态库加载失败(dlopen/.node/image not found)。比"只扫目录"或"抽象比版本号"更真。
+
+# require 解析相对 cwd 的 node_modules;故 _run_probe 以 milkie 包根为 cwd。
+_PROBE_JS = (
+    "console.log('MILKIE_DEPS_ABI ' + process.version + ' ' + process.versions.modules);"
+    "require('better-sqlite3');"
+    "console.log('MILKIE_DEPS_OK');"
+)
+
+_PROBE_TITLE = "milkie native deps"
+
+
+def _run_probe(node_bin: str, cwd: str) -> Tuple[int, str, str]:
+    """跑一次 node -e 探针,返回 (returncode, stdout, stderr)。seam:测试可 monkeypatch。"""
+    out = subprocess.run(
+        [node_bin, "-e", _PROBE_JS],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+    return out.returncode, out.stdout, out.stderr
+
+
+def _tail(text: str) -> str:
+    lines = [ln for ln in text.splitlines() if ln.strip()]
+    return "\n".join(lines[-_DIAG_TAIL_LINES:])
+
+
+def probe_native_deps(node_bin: str, milkie_root) -> Optional[DoctorItem]:
+    """实测 better-sqlite3 能否被 node_bin 加载。
+
+    milkie 目录整体不存在 → 返回 None(provider 未用 milkie,无需探测)。
+    成功 → OK(带 node 版本/ABI);失败 → ERROR,按 stderr 给可执行修复命令。
+    """
+    root = Path(milkie_root)
+    if not root.exists():
+        return None
+
+    try:
+        rc, out, err = _run_probe(node_bin, str(root))
+    except Exception as e:  # node 不存在 / 无法执行
+        return DoctorItem(
+            level="ERROR",
+            title=_PROBE_TITLE,
+            details=f"native deps 探针无法执行({node_bin}):{e}",
+            hint="确认 everbot.milkie.node_bin 指向可用的 node 可执行(见上一项 node_bin 检查)。",
+        )
+
+    blob = f"{out}\n{err}"
+
+    if rc == 0 and "MILKIE_DEPS_OK" in out:
+        abi = next(
+            (ln for ln in out.splitlines() if ln.startswith("MILKIE_DEPS_ABI")),
+            "MILKIE_DEPS_ABI ?",
+        )
+        return DoctorItem(
+            level="OK",
+            title=_PROBE_TITLE,
+            details=f"better-sqlite3 加载正常({abi.replace('MILKIE_DEPS_ABI ', 'node ')})",
+        )
+
+    if "NODE_MODULE_VERSION" in blob:
+        return DoctorItem(
+            level="ERROR",
+            title=_PROBE_TITLE,
+            details=_tail(err) or _tail(blob),
+            hint=(
+                f"原生模块 ABI 与 {node_bin} 不匹配 → 用该 node 对应的 npm 跑:"
+                f"(cd {root} && npm rebuild better-sqlite3)"
+            ),
+        )
+
+    if "Cannot find module" in blob:
+        return DoctorItem(
+            level="ERROR",
+            title=_PROBE_TITLE,
+            details=_tail(err) or _tail(blob),
+            hint=f"milkie 依赖缺失/不全 → 用 {node_bin} 对应的 npm 跑:(cd {root} && npm ci)",
+        )
+
+    if any(k in blob for k in ("dlopen", ".node", "image not found", "dylib", "shared library", "undefined symbol")):
+        return DoctorItem(
+            level="ERROR",
+            title=_PROBE_TITLE,
+            details=_tail(err) or _tail(blob),
+            hint=f"原生模块动态库加载失败 → 用 {node_bin} 重装/重编:(cd {root} && npm rebuild better-sqlite3)",
+        )
+
+    return DoctorItem(
+        level="ERROR",
+        title=_PROBE_TITLE,
+        details=_tail(blob) or f"探针非零退出(exit {rc}),无 stderr 输出。",
+        hint=f"手动复现:(cd {root} && {node_bin} -e \"require('better-sqlite3')\")",
     )

--- a/tests/unit/test_daemon_boot_preflight.py
+++ b/tests/unit/test_daemon_boot_preflight.py
@@ -1,0 +1,42 @@
+"""#91 PR4:daemon boot 接入 milkie preflight。
+
+验证 daemon._run_milkie_boot_preflight 把 self.config 传给 enforce_boot_preflight,
+且 native deps 致命时异常向上传播(start() 据此拒绝启动 → fail-fast)。
+"""
+import pytest
+
+from src.everbot.cli import daemon as daemon_module
+
+
+def _make_daemon(tmp_path):
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(
+        "everbot:\n  enabled: true\n  milkie:\n    node_bin: /opt/homebrew/bin/node\n",
+        encoding="utf-8",
+    )
+    return daemon_module.EverBotDaemon(config_path=str(cfg))
+
+
+def test_boot_preflight_invoked_with_daemon_config(tmp_path, monkeypatch):
+    d = _make_daemon(tmp_path)
+    captured = {}
+    monkeypatch.setattr(
+        "src.everbot.cli.milkie_preflight.enforce_boot_preflight",
+        lambda config, project_root, log: captured.update(config=config, log=log),
+    )
+    d._run_milkie_boot_preflight()
+    assert captured["config"] is d.config
+    assert captured["log"] is daemon_module.logger
+
+
+def test_boot_preflight_fatal_propagates(tmp_path, monkeypatch):
+    d = _make_daemon(tmp_path)
+
+    def _raise(config, project_root, log):
+        raise RuntimeError("preflight fatal")
+
+    monkeypatch.setattr(
+        "src.everbot.cli.milkie_preflight.enforce_boot_preflight", _raise
+    )
+    with pytest.raises(RuntimeError, match="preflight fatal"):
+        d._run_milkie_boot_preflight()

--- a/tests/unit/test_doctor.py
+++ b/tests/unit/test_doctor.py
@@ -4,8 +4,29 @@ from pathlib import Path
 import sys
 import tempfile
 
-from src.everbot.cli.doctor import collect_doctor_report
+from src.everbot.cli.doctor import collect_doctor_report, DoctorItem
 from src.everbot.infra.user_data import UserDataManager
+
+
+def test_doctor_wires_native_deps_probe(tmp_path, monkeypatch):
+    """#91 件2:doctor 调 probe_native_deps,其产出的 item 进报告。"""
+    home = tmp_path / ".alfred"
+    home.mkdir(parents=True)
+    (home / "config.yaml").write_text(
+        f"everbot:\n  milkie:\n    node_bin: {sys.executable}\n", encoding="utf-8"
+    )
+    from src.everbot.cli import milkie_preflight
+
+    monkeypatch.setattr(
+        milkie_preflight,
+        "probe_native_deps",
+        lambda node_bin, milkie_root: DoctorItem(
+            level="OK", title="milkie native deps", details="probed"
+        ),
+    )
+    items = collect_doctor_report(project_root=tmp_path, alfred_home=home)
+    probe_items = [i for i in items if i.title == "milkie native deps"]
+    assert len(probe_items) == 1 and probe_items[0].details == "probed"
 
 
 def test_doctor_includes_node_bin_check_ok_for_absolute(tmp_path):

--- a/tests/unit/test_milkie_preflight.py
+++ b/tests/unit/test_milkie_preflight.py
@@ -124,3 +124,108 @@ def test_probe_runner_exception_is_error(monkeypatch, tmp_path):
     item = probe_native_deps("/opt/homebrew/bin/node", tmp_path)
     assert item.level == "ERROR"
     assert "node not found" in item.details
+
+
+# --- #91 PR4:daemon boot preflight(解析 + 决策 + fail-fast)--------------------
+
+from pathlib import Path as _Path  # noqa: E402
+
+from src.everbot.cli.milkie_preflight import (  # noqa: E402
+    resolve_node_bin_and_milkie_root,
+    run_boot_preflight,
+    enforce_boot_preflight,
+)
+
+
+def test_resolve_defaults_to_node_and_sibling_milkie(tmp_path):
+    node_bin, milkie_root = resolve_node_bin_and_milkie_root({}, tmp_path / "alfred")
+    assert node_bin == "node"
+    assert milkie_root == (tmp_path / "milkie")  # project_root.parent / milkie
+
+
+def test_resolve_reads_config_node_bin_and_dist_path():
+    cfg = {
+        "everbot": {
+            "milkie": {
+                "node_bin": "/opt/homebrew/bin/node",
+                "dist_path": "/x/milkie/dist/cli/index.js",
+            }
+        }
+    }
+    node_bin, milkie_root = resolve_node_bin_and_milkie_root(cfg, _Path("/x/alfred"))
+    assert node_bin == "/opt/homebrew/bin/node"
+    assert milkie_root == _Path("/x/milkie")
+
+
+def test_boot_preflight_fatal_on_native_deps_error(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "src.everbot.cli.milkie_preflight.probe_native_deps",
+        lambda nb, mr: DoctorItem(level="ERROR", title="milkie native deps", details="ABI"),
+    )
+    findings, fatal = run_boot_preflight("/opt/homebrew/bin/node", tmp_path)
+    assert fatal is True
+
+
+def test_boot_preflight_not_fatal_when_unpinned_but_deps_ok(monkeypatch, tmp_path):
+    # node_bin 裸名(WARN)但 deps 能加载 → 不致命(当前 node 可用,只是没钉死)。
+    monkeypatch.setattr(
+        "src.everbot.cli.milkie_preflight.shutil.which", lambda n: "/usr/bin/node"
+    )
+    monkeypatch.setattr(
+        "src.everbot.cli.milkie_preflight.probe_native_deps",
+        lambda nb, mr: DoctorItem(level="OK", title="milkie native deps", details="ok"),
+    )
+    findings, fatal = run_boot_preflight("node", tmp_path)
+    assert fatal is False
+    assert any(f.title == "milkie node_bin" and f.level == "WARN" for f in findings)
+
+
+def test_boot_preflight_not_fatal_when_milkie_absent(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "src.everbot.cli.milkie_preflight.probe_native_deps", lambda nb, mr: None
+    )
+    findings, fatal = run_boot_preflight("/opt/homebrew/bin/node", tmp_path)
+    assert fatal is False
+
+
+class _FakeLog:
+    def __init__(self):
+        self.calls = []
+
+    def error(self, *a):
+        self.calls.append(("error", a))
+
+    def warning(self, *a):
+        self.calls.append(("warning", a))
+
+    def info(self, *a):
+        self.calls.append(("info", a))
+
+
+def test_enforce_boot_preflight_raises_on_fatal(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "src.everbot.cli.milkie_preflight.run_boot_preflight",
+        lambda nb, mr: (
+            [DoctorItem(level="ERROR", title="milkie native deps", details="ABI", hint="rebuild")],
+            True,
+        ),
+    )
+    log = _FakeLog()
+    import pytest as _pytest
+    with _pytest.raises(RuntimeError):
+        enforce_boot_preflight({}, tmp_path / "alfred", log)
+    # 致命诊断必须被 error 出来
+    assert any(lvl == "error" for lvl, _ in log.calls)
+
+
+def test_enforce_boot_preflight_returns_when_not_fatal(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "src.everbot.cli.milkie_preflight.run_boot_preflight",
+        lambda nb, mr: (
+            [DoctorItem(level="WARN", title="milkie node_bin", details="unpinned", hint="pin it")],
+            False,
+        ),
+    )
+    log = _FakeLog()
+    enforce_boot_preflight({}, tmp_path / "alfred", log)  # must NOT raise
+    assert any(lvl == "warning" for lvl, _ in log.calls)

--- a/tests/unit/test_milkie_preflight.py
+++ b/tests/unit/test_milkie_preflight.py
@@ -9,7 +9,7 @@ daemon(launchd)与交互 shell 的 PATH 不同,裸 ``node`` 会解析到不同 n
 """
 import sys
 
-from src.everbot.cli.milkie_preflight import check_node_bin
+from src.everbot.cli.milkie_preflight import check_node_bin, probe_native_deps
 from src.everbot.cli.doctor import DoctorItem
 
 
@@ -55,3 +55,72 @@ def test_bare_node_bin_unresolvable_is_error(monkeypatch):
     item = check_node_bin("node", service_mode=False)
     assert item.level == "ERROR"
     assert item.hint and "node_bin" in item.hint
+
+
+# --- #91 件2:native deps 探针(用 node_bin 实测 require('better-sqlite3'))-------
+#
+# 用 monkeypatch 替换 _run_probe(避免依赖真 node / 真 better-sqlite3),聚焦
+# "退出码+stdout+stderr → DoctorItem" 的映射逻辑。
+
+def _patch_probe(monkeypatch, rc, out, err):
+    monkeypatch.setattr(
+        "src.everbot.cli.milkie_preflight._run_probe",
+        lambda node_bin, cwd: (rc, out, err),
+    )
+
+
+def test_probe_ok(monkeypatch, tmp_path):
+    _patch_probe(monkeypatch, 0, "MILKIE_DEPS_ABI v23.11.0 131\nMILKIE_DEPS_OK\n", "")
+    item = probe_native_deps("/opt/homebrew/bin/node", tmp_path)
+    assert item.level == "OK"
+    assert "131" in item.details  # ABI 进 details
+
+
+def test_probe_abi_mismatch_hints_rebuild(monkeypatch, tmp_path):
+    err = (
+        "Error: The module 'better_sqlite3.node' was compiled against a different "
+        "Node.js version using NODE_MODULE_VERSION 127. This version of Node.js "
+        "requires NODE_MODULE_VERSION 131."
+    )
+    _patch_probe(monkeypatch, 1, "", err)
+    item = probe_native_deps("/opt/homebrew/bin/node", tmp_path)
+    assert item.level == "ERROR"
+    assert "NODE_MODULE_VERSION" in item.details          # 真实 stderr 进诊断
+    assert item.hint and "npm rebuild better-sqlite3" in item.hint
+
+
+def test_probe_missing_module_hints_npm_ci(monkeypatch, tmp_path):
+    _patch_probe(monkeypatch, 1, "", "Error: Cannot find module 'better-sqlite3'")
+    item = probe_native_deps("/opt/homebrew/bin/node", tmp_path)
+    assert item.level == "ERROR"
+    assert item.hint and "npm ci" in item.hint
+
+
+def test_probe_dylib_load_failure_is_error(monkeypatch, tmp_path):
+    err = "dlopen(.../better_sqlite3.node): Library not loaded: ... image not found"
+    _patch_probe(monkeypatch, 1, "", err)
+    item = probe_native_deps("/opt/homebrew/bin/node", tmp_path)
+    assert item.level == "ERROR"
+    assert "image not found" in item.details
+
+
+def test_probe_generic_nonzero_is_error(monkeypatch, tmp_path):
+    _patch_probe(monkeypatch, 1, "", "some unexpected failure")
+    item = probe_native_deps("/opt/homebrew/bin/node", tmp_path)
+    assert item.level == "ERROR"
+
+
+def test_probe_skipped_when_milkie_root_absent(tmp_path):
+    # milkie 整个目录不存在(provider 未用 milkie)→ 跳过,不产 item。
+    item = probe_native_deps("/opt/homebrew/bin/node", tmp_path / "no_such_milkie")
+    assert item is None
+
+
+def test_probe_runner_exception_is_error(monkeypatch, tmp_path):
+    def _boom(node_bin, cwd):
+        raise FileNotFoundError("node not found")
+
+    monkeypatch.setattr("src.everbot.cli.milkie_preflight._run_probe", _boom)
+    item = probe_native_deps("/opt/homebrew/bin/node", tmp_path)
+    assert item.level == "ERROR"
+    assert "node not found" in item.details


### PR DESCRIPTION
## 修复 stacked PR 漏合:把件2(#97)+ PR4(#98)补进 main

#97、#98 虽被标记 MERGED,但它们的 base 是**中间分支**(#97→`feat/91-pin-node-bin`、#98→`feat/91-native-deps-probe`),底层 #96 合入 main 后这些 PR 实际 merge 进了已废弃的中间分支,**内容没进 main**。main 当前只有件1(#95)+件3(#96)。

本 PR 从 `feat/91-boot-preflight` → **main**,一次补齐缺失的两块:
- **件2(原 #97)**:`milkie_preflight.probe_native_deps` —— node_bin 实测 `require('better-sqlite3')`,覆盖 node_modules 缺失 / ABI 不匹配 / 动态库加载失败;接入 `doctor`。
- **PR4(原 #98)**:daemon boot 期 preflight + native deps fail-fast(node_bin 未钉死走 WARN 不阻塞)。

设计/评审见 #91 评论。两块均已 TDD 实现并验证。

## 验证

- 与最新 main 干净合并(无冲突,仅 6 文件:milkie_preflight/doctor/daemon + 三个测试)。
- 合并态跑 preflight+doctor+daemon+sidecar 测试:43 passed(件1~PR4 共存一致)。

关联 #91。取代漏合的 #97、#98。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
