### PR TITLE
feat(config): 变更爆炸半径可见 — config --impact — #94 件A

### DIFF
--- a/src/everbot/cli/config_impact.py
+++ b/src/everbot/cli/config_impact.py
@@ -1,0 +1,32 @@
+"""配置变更爆炸半径(#94 件A)。
+
+agent → llm key →(cloud, model_name)映射,并标出被多 agent 共用的 key —— 改某条 llm
+的 model_name 会连带改掉所有共用它的 agent,本视图让"改这条影响谁"在改之前可查。
+"""
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+
+def build_config_impact(agent_keys: Dict[str, str], llms: Dict[str, dict]) -> List[dict]:
+    """汇总每个 agent 的 {agent, key, cloud, model_name, shared_with}。
+
+    shared_with = 与本 agent 共用同一 llm key 的其它 agent(排序、去自身)。
+    """
+    rows: List[dict] = []
+    for agent in sorted(agent_keys):
+        key = agent_keys[agent]
+        llm = llms.get(key) or {}
+        shared_with = sorted(
+            other for other, k in agent_keys.items() if k == key and other != agent
+        )
+        rows.append(
+            {
+                "agent": agent,
+                "key": key,
+                "cloud": llm.get("cloud"),
+                "model_name": llm.get("model_name"),
+                "shared_with": shared_with,
+            }
+        )
+    return rows

--- a/src/everbot/cli/main.py
+++ b/src/everbot/cli/main.py
@@ -122,8 +122,31 @@ def cmd_config(args):
         config = get_default_config()
         save_config(config, args.config)
         print(f"配置已初始化: {args.config or '~/.alfred/config.yaml'}")
+    elif getattr(args, "impact", False):
+        _print_config_impact(args.config)
     else:
-        print("使用 --show 查看配置，--init 初始化配置")
+        print("使用 --show 查看配置，--init 初始化配置，--impact 查看模型变更爆炸半径")
+
+
+def _print_config_impact(config_path=None) -> None:
+    """打印 agent→llm key→(cloud, model_name) 映射 + 共享标记(#94 件A)。"""
+    from .config_impact import build_config_impact
+    from ..core.agent.agent_config import resolve_agent_model
+    from ..core.agent.provider.model_config import load_model_config
+
+    config = get_config(config_path)
+    agents = list(((config.get("everbot") or {}).get("agents") or {}).keys())
+    if not agents:
+        print("配置中无 agent。")
+        return
+    mc = load_model_config()
+    agent_keys = {a: (resolve_agent_model(a) or "?") for a in agents}
+    rows = build_config_impact(agent_keys, mc.llms)
+
+    print("配置变更爆炸半径(agent → llm key → cloud/model):")
+    for r in rows:
+        shared = f"  ⚠️ 共享(改 model_name 连带影响: {', '.join(r['shared_with'])})" if r["shared_with"] else ""
+        print(f"  - {r['agent']}: {r['key']} → {r['cloud']}/{r['model_name']}{shared}")
 
 
 def cmd_stop(args):
@@ -274,6 +297,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser_config = subparsers.add_parser("config", help="配置管理")
     parser_config.add_argument("--show", action="store_true", help="显示当前配置")
     parser_config.add_argument("--init", action="store_true", help="初始化默认配置")
+    parser_config.add_argument("--impact", action="store_true", help="查看模型变更爆炸半径(agent→模型,标共享 key)")
     parser_config.set_defaults(func=cmd_config)
 
     # heartbeat 命令

--- a/tests/unit/test_config_impact.py
+++ b/tests/unit/test_config_impact.py
@@ -1,0 +1,39 @@
+"""TDD #94 件A:配置变更爆炸半径可见。
+
+回应 #91 痛点:改 models.yaml 一条 llm key 的 model_name,会连带改掉所有共用该 key
+的 agent(当天 demo_agent 改 glm-5.2 顺带改了 _reflector),改前无从得知影响谁。
+"""
+from src.everbot.cli.config_impact import build_config_impact
+
+_LLMS = {
+    "deepseek-volcengine": {"cloud": "volcengine", "model_name": "glm-5.2"},
+    "kimi-code": {"cloud": "kimi", "model_name": "kimi-for-coding"},
+}
+
+
+def test_shared_key_lists_other_agents():
+    rows = build_config_impact(
+        {"demo_agent": "deepseek-volcengine", "_reflector": "deepseek-volcengine"},
+        _LLMS,
+    )
+    by_agent = {r["agent"]: r for r in rows}
+    assert by_agent["demo_agent"]["shared_with"] == ["_reflector"]
+    assert by_agent["_reflector"]["shared_with"] == ["demo_agent"]
+    # 解析出 cloud/model_name
+    assert by_agent["demo_agent"]["cloud"] == "volcengine"
+    assert by_agent["demo_agent"]["model_name"] == "glm-5.2"
+
+
+def test_unique_key_has_no_shared():
+    rows = build_config_impact(
+        {"coding-master": "kimi-code", "demo_agent": "deepseek-volcengine"}, _LLMS
+    )
+    by_agent = {r["agent"]: r for r in rows}
+    assert by_agent["coding-master"]["shared_with"] == []
+
+
+def test_unknown_key_resolves_to_none():
+    rows = build_config_impact({"x": "ghost-key"}, _LLMS)
+    assert rows[0]["cloud"] is None
+    assert rows[0]["model_name"] is None
+    assert rows[0]["key"] == "ghost-key"


### PR DESCRIPTION
## #94(D)定稿范围:最小档(impact 可见 + 复用 #93 stale 提示重启)

砍掉本地/repo 分离工具、热加载、`config set` 写命令(评审定:过度工程)。

## 改动
- 新增 `cli/config_impact.build_config_impact`:agent→llm key→(cloud, model_name),标 `shared_with`(共用同 key 的其它 agent)。
- `cmd_config` 加 `--impact`:打印映射 + ⚠️ 共享警示。

## 验收
真实 `bin/everbot config --impact`:
```
  - _reflector: deepseek-volcengine → volcengine/glm-5.2  ⚠️ 共享(改 model_name 连带影响: demo_agent)
  - demo_agent: deepseek-volcengine → volcengine/glm-5.2  ⚠️ 共享(改 model_name 连带影响: _reflector)
```
正是当天该有的预警:改这条 model_name 会同时影响 demo_agent 与 _reflector。

## 测试(TDD)
RED(模块缺失)→ 实现 → GREEN。shared/unique/unknown-key 3 例。

定稿见 #94 body。关联 #94。

🤖 Generated with [Claude Code](https://claude.com/claude-code)