### PR TITLE
feat(status): restart 核验 + status 展示生效/配置模型与 stale — #93

### DIFF
--- a/bin/everbot
+++ b/bin/everbot
@@ -390,7 +390,23 @@ case "${cmd}" in
           _svc_target="gui/$(id -u)/${_svc_label}"
           if launchctl print "${_svc_target}" >/dev/null 2>&1; then
             echo "Restarting via launchctl (${_svc_label})..."
-            exec launchctl kickstart -k "${_svc_target}"
+            # #93 件A:核验重启确实生效 —— 记旧 pid → kickstart → 轮询新 pid 变更。
+            # 不再 exec(否则无法回报);pid 未变 = 重启没生效,非零退出报错。
+            _svc_pid() { launchctl print "${_svc_target}" 2>/dev/null | awk -F'= *' '/^[[:space:]]*pid =/{gsub(/[^0-9]/,"",$2); print $2; exit}'; }
+            _old_pid="$(_svc_pid)"
+            launchctl kickstart -k "${_svc_target}"
+            _new_pid=""
+            for _i in $(seq 1 30); do
+              _new_pid="$(_svc_pid)"
+              if [[ -n "${_new_pid}" && "${_new_pid}" != "${_old_pid}" ]]; then break; fi
+              sleep 0.5
+            done
+            if [[ -n "${_new_pid}" && "${_new_pid}" != "${_old_pid}" ]]; then
+              echo "restart OK: pid ${_old_pid:-none} → ${_new_pid}"
+              exit 0
+            fi
+            echo "restart FAILED: daemon pid 未变更 (still ${_old_pid:-none}) —— 重启可能未生效" >&2
+            exit 1
           fi
           ;;
         Linux)

--- a/src/everbot/cli/agent_model_state.py
+++ b/src/everbot/cli/agent_model_state.py
@@ -1,0 +1,59 @@
+"""从运行 sidecar 的 agent.md 读「生效模型」,与配置目标比对出 stale(#93 件B)。
+
+sidecar 启动那刻把模型烧进 ``~/.alfred/milkie/<agent>/agent.md`` 后不再重读;改了
+models.yaml 不重启就不生效。本模块让"生效模型 vs 配置目标"可见,供 status 展示。
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Callable, List, Optional
+
+_INDENT_MODEL_RE = re.compile(r"\s+model:\s*(\S+)")
+
+
+def parse_agent_md_model(path) -> Optional[str]:
+    """取 agent.md 顶层 ``model:`` 块里的主模型名(忽略 ``models.fast`` 与正文)。"""
+    try:
+        lines = Path(path).read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return None
+    in_block = False
+    for ln in lines:
+        if ln.rstrip() == "model:":  # 顶层 model: 块开始
+            in_block = True
+            continue
+        if in_block:
+            if ln[:1].isspace():  # 块内缩进行
+                m = _INDENT_MODEL_RE.match(ln)
+                if m:
+                    return m.group(1)
+            elif ln.strip():  # 遇到下一个顶层键 → 块结束
+                break
+    return None
+
+
+def collect_agent_model_states(
+    agent_names: List[str],
+    *,
+    milkie_root,
+    configured_resolver: Callable[[str], Optional[str]],
+) -> List[dict]:
+    """对每个 agent 汇总 {agent, effective, configured, stale}。
+
+    effective 来自运行 agent.md;configured 来自配置解析。无 agent.md(sidecar 未拉起)
+    → effective=None、stale=False(尚无"生效"可言)。
+    """
+    root = Path(milkie_root)
+    out: List[dict] = []
+    for name in agent_names:
+        effective = parse_agent_md_model(root / name / "agent.md")
+        try:
+            configured = configured_resolver(name)
+        except Exception:
+            configured = None
+        stale = bool(effective and configured and effective != configured)
+        out.append(
+            {"agent": name, "effective": effective, "configured": configured, "stale": stale}
+        )
+    return out

--- a/src/everbot/cli/main.py
+++ b/src/everbot/cli/main.py
@@ -81,6 +81,9 @@ def cmd_status(args):
     if agents:
         print(f"Agents: {', '.join(agents)}")
 
+    # #93 件B:每 agent 生效模型 vs 配置目标(stale = 改了配置但未重启生效)。
+    _print_agent_model_states()
+
     hb = (snapshot.get("heartbeats", {}) if isinstance(snapshot, dict) else {}) or {}
     if hb:
         print("最近心跳:")
@@ -89,6 +92,42 @@ def cmd_status(args):
             preview = (state or {}).get("result_preview", "")
             if ts:
                 print(f"  - {agent_name}: {ts} {preview[:80]}")
+
+
+def _print_agent_model_states() -> None:
+    """打印每个配置 agent 的生效模型 / 配置目标 / stale 标记(#93 件B)。"""
+    try:
+        from .agent_model_state import collect_agent_model_states
+        from ..core.agent.agent_config import resolve_agent_model
+        from ..core.agent.provider.model_config import load_model_config
+
+        config = get_config()
+        agents = list(((config.get("everbot") or {}).get("agents") or {}).keys())
+        if not agents:
+            return
+        milkie_root = Path(
+            ((config.get("everbot") or {}).get("milkie") or {}).get("data_dir_root")
+            or (get_user_data_manager().alfred_home / "milkie")
+        ).expanduser()
+        mc = load_model_config()
+
+        def _configured(agent_name: str):
+            key = resolve_agent_model(agent_name)
+            return (mc.llms.get(key) or {}).get("model_name") if key else None
+
+        states = collect_agent_model_states(
+            agents, milkie_root=milkie_root, configured_resolver=_configured
+        )
+    except Exception as e:  # status 是只读自检,绝不因此崩
+        logging.getLogger(__name__).debug("agent model state collect failed: %s", e)
+        return
+
+    print("模型(生效 / 配置):")
+    for s in states:
+        eff = s["effective"] or "—(sidecar 未拉起)"
+        cfg = s["configured"] or "?"
+        flag = "  ⚠️ STALE 待重启生效" if s["stale"] else ""
+        print(f"  - {s['agent']}: {eff} / {cfg}{flag}")
 
 
 async def cmd_start_async(args):

--- a/tests/unit/test_agent_model_state.py
+++ b/tests/unit/test_agent_model_state.py
@@ -1,0 +1,77 @@
+"""TDD #93 件B:从运行 sidecar 的 agent.md 读「生效模型」,与配置目标比对出 stale。
+
+回应 #91 痛点:改完 models.yaml 后,没有命令能告诉你 agent 此刻实际在用什么模型、
+是否需要重启才生效。
+"""
+from pathlib import Path
+
+from src.everbot.cli.agent_model_state import (
+    parse_agent_md_model,
+    collect_agent_model_states,
+)
+
+_AGENT_MD = """\
+@_date() -> date
+
+model:
+  provider: volcengine
+  model: glm-5.2
+  adapter: openai-compatible
+  baseUrl: https://ark.cn-beijing.volces.com/api/coding/v3
+models:
+  fast:
+    provider: volcengine
+    model: doubao-seed-2-0-pro-260215
+    adapter: openai-compatible
+---
+some prose here, model: not-this
+"""
+
+
+def test_parse_agent_md_model_reads_primary_not_fast(tmp_path):
+    p = tmp_path / "agent.md"
+    p.write_text(_AGENT_MD, encoding="utf-8")
+    assert parse_agent_md_model(p) == "glm-5.2"  # 主模型,非 fast 档的 doubao
+
+
+def test_parse_agent_md_model_missing_file(tmp_path):
+    assert parse_agent_md_model(tmp_path / "nope.md") is None
+
+
+def test_collect_states_marks_stale_when_effective_differs(tmp_path):
+    milkie_root = tmp_path / "milkie"
+    (milkie_root / "demo").mkdir(parents=True)
+    (milkie_root / "demo" / "agent.md").write_text(_AGENT_MD, encoding="utf-8")
+
+    # 配置目标是 doubao,但运行 agent.md 是 glm-5.2 → stale(待重启)
+    states = collect_agent_model_states(
+        ["demo"],
+        milkie_root=milkie_root,
+        configured_resolver=lambda a: "doubao-seed-2-0-pro-260215",
+    )
+    s = states[0]
+    assert s["agent"] == "demo"
+    assert s["effective"] == "glm-5.2"
+    assert s["configured"] == "doubao-seed-2-0-pro-260215"
+    assert s["stale"] is True
+
+
+def test_collect_states_not_stale_when_match(tmp_path):
+    milkie_root = tmp_path / "milkie"
+    (milkie_root / "demo").mkdir(parents=True)
+    (milkie_root / "demo" / "agent.md").write_text(_AGENT_MD, encoding="utf-8")
+    states = collect_agent_model_states(
+        ["demo"], milkie_root=milkie_root, configured_resolver=lambda a: "glm-5.2"
+    )
+    assert states[0]["stale"] is False
+
+
+def test_collect_states_no_sidecar_when_agent_md_absent(tmp_path):
+    milkie_root = tmp_path / "milkie"
+    milkie_root.mkdir()
+    states = collect_agent_model_states(
+        ["demo"], milkie_root=milkie_root, configured_resolver=lambda a: "glm-5.2"
+    )
+    s = states[0]
+    assert s["effective"] is None
+    assert s["stale"] is False  # 无运行 sidecar → 不判 stale(还没生效一说)


### PR DESCRIPTION
## #93(C):生效态可观测 + 操作核验

承 #91 复盘:定位全靠 ps+agent.md 考古;第一次 `restart` 没生效却毫无信号。

## 改动
- **件A restart 核验**:`bin/everbot restart`(launchctl 路径)不再 `exec kickstart`,改为记旧 pid → kickstart → 轮询新 pid。变更 → `restart OK: 旧→新`;未变更 → 非零退出 + 报错。
- **件B status 生效态**:新增 `cli/agent_model_state.py`(读运行 `agent.md` 的生效模型,与配置目标比对出 stale);`cmd_status` 增「模型(生效 / 配置)」段,改了配置未重启即标 `⚠️ STALE 待重启生效`。无 daemon 改动。

## 范围(评审定,不过度工程)
只做模型生效态 + restart 核验;node/pid/health 由 `doctor`(#91 preflight)覆盖,不在 status 重复 plumbing。

## 验收
真实 `bin/everbot status`:
```
模型(生效 / 配置):
  - demo_agent: glm-5.2 / glm-5.2
  - coding-master: —(sidecar 未拉起) / deepseek-chat
```
改 models.yaml 不重启 → demo_agent 行会标 STALE。

## 测试(TDD)
RED(模块缺失)→ 实现 → GREEN。`parse_agent_md_model`(主模型非 fast/正文)+ `collect_agent_model_states`(stale/match/无 sidecar)共 5 例。

定稿见 #93 body。关联 #93。

🤖 Generated with [Claude Code](https://claude.com/claude-code)