### PR TITLE
feat(#127): L1 provenance gate — observe-only 首切

### DIFF
--- a/src/everbot/core/runtime/cron.py
+++ b/src/everbot/core/runtime/cron.py
@@ -650,6 +650,11 @@ class CronExecutor:
             await self.session_manager.save_session(job_session_id, agent)
             await self.session_manager.mark_session_archived(job_session_id)
 
+            # #127 L1 provenance gate (observe-only): log whether this report run
+            # was backed by real tools + cites. Does NOT alter delivery — we
+            # measure the live flag rate before any banner/block (防误杀).
+            self._observe_provenance(task, agent)
+
             summary = f"{task_title or task.id} completed"
             await self.delivery.deposit_job_event(
                 event_type="job_completed",
@@ -689,6 +694,34 @@ class CronExecutor:
                 fail_msg += f"\n\n{retry_hint}"
             await self.delivery._emit_realtime(fail_msg, run_id)
             raise
+
+    def _observe_provenance(self, task: Task, agent: Any) -> None:
+        """#127 L1 (observe-only): log a backing verdict for this isolated report
+        run — did it run real data tools, did it cite? LOG ONLY; never alters
+        delivery and never raises into it. Lets us measure the live flag rate
+        before turning on any banner/block (防误杀: observe-first)."""
+        try:
+            from .provenance_gate import assess_report_backing, read_run_events
+            from ..agent.provider.milkie.provider import _milkie_data_dir
+
+            milkie_run_id = getattr(agent, "last_run_id", None)
+            if not milkie_run_id:
+                return
+            events = read_run_events(_milkie_data_dir(self.agent_name), milkie_run_id)
+            if not events:
+                return
+            v = assess_report_backing(events)
+            verdict = (
+                "UNBACKED" if not v.has_tool_backing
+                else "NO_CITES" if not v.has_cites
+                else "ok"
+            )
+            logger.info(
+                "[provenance/observe] task=%s run=%s tool_calls=%d cites=%d verdict=%s",
+                task.id, milkie_run_id, v.tool_calls, v.cites, verdict,
+            )
+        except Exception:
+            logger.debug("provenance observe failed", exc_info=True)
 
     async def _create_job_agent(self, job_session_id: str) -> Any:
         """Create a fresh agent for isolated job execution."""

--- a/src/everbot/core/runtime/provenance_gate.py
+++ b/src/everbot/core/runtime/provenance_gate.py
@@ -1,0 +1,91 @@
+"""#127 L1 provenance gate (observe-first).
+
+Assess whether a completed report run is *backed*: did the agent actually run
+real data tools, and did it declare cite edges for its claims? This catches F2
+("不跑就编" — a report whose numbers came from no tool at all) and measures L2
+cite coverage.
+
+**observe-first**: this module only *computes* a verdict from a run's events;
+it does NOT alter delivery. The caller logs the verdict so we can measure the
+real false-positive rate on live traffic before any banner / hard block is
+turned on (see issue #127). Reading the events is pure alfred-side (the milkie
+run JSONL) — no milkie change.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List
+
+logger = logging.getLogger(__name__)
+
+# Tools that produce/cite/think rather than *fetch data* — excluded from the
+# data-tool count so "did real data get fetched?" isn't satisfied by cite/think.
+_NON_DATA_TOOLS = frozenset({
+    "cite", "declare_relation", "think", "create_plan", "update_step",
+    "get_lineage", "get_execution", "get_run_io",
+})
+
+
+@dataclass
+class BackingVerdict:
+    """How well a report run is backed by tools + provenance."""
+    tool_calls: int = 0          # real data-tool executions (excl. cite/think/…)
+    cites: int = 0               # `cites` relation edges declared
+    commands: List[str] = field(default_factory=list)  # shell commands run
+
+    @property
+    def has_tool_backing(self) -> bool:
+        return self.tool_calls > 0
+
+    @property
+    def has_cites(self) -> bool:
+        return self.cites > 0
+
+    def ran_command_matching(self, needle: str) -> bool:
+        """True if any shell command contains ``needle`` (e.g. a must_run script)."""
+        return any(needle in c for c in self.commands)
+
+
+def assess_report_backing(events: List[Dict[str, Any]]) -> BackingVerdict:
+    """Fold a run's events into a backing verdict. Pure, no IO."""
+    v = BackingVerdict()
+    for e in events:
+        etype = e.get("type")
+        payload = e.get("payload") or {}
+        if etype == "tool.requested":
+            name = payload.get("toolName") or payload.get("name") or ""
+            if name and name not in _NON_DATA_TOOLS:
+                v.tool_calls += 1
+                inp = payload.get("input")
+                if isinstance(inp, dict):
+                    cmd = inp.get("command")
+                    if cmd:
+                        v.commands.append(str(cmd))
+        elif etype == "relation.created":
+            if payload.get("type") == "cites":
+                v.cites += 1
+    return v
+
+
+def read_run_events(data_dir: Any, run_id: str) -> List[Dict[str, Any]]:
+    """Read a milkie run's JSONL events. Returns [] if missing/unreadable —
+    observe-only must never raise into the delivery path."""
+    try:
+        path = Path(data_dir) / "runs" / f"{run_id}.jsonl"
+        if not path.exists():
+            return []
+        out: List[Dict[str, Any]] = []
+        for line in path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                out.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+        return out
+    except OSError:
+        return []

--- a/tests/unit/test_provenance_gate.py
+++ b/tests/unit/test_provenance_gate.py
@@ -1,0 +1,67 @@
+"""#127 L1 provenance gate — assess whether a report run is backed by real
+tool execution + cite edges. observe-first: pure assessment, no delivery change."""
+
+from src.everbot.core.runtime.provenance_gate import (
+    assess_report_backing,
+    BackingVerdict,
+)
+
+
+def _ev(etype, **payload):
+    return {"type": etype, "payload": payload}
+
+
+def test_no_tool_no_cite_is_unbacked():
+    """纯 LLM 轮、零工具、零 cite —— 正是 F2「不跑就编」的形态。"""
+    events = [_ev("llm.requested"), _ev("llm.responded")]
+    v = assess_report_backing(events)
+    assert isinstance(v, BackingVerdict)
+    assert v.tool_calls == 0 and v.cites == 0
+    assert v.has_tool_backing is False
+    assert v.has_cites is False
+
+
+def test_data_tools_counted_cite_think_lineage_excluded():
+    """只数真数据工具;cite/think/get_lineage 等非取数工具不计入 tool_calls。"""
+    events = [
+        _ev("tool.requested", toolName="run_command", input={"command": "python rhino_report.py"}),
+        _ev("tool.requested", toolName="think", input={}),
+        _ev("tool.requested", toolName="cite", input={"claim": "x", "objectId": "o"}),
+        _ev("tool.requested", toolName="get_lineage", input={}),
+    ]
+    v = assess_report_backing(events)
+    assert v.tool_calls == 1
+    assert v.commands and "rhino_report.py" in v.commands[0]
+
+
+def test_cites_relations_counted_derives_from_not():
+    events = [
+        _ev("relation.created", type="cites", fromObjectId="a", toObjectId="b"),
+        _ev("relation.created", type="cites", fromObjectId="a", toObjectId="c"),
+        _ev("relation.created", type="derives_from", fromObjectId="a", toObjectId="d"),
+    ]
+    v = assess_report_backing(events)
+    assert v.cites == 2
+
+
+def test_realistic_backed_report_passes():
+    """跑了脚本 + 逐条 cite —— 合格报告。"""
+    events = [
+        _ev("tool.requested", toolName="skill_request", input={"name": "gray-rhino"}),
+        _ev("tool.requested", toolName="run_command", input={"command": "python scripts/rhino_report.py"}),
+        _ev("relation.created", type="cites", fromObjectId="c1", toObjectId="o"),
+        _ev("relation.created", type="cites", fromObjectId="c2", toObjectId="o"),
+    ]
+    v = assess_report_backing(events)
+    assert v.has_tool_backing and v.has_cites
+    assert v.tool_calls == 2 and v.cites == 2
+
+
+def test_command_ran_matches_declared_must_run():
+    """must_run 匹配:声明的必经脚本到底跑没跑(后续强制判据的基础)。"""
+    events = [
+        _ev("tool.requested", toolName="run_command", input={"command": "cd x && python scripts/rhino_report.py --format text"}),
+    ]
+    v = assess_report_backing(events)
+    assert v.ran_command_matching("rhino_report.py") is True
+    assert v.ran_command_matching("news_fetcher.py") is False


### PR DESCRIPTION
L1 强制闸门第一刀:**observe-only**(只算 verdict + 日志,零投递影响),先在真实流量上量误杀率,再谈 banner/硬扣。

## 实现
- `provenance_gate.assess_report_backing(events) -> BackingVerdict`(纯函数,TDD):折叠 milkie run 事件 → `tool_calls`(真数据工具,排除 cite/think/get_*)+ `cites` + `commands`(供 must_run 匹配)。
- `read_run_events`:读 run JSONL,best-effort 不抛。
- `cron._run_isolated_agent` 投递前调 `_observe_provenance`:`agent.last_run_id` → 读事件 → 算 verdict → **只日志**(`verdict=UNBACKED/NO_CITES/ok`),不碰投递、不抛。集成点 `agent.last_run_id` 已验证。

## 防误杀(本 PR 阶段)
observe-only:**完全不改投递**。后续才接 SKILL `provenance.required/must_run` 声明 + opt-in 强制 + 软 banner。

## 验证
TDD 5 测;**1889 单测通过**。

Refs #127