### PR TITLE
fix(scheduler): active_hours 按本地时区判断，修复夜间静默失效 (#117)

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ alfred/
 
 ### Q: 如何修改心跳间隔？
 
-A: 编辑 `~/.alfred/config.yaml`，修改 `everbot.agents.<agent_name>.heartbeat.interval` 值（单位：分钟）。还可以设置 `night_interval_minutes` 来降低夜间频率。
+A: 编辑 `~/.alfred/config.yaml`，修改 `everbot.agents.<agent_name>.heartbeat.interval` 值（单位：分钟）。还可以设置 `heartbeat.night_interval` 来降低夜间频率（0 或省略表示夜间静默）。`active_hours` 按部署机本地时区判断；改完需 `./bin/everbot restart` 生效。
 
 ### Q: 心跳任务会污染用户对话历史吗？
 

--- a/src/everbot/README.md
+++ b/src/everbot/README.md
@@ -47,9 +47,13 @@ everbot:
       workspace: ~/.alfred/agents/my_agent
       heartbeat:
         enabled: true
-        interval: 30          # 每30分钟执行一次
-        active_hours: [8, 22] # 8:00-22:00 活跃
+        interval: 30           # 活跃时段每 30 分钟执行一次
+        active_hours: [8, 22]  # 活跃时段，按【部署机本地时区】判断，半开区间 [8, 22)（22:00 不含）
+        night_interval: 0      # 非活跃时段间隔（分钟）：0 或省略 = 夜间静默，正整数 = 夜间降频
 ```
+
+> ⚠️ `active_hours` 按**部署机本地时区**判断（不是 UTC）。修改 `config.yaml` 后需执行
+> `./bin/everbot restart` 才会生效——daemon 不会热重载已加载的代码与配置。
 
 ### 3. 编写任务清单
 

--- a/src/everbot/core/runtime/scheduler.py
+++ b/src/everbot/core/runtime/scheduler.py
@@ -463,7 +463,12 @@ class Scheduler:
 
     @staticmethod
     def _is_active_time(schedule: Any, ts: datetime) -> bool:
-        hour = ts.hour
+        # active_hours is local-time semantics (the operator configures "8 to
+        # 23" meaning local clock hours). ts is normalized to UTC internally, so
+        # convert back to the deployment-host local timezone before comparing —
+        # otherwise the active window is shifted by the UTC offset and night
+        # silencing breaks (#117).
+        hour = ts.astimezone().hour
         start, end = schedule.active_hours
         return start <= hour < end
 

--- a/tests/unit/test_core_runtime.py
+++ b/tests/unit/test_core_runtime.py
@@ -308,24 +308,94 @@ async def test_scheduler_triggers_heartbeat_on_due_interval():
 
 
 @pytest.mark.asyncio
-async def test_scheduler_respects_active_hours():
-    """Heartbeat is skipped outside active hours."""
-    # 3 AM is outside default (8, 22)
-    now = datetime(2026, 2, 12, 3, 0, 0)
-    heartbeat_calls: list[str] = []
+async def test_scheduler_runs_heartbeat_during_local_active_hours(monkeypatch):
+    """During local active hours heartbeat fires — even when the same instant is
+    outside active_hours when read in UTC. Complements the night-silence case
+    below; together they pin active_hours to local-time semantics (#117)."""
+    import time
 
-    async def _run_heartbeat(agent_name: str, ts: datetime):
-        heartbeat_calls.append(agent_name)
+    monkeypatch.setenv("TZ", "Asia/Shanghai")
+    time.tzset()
+    try:
+        # 05:00 UTC == 13:00 Beijing → inside active_hours (8, 22).
+        # The pre-fix code compared UTC hour (5) and wrongly skipped.
+        now = datetime(2026, 2, 12, 5, 0, 0, tzinfo=timezone.utc)
+        heartbeat_calls: list[str] = []
 
-    scheduler = Scheduler(
-        run_heartbeat=_run_heartbeat,
-        agent_schedules={
-            "alice": AgentSchedule(agent_name="alice", interval_minutes=30),
-        },
-    )
+        async def _run_heartbeat(agent_name: str, ts: datetime):
+            heartbeat_calls.append(agent_name)
 
-    await scheduler.tick(now)
-    assert heartbeat_calls == []
+        scheduler = Scheduler(
+            run_heartbeat=_run_heartbeat,
+            agent_schedules={
+                "alice": AgentSchedule(agent_name="alice", interval_minutes=30),
+            },
+        )
+
+        await scheduler.tick(now)
+        assert heartbeat_calls == ["alice"]
+    finally:
+        time.tzset()
+
+
+@pytest.mark.asyncio
+async def test_scheduler_active_hours_uses_local_timezone(monkeypatch):
+    """active_hours is local-time semantics: Beijing 3 AM must be inactive
+    even though the same instant is 19:00 UTC (inside default active_hours).
+
+    Regression for #117: _is_active_time compared UTC hour against locally
+    configured active_hours, shifting the active window by the UTC offset and
+    letting heartbeat/inspector run all through the local night.
+    """
+    import time
+
+    monkeypatch.setenv("TZ", "Asia/Shanghai")
+    time.tzset()
+    try:
+        # 19:00 UTC == 03:00 Beijing next day → outside active_hours (8, 22)
+        now = datetime(2026, 2, 12, 19, 0, 0, tzinfo=timezone.utc)
+        heartbeat_calls: list[str] = []
+
+        async def _run_heartbeat(agent_name: str, ts: datetime):
+            heartbeat_calls.append(agent_name)
+
+        scheduler = Scheduler(
+            run_heartbeat=_run_heartbeat,
+            agent_schedules={
+                "alice": AgentSchedule(agent_name="alice", interval_minutes=30),
+            },
+        )
+
+        await scheduler.tick(now)
+        assert heartbeat_calls == []
+    finally:
+        time.tzset()
+
+
+@pytest.mark.parametrize(
+    "local_hour,expected_active",
+    [
+        (7, False),   # just before start → inactive
+        (8, True),    # start is inclusive
+        (21, True),
+        (22, False),  # end is exclusive
+        (23, False),
+        (3, False),   # deep night
+    ],
+)
+def test_is_active_time_local_half_open_interval(monkeypatch, local_hour, expected_active):
+    """active_hours is a half-open [start, end) interval evaluated in local time."""
+    import time
+    from zoneinfo import ZoneInfo
+
+    monkeypatch.setenv("TZ", "Asia/Shanghai")
+    time.tzset()
+    try:
+        schedule = AgentSchedule(agent_name="alice", active_hours=(8, 22))
+        ts = datetime(2026, 2, 12, local_hour, 0, tzinfo=ZoneInfo("Asia/Shanghai"))
+        assert Scheduler._is_active_time(schedule, ts) is expected_active
+    finally:
+        time.tzset()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #117

## 根因

`Scheduler._is_active_time` 用 **UTC 小时**比对本地配置的 `active_hours`,使活跃窗口偏移 UTC 时差。北京 `active_hours: [8, 23]` 实际生效成"16:00 → 次日 07:00 活跃",整个凌晨被误判为活跃窗口 → heartbeat / inspector 夜间静默失效,凌晨空转反复撞夜里断网,`consecutive_failures` 整夜累加。

```python
# tick(): ts = _normalize_ts(... datetime.now(timezone.utc))  → ts 是 UTC
# 前: hour = ts.hour                  # UTC 小时
# 后: hour = ts.astimezone().hour     # 部署机本地时区小时
```

`active_hours` 明确为"部署机本地时间的小时区间"。当前单机本地部署(CST+0800),无 per-agent 多时区需求,故不新增 `timezone` 配置字段(YAGNI)。

## 影响范围

- **受影响(修复生效)**:`_tick_heartbeats`、`_tick_inspector` —— 夜间静默恢复正确。
- **不受影响(设计如此)**:`_tick_tasks`(cron routine / inline LLM probe)本就不看 `active_hours`,行为不变。

## 测试(TDD,红→绿)

1. **夜间静默**(回归核心):UTC 19:00 = 北京 03:00,断言静默 —— 改前 FAIL、改后 PASS。
2. **白天活跃**:UTC 05:00 = 北京 13:00,断言正常触发 —— 由原 naive-datetime 用例改造(原用例编码了旧的错误时区假设)。
3. **半开区间端点边界**:参数化覆盖 7/8/21/22/23/3 点,钉住 `[start, end)` 语义。
- 三组固定 `TZ=Asia/Shanghai` 保证 CI 确定性。

## 验证

- `tests/unit/test_core_runtime.py` **17 passed**;heartbeat / scheduler / cron / inline 相关回归 **152 passed**。
- `test_daemon_lifecycle` 的 2 个失败为 **pre-existing**(node_bin / `_FakePopen` mock 环境问题,已 stash 验证与本改动无关)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
