### PR TITLE
fix(telegram): round_reset 不再丢弃已展示的实质内容 — 长报告被末尾摘要覆盖 (#114)

### DIFF
--- a/src/everbot/channels/telegram_channel.py
+++ b/src/everbot/channels/telegram_channel.py
@@ -696,13 +696,18 @@ class TelegramChannel:
                     last_update_time = current_time  # prevent immediate retry
 
         async def on_event(out: OutboundMessage) -> None:
-            nonlocal tool_call_count, accumulated_text
+            nonlocal tool_call_count, accumulated_text, streaming_message_id
             if out.msg_type == "delta":
                 chunks.append(out.content)
                 accumulated_text += out.content
                 await flush_streaming()
             elif out.msg_type == "round_reset":
-                # New agentic round — discard intermediate text
+                # New agentic round. #114:已展示给用户的实质内容(长报告)定稿为独立消息,
+                # 不再被后续轮的短摘要覆盖;未展示的工具前过渡碎语仍丢弃。
+                if await self._commit_round_on_reset(
+                    chat_id, streaming_message_id, accumulated_text
+                ):
+                    streaming_message_id = None  # 下一轮另起新消息
                 chunks.clear()
                 accumulated_text = ""
             elif out.msg_type == "skill":
@@ -965,6 +970,36 @@ class TelegramChannel:
                 ok_count += 1
             search_from = part_start + len(part)
         return ok_count, len(parts)
+
+    async def _commit_round_on_reset(
+        self, chat_id: str, streaming_message_id: Optional[int], accumulated_text: str
+    ) -> bool:
+        """#114:新一轮(round_reset)开始时,如何处置上一轮的流式文本。
+
+        若上一轮文本**已展示给用户**(``streaming_message_id`` 非空——意味它过了流式阈值、
+        真发出去过),它是**实质内容**(而非工具调用前的过渡碎语):把它**定稿为一条独立消息**
+        (去掉流式光标),返回 ``True``,让调用方重置流式状态、下一轮另起新消息。
+
+        超长报告(>4096)走 batch 模式、未实时展示(``streaming_message_id`` 为 None),
+        但它显然是实质内容 → 也定稿(作为新消息分条发送)。
+
+        否则(短且未展示)沿用旧语义:丢弃,返回 ``False`` —— 那是工具调用前的过渡碎语。
+
+        修复:长报告在第 1 轮产出、随后调工具进入第 2 轮,旧逻辑会清空累积文本 →
+        第 2 轮的短摘要把同一条消息覆盖,用户侧"报告消失"。现在第 1 轮的报告作为独立消息留存。
+        """
+        if not accumulated_text.strip():
+            return False
+        shown = streaming_message_id is not None
+        too_long_to_stream = len(accumulated_text) > TELEGRAM_MSG_LIMIT
+        if not (shown or too_long_to_stream):
+            return False  # 短且未展示 = 工具前过渡碎语 → 丢弃
+        final_text, final_entities = self._convert_markdown(accumulated_text)
+        if shown:
+            await self._finalize_streaming(chat_id, streaming_message_id, final_text, final_entities)
+        else:
+            await self._send_split_with_entities(chat_id, final_text, final_entities)
+        return True
 
     async def _finalize_streaming(
         self, chat_id: str, message_id: int, text: str, entities: Optional[list],

--- a/tests/unit/test_telegram_channel.py
+++ b/tests/unit/test_telegram_channel.py
@@ -1929,3 +1929,51 @@ class TestConvertMarkdown:
         assert "# " not in plain
         assert "Heading" in plain
         assert entities is None
+
+
+# ---------------------------------------------------------------------------
+# #114: round_reset 不应丢弃已展示的实质内容(长报告被末尾摘要覆盖)
+# ---------------------------------------------------------------------------
+class TestCommitRoundOnReset:
+    @pytest.fixture
+    def channel(self, tmp_path):
+        ch = _make_channel(tmp_path)
+        ch._finalize_streaming = AsyncMock(return_value=True)
+        return ch
+
+    async def test_finalizes_shown_substantive_text(self, channel):
+        # 上一轮文本已展示(streaming_message_id 非空)→ 定稿为独立消息,返回 True。
+        committed = await channel._commit_round_on_reset("chat1", 42, "# 每日报告\n正文很长很长")
+        assert committed is True
+        channel._finalize_streaming.assert_awaited_once()
+        a = channel._finalize_streaming.await_args.args
+        assert a[0] == "chat1" and a[1] == 42
+        assert "正文很长很长" in a[2]
+
+    async def test_discards_when_not_shown(self, channel):
+        # 未展示(streaming_message_id None = 工具前过渡碎语)→ 丢弃,返回 False,不定稿。
+        committed = await channel._commit_round_on_reset("chat1", None, "让我看看新闻")
+        assert committed is False
+        channel._finalize_streaming.assert_not_awaited()
+
+    async def test_discards_blank_text(self, channel):
+        committed = await channel._commit_round_on_reset("chat1", 42, "   ")
+        assert committed is False
+        channel._finalize_streaming.assert_not_awaited()
+
+
+class TestCommitRoundOnResetTooLong:
+    @pytest.fixture
+    def channel(self, tmp_path):
+        ch = _make_channel(tmp_path)
+        ch._finalize_streaming = AsyncMock(return_value=True)
+        ch._send_split_with_entities = AsyncMock(return_value=(1, 1))
+        return ch
+
+    async def test_too_long_unshown_report_sent_as_new_messages(self, channel):
+        # >4096 报告走 batch、未实时展示(message_id None),仍应定稿(分条发送),不丢弃。
+        long_report = "# 报告\n" + ("正" * 5000)
+        committed = await channel._commit_round_on_reset("chat1", None, long_report)
+        assert committed is True
+        channel._send_split_with_entities.assert_awaited_once()
+        channel._finalize_streaming.assert_not_awaited()


### PR DESCRIPTION
## 摘要
修 #114:一轮 turn 产出 `[长报告] → cite → [短摘要]` 两条 assistant 消息时,长报告从 telegram 消失。

## 根因
`on_event` 的 `round_reset` 处理直接清空上一轮累积文本(`chunks.clear(); accumulated_text=""`)。报告在第 1 轮产出并流式展示,`cite` 工具后进入第 2 轮 → round_reset 丢弃报告 → 第 2 轮短摘要把**同一条** telegram 消息覆盖。本意是丢"工具前过渡碎语",却误伤了已展示的实质报告。

## 修复
新增 `_commit_round_on_reset`:round_reset 时,若上一轮文本
- **已展示**(`streaming_message_id` 非空)→ 定稿为独立消息(`_finalize_streaming`,去光标);
- **超长**(>4096,batch 模式未实时展示)→ 分条发送(`_send_split_with_entities`);
- 否则(短且未展示 = 工具前碎语)→ 仍丢弃。

定稿后下一轮 `streaming_message_id` 置空、另起新消息 → 报告与摘要**分条留存,不再互相覆盖**。

## 测试(TDD)
- `_commit_round_on_reset`:已展示→定稿、未展示→丢弃、空白→丢弃、超长未展示→分条发送。
- telegram 通道 131 passed;全量 **1842 passed**。

## 实证背景
本次线上复现:contrarian-signals 1926 字报告流式可见后被 77 字摘要覆盖;报告完好留在 history(数据没丢,是展示被覆盖)。非沙箱问题。

Closes #114
关联 #79(流式收尾家族)

🤖 Generated with [Claude Code](https://claude.com/claude-code)