### PR TITLE
fix(skills): exclude 引用不存在的 skill 降级为 WARNING 不再 brick agent (#106)

### DIFF
--- a/src/everbot/core/agent/provider/milkie/provider.py
+++ b/src/everbot/core/agent/provider/milkie/provider.py
@@ -115,8 +115,9 @@ def _build_default_prompt_and_skills(
     # 动态发现 shell 型 skill 并注入(milkie 无 dolphin 的 ResourceSkillkit;agent 经
     # 内建 run_command(milkie#134)读 SKILL.md 并跑脚本 —— 与 dolphin 能力对等)。
     # per-agent allowlist:everbot.agents.<name>.skills.include/exclude(A3,对齐 dolphin)。
-    # discover_skills 对 include/exclude 笔误 fail-loud(raise ValueError)——即 milkie#139
-    # 要求的 producer 侧 fail-fast(错误落在 spawn 边界、operator 可见)。
+    # discover_skills 对 include 笔误 fail-loud(raise ValueError)——milkie#139 要求的
+    # producer 侧 fail-fast(错误落在 spawn 边界、operator 可见)。exclude 笔误/残留则降级为
+    # WARNING + 忽略(#106 E0:exclude 引用不存在者不该 brick agent)。
     include, exclude = _agent_skill_filter(agent_name)
     skills = discover_skills(workspace, include=include, exclude=exclude)
     section = build_milkie_skills_section(skills, workspace)

--- a/src/everbot/core/agent/provider/milkie/skills.py
+++ b/src/everbot/core/agent/provider/milkie/skills.py
@@ -183,8 +183,9 @@ def discover_skills(
     per-agent allowlist(对应 dolphin 的 ``everbot.agents.<name>.skills.include/exclude``):
     - ``include`` 非空 → 只保留其中的 skill;
     - ``exclude`` → 移除其中的 skill;
-    - include/exclude 里出现**未发现**的 skill 名 → ``ValueError``(fail-loud,防配置笔误,
-      与 dolphin 行为一致)。
+    - ``include`` 里出现**未发现**的 skill 名 → ``ValueError``(fail-loud,allowlist 笔误应暴露);
+    - ``exclude`` 里出现**未发现**的 skill 名 → ``WARNING`` + 忽略(#106 E0,不 brick agent;
+      exclude 语义="确保不出现",引用不存在者本就满足)。
     """
     skills, saw_skill_md, names = _discover_stable(workspace_path)
 
@@ -204,9 +205,15 @@ def discover_skills(
             raise ValueError(f"skills.include 含未发现的 skill: {unknown}(可用: {sorted(available)})")
         skills = [s for s in skills if s["name"] in set(include)]
     if exclude:
+        # #106 E0:exclude 语义 = "确保这些不出现"。引用一个不存在的 skill 本就已满足该
+        # 语义,不该抛错把整个 agent spawn 弄挂(残留/笔误 exclude 不应 brick agent)。
+        # → 当作无操作 + WARNING(不静默),与 include(allowlist 笔误 fail-loud)区别对待。
         unknown = [n for n in exclude if n not in available]
         if unknown:
-            raise ValueError(f"skills.exclude 含未发现的 skill: {unknown}(可用: {sorted(available)})")
+            logger.warning(
+                "skills.exclude 含未发现的 skill(已忽略,不影响其余技能): %s(可用: %s)",
+                sorted(unknown), sorted(available),
+            )
         skills = [s for s in skills if s["name"] not in set(exclude)]
     return skills
 

--- a/tests/unit/test_milkie_skills.py
+++ b/tests/unit/test_milkie_skills.py
@@ -132,11 +132,25 @@ def test_discover_skills_unknown_in_include_raises(tmp_path, monkeypatch):
         msk.discover_skills(tmp_path, include=["alpha", "nonexistent"])
 
 
-def test_discover_skills_unknown_in_exclude_raises(tmp_path, monkeypatch):
-    import pytest
+def test_discover_skills_unknown_in_exclude_degrades_not_raises(tmp_path, monkeypatch, caplog):
+    """exclude 引用不存在的 skill → 不 brick:WARNING + 当作无操作,其余正常返回(#106 E0)。
+
+    exclude 语义="确保这些不出现",引用一个不存在的 skill 本就已满足,不该抛错把整个
+    agent spawn 弄挂。
+    """
+    import logging
     _setup_three(tmp_path, monkeypatch)
-    with pytest.raises(ValueError, match="ghost"):
-        msk.discover_skills(tmp_path, exclude=["ghost"])
+    with caplog.at_level(logging.WARNING, logger=msk.__name__):
+        found = msk.discover_skills(tmp_path, exclude=["ghost"])
+    assert sorted(s["name"] for s in found) == ["alpha", "beta", "gamma"]
+    assert any("ghost" in r.message for r in caplog.records)
+
+
+def test_discover_skills_exclude_mixes_known_and_unknown(tmp_path, monkeypatch):
+    """known + unknown 混合:known 照常移除,unknown 忽略,不抛错(#106 E0)。"""
+    _setup_three(tmp_path, monkeypatch)
+    found = msk.discover_skills(tmp_path, exclude=["gamma", "ghost"])
+    assert sorted(s["name"] for s in found) == ["alpha", "beta"]
 
 
 def test_discover_skills_no_filter_returns_all(tmp_path, monkeypatch):


### PR DESCRIPTION
## 摘要
修 #106(鲁棒性E0):`skills.exclude` 引用**不存在**的 skill 时,`discover_skills` 不再抛 `ValueError`,改为 `WARNING` + 忽略,避免把整个 agent spawn 弄挂。

## 背景
实地踩到:删除 codex-coding-tool / kweaver / kweaver-code-review 后,demo_agent config 残留对它们的 `skills.exclude` 引用 → `discover_skills` 抛 ValueError → demo_agent **整体不可用**。

## 改动
- **exclude** 含未发现 skill 名 → `WARNING` + 忽略(exclude 语义="确保不出现",引用不存在者本就满足)。
- **include** 保持 `fail-loud`(allowlist 笔误应暴露)——行为不变。
- 同步更新 docstring + provider.py 失准注释。

## 测试(TDD)
- 新增 `test_discover_skills_unknown_in_exclude_degrades_not_raises`(不抛错 + WARNING + 其余正常)
- 新增 `test_discover_skills_exclude_mixes_known_and_unknown`(known 移除、unknown 忽略)
- 替换原断言旧行为的 `test_discover_skills_unknown_in_exclude_raises`
- include fail-loud 测试保留
- 全量单测 **1826 passed**

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)