### PR TITLE
feat(security): sidecar 沙箱开关支持 per-agent 覆盖 (#112)

### DIFF
--- a/src/everbot/core/agent/provider/milkie/launcher.py
+++ b/src/everbot/core/agent/provider/milkie/launcher.py
@@ -121,6 +121,7 @@ class SidecarLauncher:
         skills: Optional[List[Dict[str, Any]]] = None,
         default_model: str | None = None,
         agent_workspace: Optional[Path] = None,
+        sandbox_enabled: Optional[bool] = None,
     ) -> LaunchSpec:
         # default_model:per-agent 模型覆盖(everbot.agents.<name>.model)。缺省回退全局默认。
         # 不传则**所有 agent 用同一全局模型**——会无视 per-agent 配置(实测踩到:demo_agent
@@ -163,7 +164,9 @@ class SidecarLauncher:
                 encoding="utf-8",
             )
             env[SKILL_MANIFEST_ENV] = str(manifest_path)
-        cmd = self._maybe_sandbox(cmd, agent_name, data_dir, agent_workspace)
+        # per-agent override(#112):build 传 sandbox_enabled 则覆盖构造默认;None → 沿用默认。
+        enabled = self._sandbox_enabled if sandbox_enabled is None else sandbox_enabled
+        cmd = self._maybe_sandbox(cmd, agent_name, data_dir, agent_workspace, enabled)
         return LaunchSpec(cmd=cmd, env=env, data_dir=data_dir, agent_md=agent_md)
 
     def _maybe_sandbox(
@@ -172,13 +175,15 @@ class SidecarLauncher:
         agent_name: str,
         data_dir: Path,
         agent_workspace: Optional[Path],
+        enabled: bool,
     ) -> List[str]:
         """E2b(#108):启用且 darwin 时,写 per-agent profile 并用 sandbox-exec 包裹 cmd。
 
         非 darwin → 跳过 + WARNING(暂不支持,Linux 留后续 bwrap/namespaces);未配 alfred_root
         → 无从定位受保护路径,跳过 + WARNING。灰度默认关(``sandbox_enabled=False``)。
+        ``enabled`` 由调用方解析(per-agent override > 构造默认),见 :meth:`build`。
         """
-        if not self._sandbox_enabled:
+        if not enabled:
             return cmd
         if not _is_darwin():
             logger.warning(

--- a/src/everbot/core/agent/provider/milkie/provider.py
+++ b/src/everbot/core/agent/provider/milkie/provider.py
@@ -171,6 +171,25 @@ def _skills_fingerprint(agent_name: str) -> Optional[str]:
     return hashlib.sha256(canon.encode("utf-8")).hexdigest()
 
 
+def _agent_sandbox_enabled(agent_name: str) -> bool:
+    """解析 sidecar 沙箱开关(#112):per-agent 覆盖 > 全局 > False。
+
+    ``everbot.agents.<name>.security.sidecar_sandbox`` > ``everbot.security.sidecar_sandbox``
+    > ``False``。读失败按关处理(沙箱是加固项,解析异常不应阻断 spawn)。
+    """
+    try:
+        from .....infra.config import get_config
+
+        everbot_cfg = (get_config() or {}).get("everbot", {}) or {}
+        global_val = bool((everbot_cfg.get("security", {}) or {}).get("sidecar_sandbox", False))
+        agent_sec = (
+            ((everbot_cfg.get("agents", {}) or {}).get(agent_name, {}) or {}).get("security", {}) or {}
+        )
+        return bool(agent_sec.get("sidecar_sandbox", global_val))
+    except Exception:
+        return False
+
+
 def _agent_skill_filter(agent_name: str):
     """读 everbot.agents.<name>.skills.{include,exclude} → (include, exclude)。缺省 (None, None)。"""
     try:
@@ -266,18 +285,16 @@ class MilkieProvider:
         from ..model_config import load_model_config
         mc = load_model_config()
 
-        # E2b(#108):sidecar OS 沙箱开关,默认关(灰度)。开后 launcher 给 milkie serve
-        # 套 sandbox-exec,物理禁止子进程写共享路径(~/.alfred/skills·config·别的 agent)。
-        sandbox_enabled = bool(
-            ((cfg.get("everbot", {}) or {}).get("security", {}) or {}).get("sidecar_sandbox", False)
-        )
+        # E2b(#108):sidecar OS 沙箱,开后 launcher 给 milkie serve 套 sandbox-exec,物理禁止
+        # 子进程写共享路径(~/.alfred/skills·config·别的 agent)。开关 per-agent 解析(#112,
+        # 见 _agent_sandbox_enabled),故 launcher 构造不固化全局值 —— 每次 build 按 agent 传入。
         alfred_root = get_user_data_manager().alfred_home
 
         launcher = SidecarLauncher(
             dist_path=dist_path, data_dir_root=data_dir_root, node_bin=node_bin,
             llms=mc.llms, clouds=mc.clouds,
             default_model=mc.default_model, fast_model=mc.fast_model,
-            sandbox_enabled=sandbox_enabled, alfred_root=alfred_root,
+            alfred_root=alfred_root,
         )
         ready_timeout = float(milkie_cfg.get("ready_timeout", 20.0))
 
@@ -300,6 +317,7 @@ class MilkieProvider:
                 skills=skills,
                 default_model=per_agent_model,
                 agent_workspace=_resolve_agent_workspace(agent_name),
+                sandbox_enabled=_agent_sandbox_enabled(agent_name),
             )
             return spec.cmd, spec.env
 

--- a/tests/unit/test_milkie_launcher.py
+++ b/tests/unit/test_milkie_launcher.py
@@ -226,7 +226,7 @@ def _rp(p):
     return os.path.realpath(str(p))
 
 
-def _sandbox_launcher(tmp_path, alfred_root):
+def _sandbox_launcher(tmp_path, alfred_root, enabled=True):
     return SidecarLauncher(
         dist_path=tmp_path / "milkie" / "dist" / "cli" / "index.js",
         data_dir_root=tmp_path / "data",
@@ -236,7 +236,7 @@ def _sandbox_launcher(tmp_path, alfred_root):
         clouds={"oa": {"api": "https://api.oa/v1", "api_key": "sk-real"}},
         default_model="main",
         fast_model="fast",
-        sandbox_enabled=True,
+        sandbox_enabled=enabled,
         alfred_root=alfred_root,
     )
 
@@ -305,3 +305,28 @@ def test_build_skips_sandbox_on_non_darwin_with_warning(tmp_path, monkeypatch, c
     assert spec.cmd[0] == "node"
     assert "sandbox-exec" not in spec.cmd
     assert any("sandbox" in r.message.lower() for r in caplog.records)
+
+
+# ── per-agent override(#112):build() 接 per-call sandbox_enabled,覆盖构造默认 ──
+
+
+def test_build_per_call_override_enables_when_global_off(tmp_path, monkeypatch):
+    monkeypatch.setattr(_lmod, "_is_darwin", lambda: True)
+    launcher = _sandbox_launcher(tmp_path, tmp_path / ".alfred", enabled=False)  # 全局关
+    spec = launcher.build("alice", system_prompt="x", sandbox_enabled=True)       # 覆盖开
+    assert spec.cmd[0] == "sandbox-exec"
+
+
+def test_build_per_call_override_disables_when_global_on(tmp_path, monkeypatch):
+    monkeypatch.setattr(_lmod, "_is_darwin", lambda: True)
+    launcher = _sandbox_launcher(tmp_path, tmp_path / ".alfred", enabled=True)    # 全局开
+    spec = launcher.build("alice", system_prompt="x", sandbox_enabled=False)      # 覆盖关
+    assert spec.cmd[0] == "node"
+    assert "sandbox-exec" not in spec.cmd
+
+
+def test_build_sandbox_follows_constructor_when_no_override(tmp_path, monkeypatch):
+    monkeypatch.setattr(_lmod, "_is_darwin", lambda: True)
+    # 不传 sandbox_enabled(None)→ 沿用构造默认(True)。
+    spec = _sandbox_launcher(tmp_path, tmp_path / ".alfred", enabled=True).build("alice", system_prompt="x")
+    assert spec.cmd[0] == "sandbox-exec"

--- a/tests/unit/test_milkie_provider.py
+++ b/tests/unit/test_milkie_provider.py
@@ -972,7 +972,7 @@ def test_injected_system_prompt_loader_is_used(monkeypatch):
     captured_skills: list = []
 
     class _CapturingLauncher:
-        def build(self, agent_name, *, system_prompt, skills=None, default_model=None, agent_workspace=None):
+        def build(self, agent_name, *, system_prompt, skills=None, default_model=None, agent_workspace=None, sandbox_enabled=None):
             captured_prompts.append(system_prompt)
             captured_skills.append(skills)
             return LaunchSpec(
@@ -1017,7 +1017,7 @@ def test_default_loader_feeds_discovered_skills_to_launcher(monkeypatch):
     captured = {}
 
     class _CapturingLauncher:
-        def build(self, agent_name, *, system_prompt, skills=None, default_model=None, agent_workspace=None):
+        def build(self, agent_name, *, system_prompt, skills=None, default_model=None, agent_workspace=None, sandbox_enabled=None):
             captured["system_prompt"] = system_prompt
             captured["skills"] = skills
             return LaunchSpec(
@@ -1114,7 +1114,7 @@ def test_build_pool_wires_skills_fingerprint(monkeypatch):
     from src.everbot.core.agent.provider.milkie.launcher import LaunchSpec
 
     class _StubLauncher:
-        def build(self, agent_name, *, system_prompt, skills=None, default_model=None, agent_workspace=None):
+        def build(self, agent_name, *, system_prompt, skills=None, default_model=None, agent_workspace=None, sandbox_enabled=None):
             return LaunchSpec(
                 cmd=["node"], env={}, data_dir=Path("/tmp"), agent_md=Path("/tmp/a.md")
             )
@@ -1231,3 +1231,37 @@ async def test_attach_projection_raises_on_non_2xx():
 
     with pytest.raises(httpx.HTTPStatusError):
         await provider.attach_projection(handle, source_run_id="r", display_text="x")
+
+
+# ── per-agent sidecar 沙箱解析(#112)──────────────────────────────────────────
+from src.everbot.infra import config as _cfgmod
+
+
+def _set_cfg(monkeypatch, d):
+    monkeypatch.setattr(_cfgmod, "get_config", lambda *a, **k: d)
+
+
+def test_agent_sandbox_global_on_agent_override_off(monkeypatch):
+    _set_cfg(monkeypatch, {"everbot": {
+        "security": {"sidecar_sandbox": True},
+        "agents": {"a": {"security": {"sidecar_sandbox": False}}}}})
+    assert provider_mod._agent_sandbox_enabled("a") is False
+
+
+def test_agent_sandbox_global_off_agent_override_on(monkeypatch):
+    _set_cfg(monkeypatch, {"everbot": {
+        "security": {"sidecar_sandbox": False},
+        "agents": {"a": {"security": {"sidecar_sandbox": True}}}}})
+    assert provider_mod._agent_sandbox_enabled("a") is True
+
+
+def test_agent_sandbox_no_override_follows_global(monkeypatch):
+    _set_cfg(monkeypatch, {"everbot": {
+        "security": {"sidecar_sandbox": True},
+        "agents": {"a": {}}}})
+    assert provider_mod._agent_sandbox_enabled("a") is True
+
+
+def test_agent_sandbox_defaults_false_when_unset(monkeypatch):
+    _set_cfg(monkeypatch, {"everbot": {}})
+    assert provider_mod._agent_sandbox_enabled("a") is False


### PR DESCRIPTION
## 摘要
实现 #112:sidecar OS 沙箱开关从**全局单值**改为 **per-agent 可覆盖**。承接 #108。

解析优先级:`everbot.agents.<name>.security.sidecar_sandbox` > `everbot.security.sidecar_sandbox` > `False`。

## 动机
干净解掉 skill-installer 纠结:沙箱开启后 agent 写不了 `~/.alfred/skills` → 无法自助装/卸 skill。per-agent 后可**留一个不沙箱的 skill 管理 agent**(继续用 installer),其余面向用户的 agent 沙箱化。隔离的是**整个 agent**,而非在 profile 上给 installer 打洞。

## 用法
```yaml
everbot:
  security: { sidecar_sandbox: true }       # 全局默认
  agents:
    demo_agent:  { security: { sidecar_sandbox: true } }    # 面向用户 → 开
    skill-admin: { security: { sidecar_sandbox: false } }   # 管 skill → 关
```

## 改动
- `provider._agent_sandbox_enabled(agent_name)`:per-agent > 全局 > False 解析(镜像 `_agent_skill_filter`;解析异常按关处理,不阻断 spawn)。
- `launcher.build(sandbox_enabled=...)`:per-call override,`None` 沿用构造默认。
- provider `_build` 按 agent 解析后传入;launcher 构造不再固化全局值。

## 测试(TDD)
- launcher:per-call override 开/关、无 override 沿用默认。
- provider:四种组合(全局开+agent 关、全局关+agent 开、无 override 跟随全局、皆无→false)。
- 全量 **1838 passed**。

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)