### PR TITLE
feat(#124): 报告型技能可信度分层方案 + gray-rhino L2 样板

### DIFF
--- a/docs/design/124-report-skill-provenance.md
+++ b/docs/design/124-report-skill-provenance.md
@@ -1,0 +1,73 @@
+# 124 — 报告型技能可信度:逐条结论可溯源
+
+> Issue: #124 · 关联: #122(L0 投递溯源)· 概念基础: milkie `docs/zh/concepts-observability-vs-lineage.md`
+
+## 1. 问题:不是一个 bug,是一个问题类
+
+排查 #122(投递溯源断链)时挖出的根本问题,不限于灰犀牛:
+
+> alfred 的"报告型技能"普遍以不透明 python 子进程产出聚合结论;**既不强制工具真执行**(可以不跑就编),**也不把原始证据铸成原子 object 进 milkie 血缘图**(可观测只到"整坨输出",逐条结论无法机械溯源)。
+
+三个叠加失败模式:
+
+| # | 失败模式 | 根因 | 用户体感 |
+|---|---|---|---|
+| F1 | 投递溯源断链 | 投递锚点用合成 job 号 | "这报告哪次跑的"——查无此物 |
+| F2 | 不跑就编整份报告 | "NEVER fabricate" 只是提示词,未强制 | 数字像凭空捏 |
+| F3 | 真跑了也说不清细节来源 | 原始条目(title+source+url)在聚类/落盘丢失;tool 输出是整坨 blob,逐条结论无原子源 | 问"这条哪来的"→ 含糊或现编 |
+
+## 2. 范围:所有"抓数据→聚合→出报告"的 routine 同病
+
+灰犀牛 `routine_d4112f2e` · 每日投资信号 `routine_38364fe6` · 每日论文 `routine_476c4861` · Serenity分析 `routine_3d785e79` · 每日新闻简报 `routine_86e85e59` · `contrarian-signals`…
+
+共用同一管道形状 → 共用同一组失败。**解法在共性层,不逐技能打补丁。**
+
+## 3. 分层解法
+
+坐标轴见 milkie 概念文档「可观测 vs 血缘」。
+
+| 层 | 做什么 | 堵住 | 成本 | 通用性 | 本 issue |
+|---|---|---|---|---|---|
+| **L0 可观测底座** | 投递可溯源到产出 run(`projection_source_id`) | F1 | — | 框架级 | #122 已完成 |
+| **L1 强制工具执行** | 报告的数必须有真实 tool 调用支撑,否则不准发 | F2 | 中 | 框架级闸门 | 🔜 后续 |
+| **L2 粗粒度血缘** | 每条结论 `cite` 到那次抓取/报告的 object;且该 object 内含逐条证据 | F2 + 半个 F3 | 低 | 约定 + 共享流程 | ✅ **本 issue 灰犀牛样板** |
+| **L3 原子血缘** | 数据工具逐条铸 object(url 进 meta),结论 `derives_from` 具体条目 | 整个 F3 | 高 | 需共享"数据工具"层 | ⛔ 暂不做 |
+
+**关键认识**:L2 = **血缘的边 + 可观测的节点**——堵"凭空编源"(`resolveObject` 拒伪造 objectId),堵不住"真源里误引"(节点是整坨 blob,「数 ∈ blob」无人机械校验)。L3 把节点原子化才两个都堵。**python/TS 边界在 L3 才真正咬人**(逐条铸 object 须在 TS 侧,python 子进程碰不到 `registerObject`),故本 issue 不碰 L3。
+
+## 4. 本 issue 落地:灰犀牛 L2 样板
+
+L2 要"可用",cite 指向的节点必须真带证据。当前 `rhino_analyzer.py` 建 cluster 时丢掉了每条新闻的 `url`(只留 `sources` 源名 + `representative_title`)。所以样板分两步:
+
+### 4.1 止损 F3 的数据丢失(本 issue 实现,TDD)
+
+- `rhino_analyzer.NewsCluster` 增 `evidence` 字段:每个 cluster 的贡献条目 `[{title, source, url, published}]`,在建 cluster 时从 `group_items` 填入(url 本就在 group_items 里)。
+- `rhino_report.py` 逐条信号输出 `evidence`:
+  - `--format json`:每个 signal 带完整 `evidence[]`。
+  - `--format text`:每条信号尾部列 top-N 条「标题 — 链接」(紧凑,定时推送带得动)。
+- 这样被 cite 的报告 object **内含逐条来源链接**,L2 的粗粒度 cite 才真正可用,也为 L3 备好数据。
+
+### 4.2 L2 cite 约定(本 issue:写进 SKILL.md)
+
+- gray-rhino `SKILL.md` 增约定:出报告后,**每条信号 `cite` 到报告/抓取的 object**(milkie shell 工具已自动把 stdout 铸成 `shell:stdout` object 并在结果带回 `objectId`)。
+- 效果:`get_lineage(query="某信号")` 走 cite 图返回报告 object;`resolveObject` 保证来源不可伪造。
+- **诚实标注边界**:这是**报告级**血缘(粗粒度)。"具体哪篇文章"仍需打开 object 看(4.1 的 evidence 让这一步有据可依),机械的逐条绑定属 L3。
+
+### 4.3 不做(明确排除)
+
+- L3 原子 object / `derives_from` 逐条边(需 TS 数据工具层,另立项)。
+- L1 强制执行闸门(需框架级"未引用结论"检测)。
+- 把 L2 铺到其余 routine(灰犀牛跑通后再铺)。
+
+## 5. 共性杠杆(后续,非本 issue)
+
+不逐技能改提示词,而建可复用基座:
+
+1. **共享"可引用数据工具"层**(L3 通用版):milkie 原生 `fetch_*`/`query_*` 逐条 `citeable`,所有报告型技能的抓取走它 → 逐条 object 免费。
+2. **报告型技能作者约定 + 模板**:数据经可引用工具产出 + 每条结论 cite。
+3. **"未引用结论"闸门**(L1):投递前检测带数字/事实的结论是否有 cites 边,否则拦下或标降级。
+
+## 6. 验收
+
+- TDD:`rhino_report --format json` 每条 signal 的 `evidence` 非空、url 来自真实抓取条目;analyzer 保留 per-item url。
+- 端到端:重跑灰犀牛,报告逐条带来源链接;SKILL.md cite 约定就位。

--- a/skills/gray-rhino/SKILL.md
+++ b/skills/gray-rhino/SKILL.md
@@ -119,6 +119,10 @@ python $SKILL_DIR/scripts/asset_mapper.py --list-scenarios
 3. **忽略 📉 信号**：除非用户明确要求，趋势减弱的事件通常已不构成灰犀牛
 4. **补充资产影响**：对未匹配到内置场景的信号，用你的分析能力推断资产影响
 5. **持续积累**：提醒用户定期运行以积累历史基线，趋势分析需要时间维度
+6. **溯源（#124 L2）**：报告每条信号现在都带 `evidence`（贡献新闻的 `title/source/url`，JSON 全量、text 列 top3 链接）。
+   - 回答"这条信号哪来的"时，**直接引用 `evidence` 里的真实链接**，不要凭印象编来源。
+   - milkie shell 工具已把脚本 stdout 铸成可引用 object（结果带回 `objectId`）。**把每条信号 `cite` 到该报告 object**，使 `get_lineage` 能溯源、且来源不可伪造。
+   - 诚实边界：这是**报告级**血缘（粗粒度）。「具体哪篇」可打开报告 object 看 `evidence`；逐条机械绑定属后续 L3，不要假装已做到。
 
 ## Dependencies
 

--- a/skills/gray-rhino/scripts/rhino_analyzer.py
+++ b/skills/gray-rhino/scripts/rhino_analyzer.py
@@ -79,6 +79,9 @@ class NewsCluster:
     sources: List[str]
     count: int
     keywords: List[str] = field(default_factory=list)
+    # #124 L2:保留每条贡献新闻的可溯源证据(title+source+url+published),
+    # 让下游报告逐条信号能带来源链接、被 cite 的报告 object 真带证据。
+    evidence: List[dict] = field(default_factory=list)
 
 
 class RhinoAnalyzer:
@@ -160,6 +163,15 @@ class RhinoAnalyzer:
                     sources=list(set(it.get("source", "") for it in group_items)),
                     count=len(group_items),
                     keywords=keywords[:10],
+                    evidence=[
+                        {
+                            "title": it.get("title", ""),
+                            "source": it.get("source", ""),
+                            "url": it.get("url", ""),
+                            "published": it.get("published", ""),
+                        }
+                        for it in group_items
+                    ],
                 ))
 
         return all_clusters

--- a/skills/gray-rhino/scripts/rhino_report.py
+++ b/skills/gray-rhino/scripts/rhino_report.py
@@ -212,6 +212,13 @@ def format_text_report(report: dict) -> str:
 
         lines.append(f"   关键词: {', '.join(sig.get('keywords', [])[:6])}")
 
+        # #124 L2:逐条来源(标题 — 链接),最多 3 条,供下钻 / cite。
+        evidence = [e for e in sig.get("evidence", []) if e.get("url")]
+        if evidence:
+            lines.append("   来源:")
+            for e in evidence[:3]:
+                lines.append(f"     - {e.get('title', '')[:50]} — {e['url']}")
+
         # Asset impact
         event = event_map.get(sig["representative_title"])
         if event:

--- a/skills/gray-rhino/scripts/trend_tracker.py
+++ b/skills/gray-rhino/scripts/trend_tracker.py
@@ -14,7 +14,7 @@ import json
 import logging
 import os
 from collections import defaultdict
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timezone, timedelta
 from pathlib import Path
 from typing import Dict, List, Tuple
@@ -45,6 +45,9 @@ class TrendSignal:
     source_diversity: float  # 0-1, 1 = many independent sources
     days_tracked: int  # how many days this topic has appeared
     history_counts: List[int]  # daily counts over tracking window
+    # #124 L2:逐条来源证据(title+source+url+published),从 cluster 透传,
+    # 供报告逐条信号下钻与 cite。
+    evidence: List[dict] = field(default_factory=list)
 
 
 @dataclass
@@ -255,6 +258,7 @@ class TrendTracker:
             source_diversity=round(source_diversity, 2),
             days_tracked=days_tracked,
             history_counts=history_counts,
+            evidence=cluster.get("evidence", []),
         )
 
     def _build_daily_counts(self, timeline: List[Tuple[str, int]],

--- a/tests/unit/test_gray_rhino_evidence.py
+++ b/tests/unit/test_gray_rhino_evidence.py
@@ -1,0 +1,98 @@
+"""#124 L2 样板:报告逐条信号保留来源证据(title+source+url),让被 cite 的
+报告 object 真带逐条链接 —— 否则 cite 到的只是一坨无 url 的聚合文本。
+
+证据在 rhino_analyzer 聚类时(NewsCluster)就该保留,经 trend_tracker(TrendSignal)
+穿到 rhino_report 输出。离线:不触网,直接喂带 url 的 NewsItem。
+"""
+import importlib.util
+import sys
+from dataclasses import asdict
+from pathlib import Path
+
+_SCRIPTS = Path(__file__).resolve().parents[2] / "skills" / "gray-rhino" / "scripts"
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+
+def _load(name):
+    spec = importlib.util.spec_from_file_location(name, _SCRIPTS / f"{name}.py")
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+nf = _load("news_fetcher")
+ra = _load("rhino_analyzer")
+rr = _load("rhino_report")
+
+
+def _items():
+    return [
+        nf.NewsItem(title="长江有色：24日铜价四连跌 下游畏高情绪仍浓",
+                    summary="铜价四连跌", source="Sina Finance",
+                    url="https://finance.sina/cu1", published="2026-06-24T08:00:00"),
+        nf.NewsItem(title="长江有色：24日铝价大跌 整体成交偏淡",
+                    summary="铝价大跌", source="Sina Finance",
+                    url="https://finance.sina/al2", published="2026-06-24T08:05:00"),
+    ]
+
+
+def _to_dicts(items):
+    out = [asdict(i) for i in items]
+    for d in out:
+        d.pop("_hash", None)
+    return out
+
+
+def test_analyzer_cluster_retains_per_item_evidence():
+    items = _to_dicts(_items())
+    clusters = ra.RhinoAnalyzer(min_cluster_size=1).analyze(items)
+    assert clusters
+
+    all_ev = [e for c in clusters for e in c.get("evidence", [])]
+    assert all_ev, "每个 cluster 必须保留贡献条目的 evidence"
+    # 每条 evidence 带可追溯的 title+source+url
+    for e in all_ev:
+        assert e.get("url") and e.get("title") and e.get("source")
+    # 原始 url 不丢:聚类后 evidence 的 url 全集 == 输入 url 全集
+    assert {e["url"] for e in all_ev} == {"https://finance.sina/cu1", "https://finance.sina/al2"}
+
+
+def _fake_fetcher_cls(items):
+    rep = {"attempted": 1, "succeeded": 1, "failed": 0,
+           "failed_detail": [], "per_source": []}
+
+    class FakeFetcher:
+        def __init__(self, *a, **k):
+            self.fetch_report = rep
+
+        def fetch_all(self, max_age_hours=48):
+            return items
+
+    return FakeFetcher
+
+
+def test_report_json_signals_carry_evidence(tmp_path, monkeypatch):
+    monkeypatch.setattr(rr, "NewsFetcher", _fake_fetcher_cls(_items()))
+    result = rr.generate_report(save_snapshot=False, history_dir=str(tmp_path))
+    assert result["ok"] is True
+
+    signals = result["signals"]
+    assert signals
+    ev_urls = {e["url"] for s in signals for e in s.get("evidence", [])}
+    assert ev_urls, "每条信号必须带 evidence(来源条目含 url)"
+    assert ev_urls <= {"https://finance.sina/cu1", "https://finance.sina/al2"}
+    # 至少一条信号的 evidence 非空且每条带 url
+    assert any(s.get("evidence") for s in signals)
+    for s in signals:
+        for e in s.get("evidence", []):
+            assert e.get("url")
+
+
+def test_text_report_lists_source_link_for_signal(tmp_path, monkeypatch):
+    monkeypatch.setattr(rr, "NewsFetcher", _fake_fetcher_cls(_items()))
+    result = rr.generate_report(save_snapshot=False, history_dir=str(tmp_path))
+    text = rr.format_text_report(result)
+    # text 报告里逐条信号应能看到来源链接(粗粒度 cite 的节点据此可下钻)
+    assert "https://finance.sina/cu1" in text or "https://finance.sina/al2" in text


### PR DESCRIPTION
落地 #124:报告型技能可信度的系统性方案(设计文档),并先拿灰犀牛做 L2 粗粒度血缘样板。L3 暂不做。

## 设计文档
`docs/design/124-report-skill-provenance.md` —— L0(#122 已修)/L1 强制执行/L2 粗粒度血缘/L3 原子血缘的分层解法,及"为什么解在共性层不逐技能打补丁"。概念基础:milkie `docs/zh/concepts-observability-vs-lineage.md`。

## 本 PR 实现(灰犀牛 L2 样板)
证据原在 `rhino_analyzer` 聚类时被丢(只留源名)。现:
- `NewsCluster.evidence` 保留每条贡献新闻 `{title,source,url,published}`,经 `TrendSignal` 透传。
- 报告输出:JSON 每条 signal 带 `evidence[]`;text 每条信号列 top3「标题 — 链接」;快照顺带留。
- `SKILL.md` L2 cite 约定:回答来源直接引真链接;每条信号 `cite` 到报告 object(`get_lineage` 可溯源、`resolveObject` 防伪造);诚实标注这是**报告级粗粒度**,逐条机械绑定属 L3。

## 不做(明确排除)
- L3 原子 object / `derives_from`(需 TS 数据工具层,另立项)。
- L1 强制执行闸门、把 L2 铺到其余 routine —— 后续。

## 验证
- TDD:analyzer 保留 per-item url;report JSON/text 逐条带 evidence。**1878 单测通过**。
- 端到端:真实脚本跑出的每条信号带真实 BBC/CNBC/Al Jazeera 链接。

Refs #124