### PR TITLE
feat(security): sidecar OS 沙箱禁写共享路径,默认灰度关 (#108)

### DIFF
--- a/src/everbot/core/agent/provider/milkie/launcher.py
+++ b/src/everbot/core/agent/provider/milkie/launcher.py
@@ -6,18 +6,59 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from .agent_spec import build_milkie_agent_md, build_milkie_model_tiers
 
+logger = logging.getLogger(__name__)
+
 
 # skill_list manifest(milkie #139):写在 milkie data-dir,经 MILKIE_SKILL_MANIFEST
 # env 告知 serve;milkie 默认 handler 读它返回真实技能列表(去 stub)。
 SKILL_MANIFEST_FILENAME = "skill-manifest.json"
 SKILL_MANIFEST_ENV = "MILKIE_SKILL_MANIFEST"
+
+# E2b(#108):sidecar OS 沙箱 —— launcher 给 milkie serve 套 macOS sandbox-exec,
+# 物理禁止子进程(含 run_command fork 的 shell)写共享/系统路径,半径锁在自身 workspace。
+SANDBOX_PROFILE_FILENAME = "sandbox.sb"
+
+
+def _is_darwin() -> bool:
+    """是否 macOS —— sandbox-exec 仅此可用(测试 seam,可 monkeypatch)。"""
+    return sys.platform == "darwin"
+
+
+def build_sandbox_profile(*, alfred_root: Path, agent_workspace: Path) -> str:
+    """生成 macOS seatbelt profile:默认放行 + 黑名单禁写共享路径,放行自身 workspace。
+
+    爆炸半径控制(#103 E2):
+    - 禁写 ``<root>/skills``(全局 skill,半径=所有 agent);
+    - 禁写 ``<root>/agents`` 整树(隔离其他 agent),再**放行自身 workspace**(在该树下);
+    - 禁写 ``<root>/config.yaml``。
+
+    **必须 realpath**:seatbelt ``subpath`` 按真实路径匹配,``/tmp``→``/private/tmp`` 之类
+    软链会让规则静默失效(spike 实测踩到)。``allow`` 自身 workspace 排在 ``deny`` agents
+    之后 —— seatbelt last-match-wins,后者覆盖前者。
+    """
+    rp = lambda p: os.path.realpath(str(p))
+    skills = rp(Path(alfred_root) / "skills")
+    agents = rp(Path(alfred_root) / "agents")
+    config = rp(Path(alfred_root) / "config.yaml")
+    ws = rp(agent_workspace)
+    return "\n".join([
+        "(version 1)",
+        "(allow default)",
+        f'(deny file-write* (subpath "{skills}"))',
+        f'(deny file-write* (subpath "{agents}"))',
+        f'(allow file-write* (subpath "{ws}"))',
+        f'(deny file-write* (literal "{config}"))',
+        "",
+    ])
 
 
 def _render_skill_manifest(skills: List[Dict[str, Any]]) -> Dict[str, Any]:
@@ -58,6 +99,8 @@ class SidecarLauncher:
         clouds: Dict[str, Any],
         default_model: str,
         fast_model: str,
+        sandbox_enabled: bool = False,
+        alfred_root: Optional[Path] = None,
     ) -> None:
         self._dist_path = Path(dist_path)
         self._data_dir_root = Path(data_dir_root)
@@ -66,6 +109,9 @@ class SidecarLauncher:
         self._clouds = clouds
         self._default_model = default_model
         self._fast_model = fast_model
+        # E2b(#108):默认关(灰度),由 everbot.security.sidecar_sandbox 开。
+        self._sandbox_enabled = sandbox_enabled
+        self._alfred_root = Path(alfred_root) if alfred_root is not None else None
 
     def build(
         self,
@@ -74,6 +120,7 @@ class SidecarLauncher:
         system_prompt: str,
         skills: Optional[List[Dict[str, Any]]] = None,
         default_model: str | None = None,
+        agent_workspace: Optional[Path] = None,
     ) -> LaunchSpec:
         # default_model:per-agent 模型覆盖(everbot.agents.<name>.model)。缺省回退全局默认。
         # 不传则**所有 agent 用同一全局模型**——会无视 per-agent 配置(实测踩到:demo_agent
@@ -116,4 +163,37 @@ class SidecarLauncher:
                 encoding="utf-8",
             )
             env[SKILL_MANIFEST_ENV] = str(manifest_path)
+        cmd = self._maybe_sandbox(cmd, agent_name, data_dir, agent_workspace)
         return LaunchSpec(cmd=cmd, env=env, data_dir=data_dir, agent_md=agent_md)
+
+    def _maybe_sandbox(
+        self,
+        cmd: List[str],
+        agent_name: str,
+        data_dir: Path,
+        agent_workspace: Optional[Path],
+    ) -> List[str]:
+        """E2b(#108):启用且 darwin 时,写 per-agent profile 并用 sandbox-exec 包裹 cmd。
+
+        非 darwin → 跳过 + WARNING(暂不支持,Linux 留后续 bwrap/namespaces);未配 alfred_root
+        → 无从定位受保护路径,跳过 + WARNING。灰度默认关(``sandbox_enabled=False``)。
+        """
+        if not self._sandbox_enabled:
+            return cmd
+        if not _is_darwin():
+            logger.warning(
+                "sidecar_sandbox 已启用但当前平台非 macOS(%s)——跳过 sandbox-exec 包裹"
+                "(暂不支持,Linux 待 bwrap/namespaces)。", sys.platform,
+            )
+            return cmd
+        if self._alfred_root is None:
+            logger.warning("sidecar_sandbox 已启用但未配 alfred_root —— 无法定位受保护路径,跳过。")
+            return cmd
+        # 自身 workspace:缺省按约定 <root>/agents/<name>(放行写,隔离其他 agent)。
+        ws = agent_workspace if agent_workspace is not None else self._alfred_root / "agents" / agent_name
+        profile_path = data_dir / SANDBOX_PROFILE_FILENAME
+        profile_path.write_text(
+            build_sandbox_profile(alfred_root=self._alfred_root, agent_workspace=ws),
+            encoding="utf-8",
+        )
+        return ["sandbox-exec", "-f", str(profile_path), *cmd]

--- a/src/everbot/core/agent/provider/milkie/provider.py
+++ b/src/everbot/core/agent/provider/milkie/provider.py
@@ -266,10 +266,18 @@ class MilkieProvider:
         from ..model_config import load_model_config
         mc = load_model_config()
 
+        # E2b(#108):sidecar OS 沙箱开关,默认关(灰度)。开后 launcher 给 milkie serve
+        # 套 sandbox-exec,物理禁止子进程写共享路径(~/.alfred/skills·config·别的 agent)。
+        sandbox_enabled = bool(
+            ((cfg.get("everbot", {}) or {}).get("security", {}) or {}).get("sidecar_sandbox", False)
+        )
+        alfred_root = get_user_data_manager().alfred_home
+
         launcher = SidecarLauncher(
             dist_path=dist_path, data_dir_root=data_dir_root, node_bin=node_bin,
             llms=mc.llms, clouds=mc.clouds,
             default_model=mc.default_model, fast_model=mc.fast_model,
+            sandbox_enabled=sandbox_enabled, alfred_root=alfred_root,
         )
         ready_timeout = float(milkie_cfg.get("ready_timeout", 20.0))
 
@@ -291,6 +299,7 @@ class MilkieProvider:
                 system_prompt=system_prompt,
                 skills=skills,
                 default_model=per_agent_model,
+                agent_workspace=_resolve_agent_workspace(agent_name),
             )
             return spec.cmd, spec.env
 

--- a/tests/unit/test_milkie_launcher.py
+++ b/tests/unit/test_milkie_launcher.py
@@ -210,3 +210,98 @@ def test_build_manifest_is_valid_utf8_json_with_cjk(tmp_path):
     raw = (spec.data_dir / SKILL_MANIFEST_FILENAME).read_text(encoding="utf-8")
     assert "抓取 X 用户最新推文" in raw  # 未被 \uXXXX 转义
     json.loads(raw)  # 合法 JSON
+
+
+# ── E2b：sidecar OS 沙箱(#108)──────────────────────────────────────────────
+import os
+
+from src.everbot.core.agent.provider.milkie import launcher as _lmod
+from src.everbot.core.agent.provider.milkie.launcher import (
+    build_sandbox_profile,
+    SANDBOX_PROFILE_FILENAME,
+)
+
+
+def _rp(p):
+    return os.path.realpath(str(p))
+
+
+def _sandbox_launcher(tmp_path, alfred_root):
+    return SidecarLauncher(
+        dist_path=tmp_path / "milkie" / "dist" / "cli" / "index.js",
+        data_dir_root=tmp_path / "data",
+        node_bin="node",
+        llms={"main": {"cloud": "oa", "model_name": "gpt-x", "type_api": "openai"},
+              "fast": {"cloud": "oa", "model_name": "gpt-fast", "type_api": "openai"}},
+        clouds={"oa": {"api": "https://api.oa/v1", "api_key": "sk-real"}},
+        default_model="main",
+        fast_model="fast",
+        sandbox_enabled=True,
+        alfred_root=alfred_root,
+    )
+
+
+def test_build_sandbox_profile_denies_shared_allows_workspace(tmp_path):
+    root = tmp_path / ".alfred"
+    (root / "skills").mkdir(parents=True)
+    ws = root / "agents" / "alice"
+    ws.mkdir(parents=True)
+    (root / "config.yaml").write_text("x", encoding="utf-8")
+
+    prof = build_sandbox_profile(alfred_root=root, agent_workspace=ws)
+
+    assert "(allow default)" in prof
+    assert f'(deny file-write* (subpath "{_rp(root / "skills")}"))' in prof
+    assert f'(deny file-write* (subpath "{_rp(root / "agents")}"))' in prof
+    assert f'(deny file-write* (literal "{_rp(root / "config.yaml")}"))' in prof
+    # 自身 workspace 在 /agents 树下 → allow 必须排在 deny agents 之后(last-match-wins)。
+    lines = prof.splitlines()
+    deny_agents_i = next(
+        i for i, l in enumerate(lines)
+        if l.strip().startswith("(deny") and _rp(root / "agents") in l and _rp(ws) not in l
+    )
+    allow_ws_i = next(
+        i for i, l in enumerate(lines)
+        if l.strip().startswith("(allow") and _rp(ws) in l
+    )
+    assert allow_ws_i > deny_agents_i
+
+
+def test_build_sandbox_profile_uses_realpath_not_symlink(tmp_path):
+    # /tmp 软链坑:profile 必须写解析后的真实路径,否则 seatbelt subpath 静默失效。
+    root = tmp_path / ".alfred"
+    (root / "skills").mkdir(parents=True)
+    ws = root / "agents" / "alice"
+    ws.mkdir(parents=True)
+    prof = build_sandbox_profile(alfred_root=root, agent_workspace=ws)
+    assert _rp(root / "skills") in prof
+
+
+def test_build_wraps_cmd_with_sandbox_when_enabled_on_darwin(tmp_path, monkeypatch):
+    monkeypatch.setattr(_lmod, "_is_darwin", lambda: True)
+    spec = _sandbox_launcher(tmp_path, tmp_path / ".alfred").build("alice", system_prompt="x")
+
+    assert spec.cmd[0] == "sandbox-exec"
+    assert spec.cmd[1] == "-f"
+    assert spec.cmd[2] == str(spec.data_dir / SANDBOX_PROFILE_FILENAME)
+    assert (spec.data_dir / SANDBOX_PROFILE_FILENAME).exists()
+    # 原始 node serve 命令原样跟在后面。
+    assert spec.cmd[3] == "node"
+    assert "serve" in spec.cmd
+
+
+def test_build_no_sandbox_when_disabled_by_default(tmp_path):
+    # 灰度默认关:不传 sandbox_enabled → cmd 不被包裹。
+    spec = _launcher(tmp_path).build("alice", system_prompt="x")
+    assert spec.cmd[0] == "node"
+    assert "sandbox-exec" not in spec.cmd
+
+
+def test_build_skips_sandbox_on_non_darwin_with_warning(tmp_path, monkeypatch, caplog):
+    import logging
+    monkeypatch.setattr(_lmod, "_is_darwin", lambda: False)
+    with caplog.at_level(logging.WARNING, logger=_lmod.__name__):
+        spec = _sandbox_launcher(tmp_path, tmp_path / ".alfred").build("alice", system_prompt="x")
+    assert spec.cmd[0] == "node"
+    assert "sandbox-exec" not in spec.cmd
+    assert any("sandbox" in r.message.lower() for r in caplog.records)

--- a/tests/unit/test_milkie_provider.py
+++ b/tests/unit/test_milkie_provider.py
@@ -972,7 +972,7 @@ def test_injected_system_prompt_loader_is_used(monkeypatch):
     captured_skills: list = []
 
     class _CapturingLauncher:
-        def build(self, agent_name, *, system_prompt, skills=None, default_model=None):
+        def build(self, agent_name, *, system_prompt, skills=None, default_model=None, agent_workspace=None):
             captured_prompts.append(system_prompt)
             captured_skills.append(skills)
             return LaunchSpec(
@@ -1017,7 +1017,7 @@ def test_default_loader_feeds_discovered_skills_to_launcher(monkeypatch):
     captured = {}
 
     class _CapturingLauncher:
-        def build(self, agent_name, *, system_prompt, skills=None, default_model=None):
+        def build(self, agent_name, *, system_prompt, skills=None, default_model=None, agent_workspace=None):
             captured["system_prompt"] = system_prompt
             captured["skills"] = skills
             return LaunchSpec(
@@ -1114,7 +1114,7 @@ def test_build_pool_wires_skills_fingerprint(monkeypatch):
     from src.everbot.core.agent.provider.milkie.launcher import LaunchSpec
 
     class _StubLauncher:
-        def build(self, agent_name, *, system_prompt, skills=None, default_model=None):
+        def build(self, agent_name, *, system_prompt, skills=None, default_model=None, agent_workspace=None):
             return LaunchSpec(
                 cmd=["node"], env={}, data_dir=Path("/tmp"), agent_md=Path("/tmp/a.md")
             )


### PR DESCRIPTION
## 摘要
实现 #108(鲁棒性E2b):launcher 给 `milkie serve` 套 macOS `sandbox-exec`,**物理禁止** sidecar 及其子进程(含 `run_command` fork 的 shell)写共享/系统路径,把 agent 变更的爆炸半径锁在自身 workspace。**默认灰度关**。

## 为什么是 OS 沙箱(spike 结论)
milkie `run_command` = `spawn(shell:true)` 任意 shell 字符串。命令字符串策略门可绕(shell 图灵完备)→ 只能算软护栏。真正的安全边界是 **OS 进程边界沙箱**,且 alfred 的 launcher 全权构造 cmd → 纯 alfred 侧实现,**零 milkie 改动**。详见 #108 spike 评论。

## 改动
- `build_sandbox_profile(alfred_root, agent_workspace)`:生成 seatbelt profile —— `(allow default)` + 黑名单 `deny file-write*`(skills / agents 树 / config.yaml)+ `allow` 自身 workspace,**全部 realpath 规范化**(`/tmp` 软链坑)。
- `SidecarLauncher`:新增 `sandbox_enabled`(默认 `False`)+ `alfred_root`;`build()` 启用且 darwin 时写 per-agent profile 并 `sandbox-exec -f` 包裹 cmd;非 darwin 跳过 + WARNING。
- `provider.py`:接 `everbot.security.sidecar_sandbox` 开关(默认关),传 `alfred_root` / `agent_workspace`。

## 测试(TDD)
单测覆盖 profile 内容(realpath、deny/allow 顺序)、cmd 包裹、默认关、非 darwin 降级。**全量 1831 passed**。

### 真·sandbox-exec 强制实测(生成的 profile)
| 写入目标 | 结果 |
|---|---|
| `skills/` | 拒绝 ✅ |
| 别的 agent 目录 | 拒绝 ✅ |
| 自身 workspace(deny agents 后 allow,验证 last-match-wins) | 写入 ✅ |
| `config.yaml` 覆写 | 拒绝 ✅ |
| python 间接写共享路径 | OS 边界拒绝 ✅ |

## 启用方式(灰度)
```yaml
everbot:
  security:
    sidecar_sandbox: true   # 默认 false
```

## 后续
- Linux 支持(bwrap/namespaces)未做,非 darwin 当前跳过 + WARNING。
- milkie 侧软策略门(E2a,干净拒绝提示)为可选锦上添花,未做。

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)