### PR TITLE
feat(channels): agent 不可用时不向用户泄漏内部诊断 — #92 件A

### DIFF
--- a/src/everbot/channels/telegram_channel.py
+++ b/src/everbot/channels/telegram_channel.py
@@ -24,6 +24,7 @@ try:
 except ImportError:
     HAS_TELEGRAMIFY = False
 
+from .user_messages import AGENT_UNAVAILABLE
 from ..core.channel.core_service import ChannelCoreService
 from ..core.channel.models import OutboundMessage
 from ..core.channel.session_resolver import ChannelSessionResolver
@@ -615,8 +616,10 @@ class TelegramChannel:
                 agent = await self._agent_service.create_agent_instance(agent_name)
                 self._session_manager.cache_agent(session_id, agent, agent_name, "auto")
             except Exception as exc:
-                logger.error("Failed to create agent %s: %s", agent_name, exc)
-                await self._send_message(chat_id, f"Failed to create agent: {exc}")
+                # #92:富诊断(SidecarStartError 含 command/stderr/ABI)只进日志,
+                # 绝不透传给用户;用户只见友好文案。
+                logger.error("Failed to create agent %s: %s", agent_name, exc, exc_info=True)
+                await self._send_message(chat_id, AGENT_UNAVAILABLE)
                 return
 
         # Register Telegram skillkit so the agent can send files/photos

--- a/src/everbot/channels/user_messages.py
+++ b/src/everbot/channels/user_messages.py
@@ -1,0 +1,8 @@
+"""面向终端用户的标准文案(#92 件A)。
+
+内部异常(SidecarStartError 等富诊断)绝不透传给用户 —— channel 边界统一回这些
+友好文案,富诊断只进日志。集中一处,保证 telegram/web 口径一致。
+"""
+
+# agent/sidecar 起不来或不可用时对用户的统一提示。
+AGENT_UNAVAILABLE = "助手暂时不可用,已记录诊断,请稍后重试。"

--- a/src/everbot/web/services/chat_service.py
+++ b/src/everbot/web/services/chat_service.py
@@ -17,6 +17,7 @@ from fastapi import WebSocket
 from ...core.agent.provider import provider_for
 
 from .agent_service import AgentService
+from ...channels.user_messages import AGENT_UNAVAILABLE
 from ...core.channel.core_service import ChannelCoreService
 from ...core.channel.models import OutboundMessage
 from ...core.runtime.events import resolve_routing
@@ -259,10 +260,11 @@ class ChatService:
                     logger.debug("Failed to check context: %s", e)
 
             except ValueError as e:
+                # #92:富诊断只进日志,用户只见友好文案。
                 logger.warning("Agent ValueError for %s: %s", agent_name, e, exc_info=True)
                 await websocket.send_json({
                     "type": "error",
-                    "content": f"Agent {agent_name} 初始化失败: {e}"
+                    "content": AGENT_UNAVAILABLE,
                 })
                 await websocket.close()
                 return
@@ -271,7 +273,7 @@ class ChatService:
                 logger.error("Agent initialization error:\n%s", error_detail)
                 await websocket.send_json({
                     "type": "error",
-                    "content": f"Agent 初始化失败: {str(e)}"
+                    "content": AGENT_UNAVAILABLE,
                 })
                 await websocket.close()
                 return

--- a/tests/unit/test_channel_error_no_leak.py
+++ b/tests/unit/test_channel_error_no_leak.py
@@ -1,0 +1,121 @@
+"""#92 件A:sidecar/agent 不可用时,内部诊断不得透传给终端用户。
+
+#91 让 SidecarStartError 带 command/stderr/ABI 富诊断(且进日志);本测试钉住:
+telegram 与 web 两个 channel 边界对用户**只发友好文案**,富诊断只进日志。
+"""
+import asyncio
+import json
+import logging
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.everbot.core.agent.provider.milkie.sidecar import SidecarStartError
+from src.everbot.channels.user_messages import AGENT_UNAVAILABLE
+
+_SECRET = "NODE_MODULE_VERSION 127 vs 131 :: /opt/homebrew/bin/node :: stderr-secret"
+
+
+def _boom() -> SidecarStartError:
+    return SidecarStartError(
+        "milkie serve exited before emitting ready signal",
+        cmd=["/opt/homebrew/bin/node", "/x/milkie/dist/cli/index.js"],
+        returncode=3,
+        stdout_tail=["booting milkie"],
+        stderr_tail=[_SECRET],
+    )
+
+
+# --- telegram 边界 ----------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_telegram_create_failure_shows_friendly_msg_not_internal(tmp_path, caplog):
+    from src.everbot.channels.telegram_channel import TelegramChannel
+
+    sm = MagicMock()
+    sm.get_cached_agent.return_value = None
+    ch = TelegramChannel(bot_token="123:FAKE", session_manager=sm, default_agent="demo_agent")
+    ch._bindings = {"111": "demo_agent"}
+    ch._agent_service.create_agent_instance = AsyncMock(side_effect=_boom())
+    ch._send_message = AsyncMock(return_value=True)
+
+    with caplog.at_level(logging.ERROR):
+        await ch._handle_message("111", "hi", {})
+
+    # 用户侧:只发友好文案,绝不含内部诊断
+    ch._send_message.assert_awaited_once()
+    sent_text = ch._send_message.await_args.args[1]
+    assert sent_text == AGENT_UNAVAILABLE
+    assert _SECRET not in sent_text
+    assert "NODE_MODULE_VERSION" not in sent_text
+    # 富诊断仍进日志
+    assert _SECRET in caplog.text
+
+
+# --- web 边界 ---------------------------------------------------------------
+
+class _ScriptedWS:
+    def __init__(self):
+        self.sent: list[dict] = []
+        self.closed = False
+        self._messages = [{"message": "hello"}]
+
+    async def accept(self):
+        pass
+
+    async def send_json(self, payload: dict):
+        self.sent.append(payload)
+
+    async def receive_json(self):
+        await asyncio.sleep(0.01)
+        if self._messages:
+            return self._messages.pop(0)
+        raise RuntimeError("disconnect")
+
+    async def close(self):
+        self.closed = True
+
+
+def _make_service_raising(tmp_path, exc):
+    from src.everbot.web.services.chat_service import ChatService
+    from src.everbot.core.channel.core_service import ChannelCoreService
+    from src.everbot.core.session.session import SessionManager
+
+    service = ChatService.__new__(ChatService)
+    service._active_connections = {}
+    service._connections_by_agent = {}
+    service._last_activity = {}
+    service._last_agent_broadcast = {}
+    service._bootstrap_locks = {}
+    service.user_data = SimpleNamespace(
+        sessions_dir=tmp_path,
+        get_session_trajectory_path=lambda a, s: tmp_path / f"{a}_{s}.jsonl",
+    )
+    service.session_manager = SessionManager(tmp_path)
+
+    async def create_agent_instance(agent_name):  # noqa: ARG001
+        raise exc
+
+    service.agent_service = SimpleNamespace(create_agent_instance=create_agent_instance)
+    service._core = ChannelCoreService(service.session_manager, service.agent_service, service.user_data)
+    return service
+
+
+@pytest.mark.asyncio
+async def test_web_create_failure_shows_friendly_msg_not_internal(tmp_path, caplog):
+    service = _make_service_raising(tmp_path, _boom())
+    ws = _ScriptedWS()
+
+    with caplog.at_level(logging.ERROR):
+        await service.handle_chat_session(ws, "demo_agent", requested_session_id="web_x")
+
+    blob = json.dumps(ws.sent, ensure_ascii=False)
+    # 用户侧:任何下发 payload 都不得含内部诊断
+    assert _SECRET not in blob
+    assert "NODE_MODULE_VERSION" not in blob
+    # 仍发了 error 帧 + 友好文案
+    err_frames = [p for p in ws.sent if p.get("type") == "error"]
+    assert err_frames and any(AGENT_UNAVAILABLE in (p.get("content") or "") for p in err_frames)
+    # 富诊断仍进日志
+    assert _SECRET in caplog.text


### PR DESCRIPTION
## #92(B)定稿范围:只做用户侧不泄漏(不做带外告警/熔断,评审定:过度工程)

#91 让 sidecar 启动失败带富诊断(command/stderr/ABI),但 channel 边界把异常原文发给了用户。本 PR 改为富诊断只进日志、用户只见友好文案。

## 改动
- 新增 `channels/user_messages.py`:`AGENT_UNAVAILABLE` 统一文案(telegram/web 口径一致)。
- `telegram_channel.py:619`、`web/services/chat_service.py`(ValueError + Exception 两分支):用户消息改为 `AGENT_UNAVAILABLE`,异常走 `logger.error(..., exc_info=True)`。

## 测试(TDD)
RED(`user_messages` 缺失)→ 实现 → GREEN。telegram + web 各一例:断言用户消息**不含** `NODE_MODULE_VERSION`/command/stderr 且为友好文案,富诊断仍进 ERROR 日志。channel 套件 144 passed。

定稿见 #92 body。关联 #92。

🤖 Generated with [Claude Code](https://claude.com/claude-code)