### PR TITLE
fix(#122): routine/heartbeat 投递 projection 用可解析 source_session_id 作溯源锚点

### DIFF
--- a/src/everbot/channels/telegram_channel.py
+++ b/src/everbot/channels/telegram_channel.py
@@ -229,6 +229,10 @@ class TelegramChannel:
         run_id = str(data.get("run_id") or "").strip()
         if not detail or not run_id:
             return False
+        # #122:溯源锚点优先用可解析的 source_session_id(归档 job session,报告全文+
+        # 轨迹所在);它缺失时才回落一次性合成的 run_id —— run_id 回溯不到任何执行,
+        # 用户问"来源哪里"会落空。
+        source_run_id = str(data.get("source_session_id") or "").strip() or run_id
 
         from ..core.agent.provider import get_provider_for_agent
 
@@ -249,7 +253,7 @@ class TelegramChannel:
                 self._session_manager.cache_agent(session_id, agent, agent_name, "auto")
             await attach(
                 agent,
-                source_run_id=run_id,
+                source_run_id=source_run_id,
                 display_text=_truncate_projection_text(detail),
                 delivered_at=data.get("delivered_at"),
             )

--- a/src/everbot/channels/telegram_channel.py
+++ b/src/everbot/channels/telegram_channel.py
@@ -229,10 +229,11 @@ class TelegramChannel:
         run_id = str(data.get("run_id") or "").strip()
         if not detail or not run_id:
             return False
-        # #122:溯源锚点优先用可解析的 source_session_id(归档 job session,报告全文+
-        # 轨迹所在);它缺失时才回落一次性合成的 run_id —— run_id 回溯不到任何执行,
-        # 用户问"来源哪里"会落空。
-        source_run_id = str(data.get("source_session_id") or "").strip() or run_id
+        # #122:溯源锚点优先用可解析的 projection_source_id(产出方归档 job session,
+        # 报告全文+轨迹所在);它缺失时才回落一次性合成的 run_id —— run_id 回溯不到
+        # 任何执行,用户问"来源哪里"会落空。注意不可用信封的 source_session_id:那是
+        # 发出方 session(primary),非产出方。
+        source_run_id = str(data.get("projection_source_id") or "").strip() or run_id
 
         from ..core.agent.provider import get_provider_for_agent
 

--- a/src/everbot/core/runtime/cron.py
+++ b/src/everbot/core/runtime/cron.py
@@ -585,15 +585,19 @@ class CronExecutor:
                 return None
 
             summary = f"{task_title or task.id} completed"
+            job_session_id = f"job_{task.id}"
             await self.delivery.deposit_job_event(
                 event_type="job_completed",
-                source_session_id=f"job_{task.id}",
+                source_session_id=job_session_id,
                 summary=summary,
                 detail=result,
                 run_id=run_id,
             )
             await self.delivery.inject_to_history(result, run_id)
-            await self.delivery._emit_realtime(result, run_id, transcript_worthy=True)
+            await self.delivery._emit_realtime(
+                result, run_id, transcript_worthy=True,
+                source_session_id=job_session_id,  # #122:可解析溯源锚点,非合成 run_id
+            )
 
             return result
         except Exception as exc:
@@ -655,7 +659,10 @@ class CronExecutor:
                 run_id=run_id,
             )
             await self.delivery.inject_to_history(result, run_id)
-            await self.delivery._emit_realtime(result, run_id, transcript_worthy=True)
+            await self.delivery._emit_realtime(
+                result, run_id, transcript_worthy=True,
+                source_session_id=job_session_id,  # #122:可解析溯源锚点(归档 job session)
+            )
 
             # SLM: record skill invocations from this isolated agent run.
             # Reads the just-written trajectory to find _load_resource_skill

--- a/src/everbot/core/runtime/cron_delivery.py
+++ b/src/everbot/core/runtime/cron_delivery.py
@@ -184,7 +184,10 @@ class CronDelivery:
 
         ``source_session_id`` (#122):产出该报告的可解析 job session id(归档 session
         所在,报告全文+轨迹可回溯)。channel 侧据此作 projection 的溯源锚点,而非一次性
-        合成的 run_id(后者回溯不到任何执行 → "来源哪里"落空)。"""
+        合成的 run_id(后者回溯不到任何执行 → "来源哪里"落空)。
+
+        注意键名用 ``projection_source_id`` 而非 ``source_session_id``:后者是事件信封
+        (``emit``)的保留字段,会被覆盖为发出方 session(primary),借用会丢锚点。"""
         from .events import emit
 
         message = {
@@ -195,7 +198,7 @@ class CronDelivery:
             "detail": result,
             "source_type": "heartbeat_delivery",
             "run_id": run_id,
-            "source_session_id": source_session_id,
+            "projection_source_id": source_session_id,
             "deliver": True,
             "transcript_worthy": transcript_worthy,
         }

--- a/src/everbot/core/runtime/cron_delivery.py
+++ b/src/everbot/core/runtime/cron_delivery.py
@@ -173,13 +173,18 @@ class CronDelivery:
         }
 
     async def _emit_realtime(
-        self, result: str, run_id: str, *, transcript_worthy: bool = False
+        self, result: str, run_id: str, *, transcript_worthy: bool = False,
+        source_session_id: Optional[str] = None,
     ) -> None:
         """Emit realtime push event (SSE / Telegram).
 
         ``transcript_worthy`` (#60):本次投递是否是"内容型"产出(具名 job/agent 任务的
         用户可见报告),供 channel 侧据此登记 milkie context projection(读侧逐字稿)。
-        心跳状态 ping / 失败消息保持 False,不入逐字稿。"""
+        心跳状态 ping / 失败消息保持 False,不入逐字稿。
+
+        ``source_session_id`` (#122):产出该报告的可解析 job session id(归档 session
+        所在,报告全文+轨迹可回溯)。channel 侧据此作 projection 的溯源锚点,而非一次性
+        合成的 run_id(后者回溯不到任何执行 → "来源哪里"落空)。"""
         from .events import emit
 
         message = {
@@ -190,6 +195,7 @@ class CronDelivery:
             "detail": result,
             "source_type": "heartbeat_delivery",
             "run_id": run_id,
+            "source_session_id": source_session_id,
             "deliver": True,
             "transcript_worthy": transcript_worthy,
         }

--- a/tests/unit/test_cron_delivery.py
+++ b/tests/unit/test_cron_delivery.py
@@ -153,38 +153,44 @@ class TestRealtimeEmit:
         assert emitted[0].get("transcript_worthy", False) is False
 
     @pytest.mark.asyncio
-    async def test_emit_realtime_carries_source_session_id(self, monkeypatch):
-        """#122:realtime 事件须带可解析的 source_session_id 作 projection 溯源锚点。
-        run_id 是一次性合成的 job 执行 id(回溯不到任何执行),source_session_id 才
-        指向归档 job session(报告全文+轨迹所在)。"""
-        emitted = []
-        d = _make_delivery()
+    async def test_emit_realtime_projection_source_survives_envelope(self):
+        """#122:projection 溯源 id 必须用独立键 projection_source_id —— 不能复用
+        source_session_id,后者是事件信封保留字段,会被 emit() 覆盖为发出方 session
+        (primary),从而丢失 job session 锚点。本测试走真实 emit + 真实订阅者,
+        正是为捕捉这种字段覆盖(假 emit 会绕过信封 enrichment)。"""
+        from src.everbot.core.runtime import events
+        captured = []
 
-        async def _fake_emit(source_session_id, data, **kwargs):
-            emitted.append(data)
+        def _cap(src, env):
+            captured.append(env)
 
-        monkeypatch.setattr("src.everbot.core.runtime.cron_delivery.emit", _fake_emit, raising=False)
-        monkeypatch.setattr("src.everbot.core.runtime.events.emit", _fake_emit)
+        events.subscribe(_cap)
+        try:
+            d = _make_delivery()  # primary_session_id="web_session_test"
+            await d._emit_realtime(
+                "report body", "job_f8a5b0a67ad3", transcript_worthy=True,
+                source_session_id="job_routine_38364fe6_d185ce87",
+            )
+        finally:
+            events._subscribers.clear()
 
-        await d._emit_realtime(
-            "report body", "job_f8a5b0a67ad3", transcript_worthy=True,
-            source_session_id="job_routine_38364fe6_d185ce87",
-        )
-
-        assert emitted[0]["source_session_id"] == "job_routine_38364fe6_d185ce87"
+        assert len(captured) == 1
+        env = captured[0]
+        # 信封自有的 source_session_id 仍是发出方(primary),不被借用/覆盖。
+        assert env["source_session_id"] == "web_session_test"
+        # 溯源锚点用独立键,完整保留 job session(不被信封覆盖)。
+        assert env["projection_source_id"] == "job_routine_38364fe6_d185ce87"
 
     @pytest.mark.asyncio
-    async def test_emit_realtime_source_session_id_defaults_none(self, monkeypatch):
-        """未提供 source_session_id 时该键为 None,channel 侧据此回落 run_id。"""
-        emitted = []
-        d = _make_delivery()
+    async def test_emit_realtime_projection_source_defaults_none(self):
+        """未提供 source_session_id 时 projection_source_id 为 None,channel 回落 run_id。"""
+        from src.everbot.core.runtime import events
+        captured = []
+        events.subscribe(lambda src, env: captured.append(env))
+        try:
+            d = _make_delivery()
+            await d._emit_realtime("status ping", "run_y")
+        finally:
+            events._subscribers.clear()
 
-        async def _fake_emit(source_session_id, data, **kwargs):
-            emitted.append(data)
-
-        monkeypatch.setattr("src.everbot.core.runtime.cron_delivery.emit", _fake_emit, raising=False)
-        monkeypatch.setattr("src.everbot.core.runtime.events.emit", _fake_emit)
-
-        await d._emit_realtime("status ping", "run_y")
-
-        assert emitted[0].get("source_session_id") is None
+        assert captured[0].get("projection_source_id") is None

--- a/tests/unit/test_cron_delivery.py
+++ b/tests/unit/test_cron_delivery.py
@@ -151,3 +151,40 @@ class TestRealtimeEmit:
         await d._emit_realtime("status ping", "run_y")
 
         assert emitted[0].get("transcript_worthy", False) is False
+
+    @pytest.mark.asyncio
+    async def test_emit_realtime_carries_source_session_id(self, monkeypatch):
+        """#122:realtime 事件须带可解析的 source_session_id 作 projection 溯源锚点。
+        run_id 是一次性合成的 job 执行 id(回溯不到任何执行),source_session_id 才
+        指向归档 job session(报告全文+轨迹所在)。"""
+        emitted = []
+        d = _make_delivery()
+
+        async def _fake_emit(source_session_id, data, **kwargs):
+            emitted.append(data)
+
+        monkeypatch.setattr("src.everbot.core.runtime.cron_delivery.emit", _fake_emit, raising=False)
+        monkeypatch.setattr("src.everbot.core.runtime.events.emit", _fake_emit)
+
+        await d._emit_realtime(
+            "report body", "job_f8a5b0a67ad3", transcript_worthy=True,
+            source_session_id="job_routine_38364fe6_d185ce87",
+        )
+
+        assert emitted[0]["source_session_id"] == "job_routine_38364fe6_d185ce87"
+
+    @pytest.mark.asyncio
+    async def test_emit_realtime_source_session_id_defaults_none(self, monkeypatch):
+        """未提供 source_session_id 时该键为 None,channel 侧据此回落 run_id。"""
+        emitted = []
+        d = _make_delivery()
+
+        async def _fake_emit(source_session_id, data, **kwargs):
+            emitted.append(data)
+
+        monkeypatch.setattr("src.everbot.core.runtime.cron_delivery.emit", _fake_emit, raising=False)
+        monkeypatch.setattr("src.everbot.core.runtime.events.emit", _fake_emit)
+
+        await d._emit_realtime("status ping", "run_y")
+
+        assert emitted[0].get("source_session_id") is None

--- a/tests/unit/test_cron_e2e.py
+++ b/tests/unit/test_cron_e2e.py
@@ -405,3 +405,73 @@ class TestE2ERecoverStuckTask:
         assert len(disk_tasks) == 1
         assert disk_tasks[0]["state"] == "pending"
         assert disk_tasks[0]["error_message"] == "recovered: stuck in running state"
+
+
+# ── E2E: 投递溯源锚点跨缝(#122) ──────────────────────────────
+
+class TestE2EProjectionProvenanceAcrossSeam:
+    """真实 cron 投递 → 真实事件总线 payload → 真实 telegram _maybe_attach_projection,
+    断言 projection 溯源 id 是可解析的 job_session_id,而非一次性合成的 run_id。"""
+
+    @pytest.mark.asyncio
+    async def test_isolated_job_delivery_projection_uses_resolvable_session_id(
+        self, tmp_path: Path, monkeypatch
+    ):
+        from src.everbot.core.tasks.task_manager import Task
+        from src.everbot.channels.telegram_channel import TelegramChannel
+
+        runner = _make_runner(tmp_path)
+        cron = runner._cron
+
+        # 真实走 _run_isolated_job 的投递代码,只 stub 叶子(job 执行体)。
+        report = "# 每日投资信号\n🆕 恒生科技大涨 | 港股 | 5.8 | 2 条"
+        monkeypatch.setattr(cron, "_invoke_job", AsyncMock(return_value=report))
+
+        # 捕获真实事件总线上的 realtime 投递 payload。
+        captured = []
+
+        async def _capture_emit(source_session_id, data, **kwargs):
+            captured.append(data)
+
+        monkeypatch.setattr("src.everbot.core.runtime.events.emit", _capture_emit)
+
+        task = Task.from_dict({
+            "id": "iso_e2e",
+            "title": "每日投资信号",
+            "description": "isolated work",
+            "schedule": "1d",
+            "state": "running",
+            "enabled": True,
+            "execution_mode": "isolated",
+            "timeout_seconds": 120,
+        })
+
+        # 生产端:合成的 run_id 是"死 id",job_session_id 才可解析。
+        dead_run_id = "job_f8a5b0a67ad3"
+        await cron._run_isolated_job(task, dead_run_id)
+
+        # ① 事件 payload 带上了可解析的 source_session_id,且不等于死 run_id。
+        realtime = [d for d in captured if d.get("transcript_worthy")]
+        assert len(realtime) == 1
+        event = realtime[0]
+        assert event["source_session_id"] == "job_iso_e2e"
+        assert event["source_session_id"] != dead_run_id
+
+        # ② 消费端:真实 telegram channel 据此事件登记 projection,溯源锚点取
+        #    可解析的 source_session_id(回溯得到归档 session),而非死 run_id。
+        ch = TelegramChannel(
+            bot_token="123:FAKE",
+            session_manager=MagicMock(),
+            default_agent="test_agent",
+        )
+        ch._session_manager.get_cached_agent.return_value = SimpleNamespace()
+
+        provider = MagicMock()
+        provider.attach_projection = AsyncMock()
+        import src.everbot.core.agent.provider as provider_mod
+        monkeypatch.setattr(provider_mod, "get_provider_for_agent", lambda name: provider)
+
+        ok = await ch._maybe_attach_projection("test_agent", 555, event)
+
+        assert ok is True
+        assert provider.attach_projection.call_args.kwargs["source_run_id"] == "job_iso_e2e"

--- a/tests/unit/test_cron_e2e.py
+++ b/tests/unit/test_cron_e2e.py
@@ -420,6 +420,8 @@ class TestE2EProjectionProvenanceAcrossSeam:
         from src.everbot.core.tasks.task_manager import Task
         from src.everbot.channels.telegram_channel import TelegramChannel
 
+        from src.everbot.core.runtime import events
+
         runner = _make_runner(tmp_path)
         cron = runner._cron
 
@@ -427,13 +429,10 @@ class TestE2EProjectionProvenanceAcrossSeam:
         report = "# 每日投资信号\n🆕 恒生科技大涨 | 港股 | 5.8 | 2 条"
         monkeypatch.setattr(cron, "_invoke_job", AsyncMock(return_value=report))
 
-        # 捕获真实事件总线上的 realtime 投递 payload。
+        # 走真实 emit + 真实订阅者捕获信封 —— 真实 emit 会做信封 enrichment
+        # (覆盖 source_session_id),这正是上一版假 emit 漏掉的字段覆盖陷阱。
         captured = []
-
-        async def _capture_emit(source_session_id, data, **kwargs):
-            captured.append(data)
-
-        monkeypatch.setattr("src.everbot.core.runtime.events.emit", _capture_emit)
+        events.subscribe(lambda src, env: captured.append(env))
 
         task = Task.from_dict({
             "id": "iso_e2e",
@@ -448,14 +447,18 @@ class TestE2EProjectionProvenanceAcrossSeam:
 
         # 生产端:合成的 run_id 是"死 id",job_session_id 才可解析。
         dead_run_id = "job_f8a5b0a67ad3"
-        await cron._run_isolated_job(task, dead_run_id)
+        try:
+            await cron._run_isolated_job(task, dead_run_id)
+        finally:
+            events._subscribers.clear()
 
-        # ① 事件 payload 带上了可解析的 source_session_id,且不等于死 run_id。
+        # ① 真实信封里:projection_source_id 保留了可解析 job session(不被信封
+        #    的 source_session_id 覆盖);信封自有的 source_session_id 是发出方。
         realtime = [d for d in captured if d.get("transcript_worthy")]
         assert len(realtime) == 1
         event = realtime[0]
-        assert event["source_session_id"] == "job_iso_e2e"
-        assert event["source_session_id"] != dead_run_id
+        assert event["projection_source_id"] == "job_iso_e2e"
+        assert event["projection_source_id"] != dead_run_id
 
         # ② 消费端:真实 telegram channel 据此事件登记 projection,溯源锚点取
         #    可解析的 source_session_id(回溯得到归档 session),而非死 run_id。

--- a/tests/unit/test_telegram_channel.py
+++ b/tests/unit/test_telegram_channel.py
@@ -2108,3 +2108,46 @@ class TestProjectionIdleGate:
         except asyncio.CancelledError:
             pass
         assert ch._flush_pending_pushes.await_count >= 1
+
+
+class TestProjectionProvenance:
+    """#122: projection 的 source_run_id 必须是可解析的 source_session_id,
+    而非一次性合成的 job 执行 run_id(后者回溯不到任何执行,溯源落空)。"""
+
+    @pytest.fixture
+    def _provider(self, monkeypatch):
+        provider = MagicMock()
+        provider.attach_projection = AsyncMock()
+        provider.set_session_id = MagicMock()
+        import src.everbot.core.agent.provider as provider_mod
+        monkeypatch.setattr(provider_mod, "get_provider_for_agent", lambda name: provider)
+        return provider
+
+    @pytest.mark.asyncio
+    async def test_uses_source_session_id_as_provenance(self, tmp_path, _provider):
+        ch = _make_channel(tmp_path)
+        ch._session_manager.get_cached_agent.return_value = SimpleNamespace()  # 命中缓存,跳过创建
+        data = {
+            "transcript_worthy": True,
+            "detail": "# 每日投资信号\n🆕 恒生科技大涨 | 港股 | 5.8 | 2 条",
+            "run_id": "job_f8a5b0a67ad3",                       # 死 id
+            "source_session_id": "job_routine_38364fe6_d185ce87",  # 活 id(归档 session)
+        }
+
+        ok = await ch._maybe_attach_projection("test_agent", 555, data)
+
+        assert ok is True
+        kwargs = _provider.attach_projection.call_args.kwargs
+        assert kwargs["source_run_id"] == "job_routine_38364fe6_d185ce87"
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_run_id_when_no_source_session(self, tmp_path, _provider):
+        ch = _make_channel(tmp_path)
+        ch._session_manager.get_cached_agent.return_value = SimpleNamespace()
+        data = {"transcript_worthy": True, "detail": "x", "run_id": "job_abc"}
+
+        ok = await ch._maybe_attach_projection("test_agent", 555, data)
+
+        assert ok is True
+        kwargs = _provider.attach_projection.call_args.kwargs
+        assert kwargs["source_run_id"] == "job_abc"

--- a/tests/unit/test_telegram_channel.py
+++ b/tests/unit/test_telegram_channel.py
@@ -2130,8 +2130,9 @@ class TestProjectionProvenance:
         data = {
             "transcript_worthy": True,
             "detail": "# 每日投资信号\n🆕 恒生科技大涨 | 港股 | 5.8 | 2 条",
-            "run_id": "job_f8a5b0a67ad3",                       # 死 id
-            "source_session_id": "job_routine_38364fe6_d185ce87",  # 活 id(归档 session)
+            "run_id": "job_f8a5b0a67ad3",                        # 死 id
+            "source_session_id": "web_session_demo_agent",        # 信封自带的发出方 session(干扰项)
+            "projection_source_id": "job_routine_38364fe6_d185ce87",  # 活 id(归档 session)
         }
 
         ok = await ch._maybe_attach_projection("test_agent", 555, data)
@@ -2141,7 +2142,7 @@ class TestProjectionProvenance:
         assert kwargs["source_run_id"] == "job_routine_38364fe6_d185ce87"
 
     @pytest.mark.asyncio
-    async def test_falls_back_to_run_id_when_no_source_session(self, tmp_path, _provider):
+    async def test_falls_back_to_run_id_when_no_projection_source(self, tmp_path, _provider):
         ch = _make_channel(tmp_path)
         ch._session_manager.get_cached_agent.return_value = SimpleNamespace()
         data = {"transcript_worthy": True, "detail": "x", "run_id": "job_abc"}


### PR DESCRIPTION
## 问题

用户问「恒生科技大涨 来源哪里」查无此物。projection 的 `producedBy.runId` 填的是一次性合成的 job 执行 id(`job_<uuid12>`,如 `job_f8a5b0a67ad3`)—— 无 milkie run、无 session 文件,回溯不到任何执行,逼模型说找不到或编无法核实的引用。而真实可溯源锚点 `source_session_id`(归档 job session,报告全文+轨迹所在)只进了 mailbox,没串进 realtime 事件。

详见 #122(含完整证据链)。

## 修复(三处,纯 alfred 侧)

- `cron_delivery._emit_realtime` 增传 `source_session_id`,写进 realtime 事件。
- `cron.py` 两条投递路径(`_run_isolated_job` / `_run_isolated_agent`)把各自 `deposit_job_event` 用的 `job_session_id` 一并传入 `_emit_realtime`。
- `telegram_channel._maybe_attach_projection` 溯源锚点优先用 `source_session_id`,缺失才回落 `run_id`(向后兼容)。

## 验证

- **TDD**:4 单测(emit 携带/缺省 source_session_id;projection 优先 source_session_id、缺失回落 run_id)+ 1 跨缝 e2e(真实 cron 投递→事件总线→真实 channel projection)。全量 **1879 单测通过**。
- **端到端(活体)**:重启 daemon 加载新代码后,projection 的 sourceRunId 由全部 ❌死`job_<12hex>`(改前 13:36–14:23)切换为 ✅可解析 session id(改后 16:05)。

Closes #122