### PR TITLE
fix(telegram): idle gate 缓冲主动推送，避免打断进行中的确认轮 (#119)

### DIFF
--- a/src/everbot/channels/telegram_channel.py
+++ b/src/everbot/channels/telegram_channel.py
@@ -14,7 +14,7 @@ import base64
 import json
 import logging
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Set, Union
+from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
 import httpx
 
@@ -50,6 +50,13 @@ from . import telegram_media
 logger = logging.getLogger(__name__)
 
 TELEGRAM_MSG_LIMIT = 4096
+
+# #119: pushes the agent initiates on its own — gated by the idle window so they
+# don't interrupt an in-flight user turn. deferred_result is intentionally NOT
+# here: user-awaited results are delivered immediately.
+_ACTIVE_PUSH_TYPES = frozenset(
+    {"heartbeat_delivery", "inspector_push", "skill_notification"}
+)
 
 
 def _truncate_projection_text(text: str, limit: int = 4000) -> str:
@@ -122,6 +129,15 @@ class TelegramChannel:
         bindings_suffix = f"_{name}" if name else ""
         self._bindings_path = self._user_data.alfred_home / f"telegram_bindings{bindings_suffix}.json"
 
+        # #119: idle gate — active background pushes (routine/heartbeat/inspector/
+        # skill) wait until the user has been quiet this long, so a delivery can't
+        # interrupt an in-flight confirmation turn. deferred_result is exempt
+        # (user-awaited). Deferred events are buffered here and flushed once idle.
+        self._idle_threshold_seconds = 180
+        self._flush_interval_seconds = 60
+        self._pending_pushes: List[Tuple[str, Dict[str, Any]]] = []
+        self._flush_task: Optional[asyncio.Task] = None
+
         self._client: Optional[httpx.AsyncClient] = None
         self._running = False
         self._poll_task: Optional[asyncio.Task] = None
@@ -144,6 +160,7 @@ class TelegramChannel:
         events.subscribe(self._on_background_event)
         self._dispatcher_task = asyncio.create_task(self._dispatcher_loop())
         self._poll_task = asyncio.create_task(self._polling_loop())
+        self._flush_task = asyncio.create_task(self._flush_loop())
         tag = f"[{self._name}] " if self._name else ""
         logger.info(
             "%sTelegramChannel started, restored %d binding(s)", tag, len(self._bindings)
@@ -167,6 +184,13 @@ class TelegramChannel:
             except asyncio.CancelledError:
                 pass
             self._dispatcher_task = None
+        if self._flush_task is not None:
+            self._flush_task.cancel()
+            try:
+                await self._flush_task
+            except asyncio.CancelledError:
+                pass
+            self._flush_task = None
         for task in self._chat_workers.values():
             task.cancel()
         for task in self._chat_workers.values():
@@ -236,6 +260,55 @@ class TelegramChannel:
             )
             return False
 
+    def _is_user_idle(self, agent_name: str) -> bool:
+        """True if the user has been quiet long enough (mirrors heartbeat gate).
+
+        Unknown / never-seen activity (None or non-numeric) is treated as idle —
+        when in doubt, deliver rather than hold (mirrors inspector.py guard)."""
+        last_activity = self._session_manager.get_last_activity_time(agent_name)
+        if not isinstance(last_activity, (int, float)):
+            return True
+        import time
+
+        return (time.time() - last_activity) >= self._idle_threshold_seconds
+
+    def _should_defer(self, source_type: Optional[str], agent_name: str) -> bool:
+        """#119: hold an agent-initiated push while the user is mid-conversation.
+
+        Only active-push types are gated; deferred_result (and anything else) is
+        delivered immediately so user-awaited results are never held back."""
+        if source_type not in _ACTIVE_PUSH_TYPES:
+            return False
+        return not self._is_user_idle(agent_name)
+
+    async def _flush_loop(self) -> None:
+        """#119: periodically retry buffered pushes until their users go idle."""
+        while self._running:
+            try:
+                await self._flush_pending_pushes()
+            except Exception:
+                logger.exception("flush_pending_pushes failed")
+            await asyncio.sleep(self._flush_interval_seconds)
+
+    async def _flush_pending_pushes(self) -> None:
+        """#119: re-deliver buffered active pushes once their user has gone idle.
+
+        Re-dispatches through ``_on_background_event``; since the user is now idle
+        the gate no longer defers, so bubble + context go out together. Entries
+        whose user is still active stay buffered for the next sweep."""
+        if not self._pending_pushes:
+            return
+        still_waiting: List[Tuple[str, Dict[str, Any]]] = []
+        ready: List[Tuple[str, Dict[str, Any]]] = []
+        for src, data in self._pending_pushes:
+            if self._should_defer(data.get("source_type"), data.get("agent_name")):
+                still_waiting.append((src, data))
+            else:
+                ready.append((src, data))
+        self._pending_pushes = still_waiting
+        for src, data in ready:
+            await self._on_background_event(src, data)
+
     async def _on_background_event(
         self, source_session_id: str, data: Dict[str, Any]
     ) -> None:
@@ -262,6 +335,18 @@ class TelegramChannel:
         # Build notification text
         detail = str(data.get("detail") or data.get("summary") or "").strip()
         if not detail:
+            return
+
+        # #119: hold agent-initiated pushes while the user is mid-conversation,
+        # so a routine/heartbeat delivery can't interrupt an in-flight turn.
+        # Bubble + context are withheld together, flushed once the user idles.
+        if self._should_defer(source_type, agent_name):
+            run_id = str(data.get("run_id") or "")
+            already = run_id and any(
+                str(d.get("run_id") or "") == run_id for _, d in self._pending_pushes
+            )
+            if not already:
+                self._pending_pushes.append((source_session_id, data))
             return
 
         if source_type == "deferred_result":

--- a/tests/unit/test_telegram_channel.py
+++ b/tests/unit/test_telegram_channel.py
@@ -1977,3 +1977,134 @@ class TestCommitRoundOnResetTooLong:
         assert committed is True
         channel._send_split_with_entities.assert_awaited_once()
         channel._finalize_streaming.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# #119: idle gate for active background pushes
+# ---------------------------------------------------------------------------
+class TestProjectionIdleGate:
+    """Active background pushes (routine/heartbeat/inspector/skill) are deferred
+    while the user is mid-conversation; deferred_result (user-awaited) is exempt."""
+
+    def _ch(self, tmp_path, last_activity, threshold=180):
+        ch = _make_channel(tmp_path)
+        ch._idle_threshold_seconds = threshold
+        ch._session_manager.get_last_activity_time = MagicMock(return_value=last_activity)
+        return ch
+
+    @pytest.mark.parametrize(
+        "source_type,active,expected",
+        [
+            ("heartbeat_delivery", True, True),    # routine/cron push, user active → defer
+            ("inspector_push", True, True),
+            ("skill_notification", True, True),
+            ("heartbeat_delivery", False, False),  # user idle → send now
+            ("deferred_result", True, False),      # user-awaited result → exempt
+            ("deferred_result", False, False),
+        ],
+    )
+    def test_should_defer_matrix(self, tmp_path, source_type, active, expected):
+        import time
+
+        last = time.time() if active else time.time() - 10_000
+        ch = self._ch(tmp_path, last_activity=last)
+        assert ch._should_defer(source_type, "test_agent") is expected
+
+    def test_no_activity_treated_as_idle(self, tmp_path):
+        # never-seen user → treat as idle → send immediately
+        ch = self._ch(tmp_path, last_activity=None)
+        assert ch._should_defer("heartbeat_delivery", "test_agent") is False
+
+    # -- behavior: gate inside _on_background_event + flush -----------------
+
+    def _ready_channel(self, tmp_path, last_activity, monkeypatch):
+        from src.everbot.channels import telegram_channel as tc
+
+        ch = self._ch(tmp_path, last_activity=last_activity)
+        ch._bindings = {"chat1": "test_agent"}
+        ch._send_split_with_entities = AsyncMock(return_value=(1, 1))
+        ch._maybe_attach_projection = AsyncMock(return_value=True)
+        ch._convert_markdown = MagicMock(return_value=("text", None))
+        monkeypatch.setattr(
+            tc, "resolve_routing",
+            lambda d: SimpleNamespace(
+                deliver=True, scope="broadcast", target_session_id=None,
+                target_channel="telegram", agent_name=d.get("agent_name"),
+            ),
+        )
+        return ch
+
+    def _push(self, source_type="heartbeat_delivery", run_id="j1"):
+        return {
+            "agent_name": "test_agent", "source_type": source_type,
+            "detail": "report body", "run_id": run_id, "transcript_worthy": True,
+        }
+
+    @pytest.mark.asyncio
+    async def test_active_push_while_active_is_buffered(self, tmp_path, monkeypatch):
+        import time
+
+        ch = self._ready_channel(tmp_path, time.time(), monkeypatch)
+        await ch._on_background_event("src", self._push())
+        ch._send_split_with_entities.assert_not_awaited()  # bubble withheld
+        ch._maybe_attach_projection.assert_not_awaited()   # context withheld
+        assert len(ch._pending_pushes) == 1                # buffered
+
+    @pytest.mark.asyncio
+    async def test_deferred_result_exempt_sent_even_when_active(self, tmp_path, monkeypatch):
+        import time
+
+        ch = self._ready_channel(tmp_path, time.time(), monkeypatch)
+        await ch._on_background_event("src", self._push(source_type="deferred_result"))
+        ch._send_split_with_entities.assert_awaited()  # delivered immediately
+        assert ch._pending_pushes == []
+
+    @pytest.mark.asyncio
+    async def test_flush_delivers_when_user_goes_idle(self, tmp_path, monkeypatch):
+        import time
+
+        ch = self._ready_channel(tmp_path, time.time(), monkeypatch)
+        await ch._on_background_event("src", self._push())
+        assert len(ch._pending_pushes) == 1
+        # user goes quiet → flush delivers bubble + context together
+        ch._session_manager.get_last_activity_time = MagicMock(
+            return_value=time.time() - 10_000
+        )
+        await ch._flush_pending_pushes()
+        ch._send_split_with_entities.assert_awaited()
+        assert ch._pending_pushes == []
+
+    @pytest.mark.asyncio
+    async def test_flush_keeps_buffered_while_still_active(self, tmp_path, monkeypatch):
+        import time
+
+        ch = self._ready_channel(tmp_path, time.time(), monkeypatch)
+        await ch._on_background_event("src", self._push())
+        await ch._flush_pending_pushes()  # user still active → keep waiting
+        ch._send_split_with_entities.assert_not_awaited()
+        assert len(ch._pending_pushes) == 1
+
+    @pytest.mark.asyncio
+    async def test_duplicate_run_id_not_buffered_twice(self, tmp_path, monkeypatch):
+        import time
+
+        ch = self._ready_channel(tmp_path, time.time(), monkeypatch)
+        await ch._on_background_event("src", self._push(run_id="dup"))
+        await ch._on_background_event("src", self._push(run_id="dup"))
+        assert len(ch._pending_pushes) == 1
+
+    @pytest.mark.asyncio
+    async def test_flush_loop_periodically_invokes_flush(self, tmp_path):
+        ch = _make_channel(tmp_path)
+        ch._flush_interval_seconds = 0.01
+        ch._flush_pending_pushes = AsyncMock()
+        ch._running = True
+        task = asyncio.create_task(ch._flush_loop())
+        await asyncio.sleep(0.05)
+        ch._running = False
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        assert ch._flush_pending_pushes.await_count >= 1


### PR DESCRIPTION
## 背景

后台主动推送（routine/heartbeat/inspector/skill）在用户对话进行中被无条件 attach 进下一轮 context，割裂了"agent 提问 ↔ 用户确认"的相邻性，导致模型把"好的"绑到无关报告上。本质是两层问题（milkie #192 渲染 + alfred 准入），**本 PR 修准入层**。

## 方案

引入 user-idle gate（复用 `get_last_activity_time`）：

- 用户活跃（距上次互动 < 3min）时，主动推送整条（气泡 + context）缓冲进 `pending`，静默后由 60s flush loop 补投。
- `deferred_result`（用户主动发起、正在等的结果）豁免，立即投。
- 气泡与 context 同生共灭，消除"屏幕有、模型不知道"的不一致。
- 放弃原方案的 short-confirmation 关键词 guard（脆弱），改用纯时序信号。

## 测试

TDD：`_should_defer` 决策矩阵 + 缓冲/豁免/flush/去重/loop 共 13 例。全套回归 150 passed。

Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)