### PR TITLE
feat(#130): T1 投递机械内联 top1 原文链接(选项 A)

### DIFF
--- a/skills/gray-rhino/scripts/rhino_report.py
+++ b/skills/gray-rhino/scripts/rhino_report.py
@@ -132,6 +132,22 @@ def _format_sources_line(sources: dict) -> str:
             + f" —— 信号基于 {contributing} 个有效源，请据此降级解读")
 
 
+def _build_provenance_block(signals: list) -> str:
+    """#130 T1:机械输出每条信号 top1 {title,url} 的 PROVENANCE 块,供投递侧提取成
+    推送原文链接(独立于 LLM 散文)。只收带 url 的 evidence;无则不出块。"""
+    out = []
+    for sig in signals:
+        for e in sig.get("evidence", []):
+            url = e.get("url")
+            title = e.get("title")
+            if url and title:
+                out.append({"title": title, "url": url})
+                break  # top1 per signal
+    if not out:
+        return ""
+    return "<PROVENANCE>" + json.dumps({"signals": out}, ensure_ascii=False) + "</PROVENANCE>"
+
+
 def format_text_report(report: dict) -> str:
     """Format report as human-readable text with trend focus."""
     if not report.get("ok"):
@@ -258,6 +274,11 @@ def format_text_report(report: dict) -> str:
             lines.append(f"     - {s['representative_title']} "
                          f"(×{s.get('acceleration', 0):.1f})")
     lines.append("")
+
+    # #130 T1:末尾机械追加 PROVENANCE 块(每信号 top1 原文链接),供投递侧提取。
+    block = _build_provenance_block(signals)
+    if block:
+        lines.append(block)
 
     return "\n".join(lines)
 

--- a/skills/gray-rhino/scripts/rhino_report.py
+++ b/skills/gray-rhino/scripts/rhino_report.py
@@ -133,8 +133,9 @@ def _format_sources_line(sources: dict) -> str:
 
 
 def _build_provenance_block(signals: list) -> str:
-    """#130 T1:机械输出每条信号 top1 {title,url} 的 PROVENANCE 块,供投递侧提取成
-    推送原文链接(独立于 LLM 散文)。只收带 url 的 evidence;无则不出块。"""
+    """#130 T1: emit a machine PROVENANCE block carrying each signal's top-1 {title,url}
+    so delivery can extract source links for the push (independent of the LLM prose). Only
+    evidence with a url is included; no block is emitted when there is none."""
     out = []
     for sig in signals:
         for e in sig.get("evidence", []):
@@ -275,7 +276,8 @@ def format_text_report(report: dict) -> str:
                          f"(×{s.get('acceleration', 0):.1f})")
     lines.append("")
 
-    # #130 T1:末尾机械追加 PROVENANCE 块(每信号 top1 原文链接),供投递侧提取。
+    # #130 T1: append the machine PROVENANCE block (top-1 source link per signal) for
+    # delivery-side extraction.
     block = _build_provenance_block(signals)
     if block:
         lines.append(block)

--- a/src/everbot/channels/telegram_channel.py
+++ b/src/everbot/channels/telegram_channel.py
@@ -229,10 +229,11 @@ class TelegramChannel:
         run_id = str(data.get("run_id") or "").strip()
         if not detail or not run_id:
             return False
-        # #122:溯源锚点优先用可解析的 projection_source_id(产出方归档 job session,
-        # 报告全文+轨迹所在);它缺失时才回落一次性合成的 run_id —— run_id 回溯不到
-        # 任何执行,用户问"来源哪里"会落空。注意不可用信封的 source_session_id:那是
-        # 发出方 session(primary),非产出方。
+        # #122/#130 T2: prefer projection_source_id as the provenance anchor. For isolated
+        # report runs this is the producing job's milkie runId (deref-able by the consuming
+        # agent via get_execution/get_lineage under milkie#200's delivered-runId allowlist);
+        # fall back to the synthesized run_id only when absent. Never use the envelope's
+        # source_session_id — that is the sender (primary) session, not the producer.
         source_run_id = str(data.get("projection_source_id") or "").strip() or run_id
 
         from ..core.agent.provider import get_provider_for_agent

--- a/src/everbot/core/runtime/cron.py
+++ b/src/everbot/core/runtime/cron.py
@@ -659,6 +659,12 @@ class CronExecutor:
             # delivered result (independent of the LLM prose).
             result = self._append_run_provenance(result, agent)
 
+            # #130 T2: the projection anchor must be the milkie run id (deref-able by the
+            # consuming agent via get_execution/get_lineage under milkie#200's
+            # delivered-runId allowlist), not the job session id — readByRunId is keyed by
+            # the milkie runId. Fall back to the session id when no run id was captured.
+            projection_anchor = getattr(agent, "last_run_id", None) or job_session_id
+
             summary = f"{task_title or task.id} completed"
             await self.delivery.deposit_job_event(
                 event_type="job_completed",
@@ -670,7 +676,7 @@ class CronExecutor:
             await self.delivery.inject_to_history(result, run_id)
             await self.delivery._emit_realtime(
                 result, run_id, transcript_worthy=True,
-                source_session_id=job_session_id,  # #122:可解析溯源锚点(归档 job session)
+                source_session_id=projection_anchor,  # #130 T2: milkie runId, deref-able
             )
 
             # SLM: record skill invocations from this isolated agent run.

--- a/src/everbot/core/runtime/cron.py
+++ b/src/everbot/core/runtime/cron.py
@@ -655,7 +655,8 @@ class CronExecutor:
             # measure the live flag rate before any banner/block (防误杀).
             self._observe_provenance(task, agent)
 
-            # #130 T1:机械追加每信号 top1 原文链接到投递结果(独立于 LLM 散文)。
+            # #130 T1: mechanically append each signal's top-1 source link to the
+            # delivered result (independent of the LLM prose).
             result = self._append_run_provenance(result, agent)
 
             summary = f"{task_title or task.id} completed"
@@ -727,9 +728,10 @@ class CronExecutor:
             logger.debug("provenance observe failed", exc_info=True)
 
     def _append_run_provenance(self, result: str, agent: Any) -> str:
-        """#130 T1:把本 run 每条信号的 top1 原文链接机械追加到报告尾部 —— 独立于
-        LLM 散文(LLM 可能把链接摘掉)。来源是 run 事件里报告脚本 stdout 的
-        PROVENANCE 块。失败一律吞掉返回原文(投递不能因溯源附加而崩)。"""
+        """#130 T1: mechanically append each signal's top-1 source link to the report —
+        independent of the LLM prose (which may drop the links). Source is the trusted
+        report-script's PROVENANCE block in the run events. Any failure is swallowed and the
+        body returned unchanged (delivery must not crash on the provenance add-on)."""
         try:
             from .provenance_footer import append_provenance_footer
             from .provenance_gate import read_run_events

--- a/src/everbot/core/runtime/cron.py
+++ b/src/everbot/core/runtime/cron.py
@@ -655,6 +655,9 @@ class CronExecutor:
             # measure the live flag rate before any banner/block (防误杀).
             self._observe_provenance(task, agent)
 
+            # #130 T1:机械追加每信号 top1 原文链接到投递结果(独立于 LLM 散文)。
+            result = self._append_run_provenance(result, agent)
+
             summary = f"{task_title or task.id} completed"
             await self.delivery.deposit_job_event(
                 event_type="job_completed",
@@ -722,6 +725,24 @@ class CronExecutor:
             )
         except Exception:
             logger.debug("provenance observe failed", exc_info=True)
+
+    def _append_run_provenance(self, result: str, agent: Any) -> str:
+        """#130 T1:把本 run 每条信号的 top1 原文链接机械追加到报告尾部 —— 独立于
+        LLM 散文(LLM 可能把链接摘掉)。来源是 run 事件里报告脚本 stdout 的
+        PROVENANCE 块。失败一律吞掉返回原文(投递不能因溯源附加而崩)。"""
+        try:
+            from .provenance_footer import append_provenance_footer
+            from .provenance_gate import read_run_events
+            from ..agent.provider.milkie.provider import _milkie_data_dir
+
+            run_id = getattr(agent, "last_run_id", None)
+            if not run_id:
+                return result
+            events = read_run_events(_milkie_data_dir(self.agent_name), run_id)
+            return append_provenance_footer(result, events)
+        except Exception:
+            logger.debug("provenance footer failed", exc_info=True)
+            return result
 
     async def _create_job_agent(self, job_session_id: str) -> Any:
         """Create a fresh agent for isolated job execution."""

--- a/src/everbot/core/runtime/provenance_footer.py
+++ b/src/everbot/core/runtime/provenance_footer.py
@@ -1,23 +1,46 @@
-"""#130 T1 — 机械给报告每条信号附 top1 原文链接。
+"""#130 T1 — mechanically attach each report signal's top-1 source link at delivery.
 
-报告型脚本在 stdout 末尾机械输出一个 ``<PROVENANCE>{"signals":[...]}</PROVENANCE>``
-块(每条信号 top1 ``{title,url}``)。投递侧从 milkie run 事件里取出该块、渲染成
-footer 追加到推送 —— **独立于 LLM 散文**(LLM 可能把链接摘掉)。纯函数,无 IO。
+Report-producing scripts emit a machine block
+``<PROVENANCE>{"signals":[{title,url}, ...]}</PROVENANCE>`` (top-1 per signal) at the end
+of stdout. Delivery pulls it from the run's events and renders a footer appended to the
+push — independent of the LLM prose, which may drop the links.
+
+Security (#131 review P1): only the block produced by the *trusted producer script*
+(``rhino_report.py``) is honored. A response's stdout is trusted only when it is bound (by
+``toolCallId``) to a ``run_command`` request whose argv invokes a trusted script. A
+``<PROVENANCE>`` tag appearing in any other tool output — e.g. external tweet/web content
+flowing through a different command — is ignored, preventing forged source links. URLs are
+restricted to http(s); titles are flattened to one line; counts and lengths are capped.
+Pure functions, no IO.
 """
 from __future__ import annotations
 
 import json
 import re
+import shlex
 from typing import Any, Dict, List
 
 _BLOCK_RE = re.compile(r"<PROVENANCE>(.*?)</PROVENANCE>", re.DOTALL)
 
+# Script-path suffixes whose run_command output may carry a PROVENANCE block. Trust is
+# bound to the executed command (which the agent constructs), never to tool output (which
+# may contain attacker-influenced external content).
+_TRUSTED_PRODUCER_SCRIPTS = ("gray-rhino/scripts/rhino_report.py",)
+
+_MAX_SIGNALS = 20
+_MAX_TITLE_LEN = 200
+_MAX_URL_LEN = 500
+_URL_SCHEME_RE = re.compile(r"^https?://", re.IGNORECASE)
+_WS_RE = re.compile(r"\s+")
+
 
 def extract_provenance_block(text: str) -> List[Dict[str, str]]:
-    """从一段文本里取出 PROVENANCE 块的 signals(title+url 俱全者)。
+    """Parse and validate the PROVENANCE block out of a piece of text.
 
-    Robust:无块 / 坏 JSON / 缺字段一律降级为 ``[]``,绝不抛 —— 投递路径不能因
-    溯源附加而崩。"""
+    Robust + hardened: missing block / bad JSON / bad fields degrade to ``[]`` and never
+    raise. Drops signals whose url is not http(s) or is over-long; flattens whitespace in
+    titles (no newlines breaking the Markdown list); caps the signal count.
+    """
     m = _BLOCK_RE.search(text or "")
     if not m:
         return []
@@ -33,20 +56,61 @@ def extract_provenance_block(text: str) -> List[Dict[str, str]]:
         if not isinstance(s, dict):
             continue
         title, url = s.get("title"), s.get("url")
-        if isinstance(title, str) and title and isinstance(url, str) and url:
-            out.append({"title": title, "url": url})
+        if not (isinstance(title, str) and title and isinstance(url, str) and url):
+            continue
+        if not _URL_SCHEME_RE.match(url) or len(url) > _MAX_URL_LEN:
+            continue
+        title = _WS_RE.sub(" ", title).strip()[:_MAX_TITLE_LEN]
+        if not title:
+            continue
+        out.append({"title": title, "url": url})
+        if len(out) >= _MAX_SIGNALS:
+            break
     return out
 
 
-def extract_signals_from_events(events: List[Dict[str, Any]]) -> List[Dict[str, str]]:
-    """扫 milkie run 事件,从 ``tool.responded`` 的 ``output.stdout`` 里取 PROVENANCE
-    块。报告脚本那步带块;取最后一个带块的 stdout(最终报告)。robust:任何字段缺
-    失/类型不符都跳过,绝不抛。"""
+def _command_is_trusted(command: Any, suffixes) -> bool:
+    """True when the shell command's argv invokes one of the trusted producer scripts."""
+    if not isinstance(command, str):
+        return False
+    try:
+        argv = shlex.split(command)
+    except ValueError:
+        return False
+    return any(tok.endswith(suf) for tok in argv for suf in suffixes)
+
+
+def extract_signals_from_events(
+    events: List[Dict[str, Any]],
+    trusted_script_suffixes=_TRUSTED_PRODUCER_SCRIPTS,
+) -> List[Dict[str, str]]:
+    """Extract PROVENANCE signals from a run's events, trusting ONLY the output of a
+    trusted producer script's ``run_command`` (bound by ``toolCallId`` to its request).
+
+    A tag in any other tool output is ignored (anti-forgery). Returns the last trusted
+    block found. Robust: any missing/mismatched field is skipped; never raises.
+    """
+    # toolCallIds of run_command requests whose argv invokes a trusted producer script.
+    trusted_calls = set()
+    for e in events:
+        if not isinstance(e, dict) or e.get("type") != "tool.requested":
+            continue
+        p = e.get("payload") or {}
+        if p.get("toolName") != "run_command":
+            continue
+        call_id = p.get("toolCallId")
+        command = (p.get("input") or {}).get("command")
+        if call_id is not None and _command_is_trusted(command, trusted_script_suffixes):
+            trusted_calls.add(call_id)
+
     found: List[Dict[str, str]] = []
     for e in events:
         if not isinstance(e, dict) or e.get("type") != "tool.responded":
             continue
-        output = (e.get("payload") or {}).get("output")
+        p = e.get("payload") or {}
+        if p.get("toolCallId") not in trusted_calls:
+            continue
+        output = p.get("output")
         stdout = output.get("stdout") if isinstance(output, dict) else None
         if not isinstance(stdout, str):
             continue
@@ -56,11 +120,12 @@ def extract_signals_from_events(events: List[Dict[str, Any]]) -> List[Dict[str, 
     return found
 
 
+# User-facing footer header (delivered content is Chinese, matching the report).
 _FOOTER_HEADER = "📎 原文链接（机械附加，未经 LLM 改写）"
 
 
 def render_provenance_footer(signals: List[Dict[str, str]]) -> str:
-    """把 signals 渲染成追加到报告尾部的 footer。空 → 空串(正文不变)。"""
+    """Render signals into a footer appended to the report. Empty -> "" (body unchanged)."""
     if not signals:
         return ""
     lines = [f"- {s['title']} — {s['url']}" for s in signals]
@@ -68,9 +133,11 @@ def render_provenance_footer(signals: List[Dict[str, str]]) -> str:
 
 
 def append_provenance_footer(result: str, events: List[Dict[str, Any]]) -> str:
-    """报告投递前的机械加工:剥掉 LLM 可能抄进散文的裸 ``<PROVENANCE>`` 机器块(不外泄
-    给用户),再从 run 事件取 evidence、渲染干净 footer 追加到 ``result``。无 evidence
-    → 仅返回剥块后的正文。独立于 LLM 散文。"""
+    """Mechanical pre-delivery step: strip any raw ``<PROVENANCE>`` block the LLM may have
+    echoed into its prose (never leak the tag to the user), then pull trusted evidence from
+    the run events and append a clean footer. No evidence -> just the stripped body.
+    Independent of the LLM prose.
+    """
     cleaned = _BLOCK_RE.sub("", result or "").rstrip()
     footer = render_provenance_footer(extract_signals_from_events(events))
     return cleaned + footer if footer else cleaned

--- a/src/everbot/core/runtime/provenance_footer.py
+++ b/src/everbot/core/runtime/provenance_footer.py
@@ -1,0 +1,76 @@
+"""#130 T1 — 机械给报告每条信号附 top1 原文链接。
+
+报告型脚本在 stdout 末尾机械输出一个 ``<PROVENANCE>{"signals":[...]}</PROVENANCE>``
+块(每条信号 top1 ``{title,url}``)。投递侧从 milkie run 事件里取出该块、渲染成
+footer 追加到推送 —— **独立于 LLM 散文**(LLM 可能把链接摘掉)。纯函数,无 IO。
+"""
+from __future__ import annotations
+
+import json
+import re
+from typing import Any, Dict, List
+
+_BLOCK_RE = re.compile(r"<PROVENANCE>(.*?)</PROVENANCE>", re.DOTALL)
+
+
+def extract_provenance_block(text: str) -> List[Dict[str, str]]:
+    """从一段文本里取出 PROVENANCE 块的 signals(title+url 俱全者)。
+
+    Robust:无块 / 坏 JSON / 缺字段一律降级为 ``[]``,绝不抛 —— 投递路径不能因
+    溯源附加而崩。"""
+    m = _BLOCK_RE.search(text or "")
+    if not m:
+        return []
+    try:
+        data = json.loads(m.group(1))
+    except (ValueError, TypeError):
+        return []
+    signals = data.get("signals") if isinstance(data, dict) else None
+    if not isinstance(signals, list):
+        return []
+    out: List[Dict[str, str]] = []
+    for s in signals:
+        if not isinstance(s, dict):
+            continue
+        title, url = s.get("title"), s.get("url")
+        if isinstance(title, str) and title and isinstance(url, str) and url:
+            out.append({"title": title, "url": url})
+    return out
+
+
+def extract_signals_from_events(events: List[Dict[str, Any]]) -> List[Dict[str, str]]:
+    """扫 milkie run 事件,从 ``tool.responded`` 的 ``output.stdout`` 里取 PROVENANCE
+    块。报告脚本那步带块;取最后一个带块的 stdout(最终报告)。robust:任何字段缺
+    失/类型不符都跳过,绝不抛。"""
+    found: List[Dict[str, str]] = []
+    for e in events:
+        if not isinstance(e, dict) or e.get("type") != "tool.responded":
+            continue
+        output = (e.get("payload") or {}).get("output")
+        stdout = output.get("stdout") if isinstance(output, dict) else None
+        if not isinstance(stdout, str):
+            continue
+        signals = extract_provenance_block(stdout)
+        if signals:
+            found = signals
+    return found
+
+
+_FOOTER_HEADER = "📎 原文链接（机械附加，未经 LLM 改写）"
+
+
+def render_provenance_footer(signals: List[Dict[str, str]]) -> str:
+    """把 signals 渲染成追加到报告尾部的 footer。空 → 空串(正文不变)。"""
+    if not signals:
+        return ""
+    lines = [f"- {s['title']} — {s['url']}" for s in signals]
+    return "\n\n" + _FOOTER_HEADER + "\n" + "\n".join(lines)
+
+
+def append_provenance_footer(result: str, events: List[Dict[str, Any]]) -> str:
+    """报告投递前的机械加工:剥掉 LLM 可能抄进散文的裸 ``<PROVENANCE>`` 机器块(不外泄
+    给用户),再从 run 事件取 evidence、渲染干净 footer 追加到 ``result``。无 evidence
+    → 仅返回剥块后的正文。独立于 LLM 散文。"""
+    cleaned = _BLOCK_RE.sub("", result or "").rstrip()
+    footer = render_provenance_footer(extract_signals_from_events(events))
+    return cleaned + footer if footer else cleaned

--- a/tests/unit/test_cron_executor.py
+++ b/tests/unit/test_cron_executor.py
@@ -1062,3 +1062,28 @@ async def test_isolated_agent_delivers_footer_appended_result(tmp_path, monkeypa
     # detail (deposit_job_event) carries it too — all three delivery paths consistent
     _, kwargs = executor.delivery.deposit_job_event.call_args
     assert "https://cnbc.com/x" in kwargs["detail"]
+
+
+@pytest.mark.asyncio
+async def test_isolated_agent_projection_anchor_is_milkie_run_id(tmp_path, monkeypatch):
+    """#130 T2: the delivered projection anchor must be the milkie run id (deref-able by
+    get_execution/get_lineage under milkie#200's delivered-runId allowlist), not the job
+    session id — otherwise readByRunId can't resolve it."""
+    from src.everbot.core.runtime import provenance_gate
+    monkeypatch.setattr(provenance_gate, "read_run_events", lambda *a, **k: [])
+    executor = _make_executor(tmp_path)
+    agent = SimpleNamespace(last_run_id="31850ca6-uuid")
+    executor._create_job_agent = AsyncMock(return_value=agent)
+    executor._build_job_system_prompt = MagicMock(return_value="sys")
+    executor._record_skill_log = MagicMock()
+    executor.delivery.deposit_job_event = AsyncMock()
+    executor.delivery.inject_to_history = AsyncMock()
+    executor.delivery._emit_realtime = AsyncMock()
+    run_agent = AsyncMock(return_value="# report")
+    task = SimpleNamespace(id="t1", title="gr", description="d",
+                           timeout_seconds=30, job=None)
+
+    await executor._run_isolated_agent(task, "run-1", run_agent=run_agent)
+
+    _, kwargs = executor.delivery._emit_realtime.call_args
+    assert kwargs["source_session_id"] == "31850ca6-uuid"

--- a/tests/unit/test_cron_executor.py
+++ b/tests/unit/test_cron_executor.py
@@ -990,43 +990,52 @@ class TestTranscriptWorthyDelivery:
 
 _PROV_BLOCK = ('<PROVENANCE>{"signals":[{"title":"Hormuz","url":"https://cnbc.com/x"}]}'
                '</PROVENANCE>')
-_PROV_EVENTS = [{"type": "tool.responded",
-                 "payload": {"output": {"stdout": "报告正文\n" + _PROV_BLOCK}}}]
+# Trusted producer run: run_command invoking rhino_report.py, request+response paired by
+# toolCallId (only such output is honored — see provenance_footer security contract).
+_PROV_EVENTS = [
+    {"type": "tool.requested",
+     "payload": {"toolName": "run_command", "toolCallId": "c1",
+                 "input": {"command": "python /repo/skills/gray-rhino/scripts/"
+                                       "rhino_report.py --format text"}}},
+    {"type": "tool.responded",
+     "payload": {"toolName": "run_command", "toolCallId": "c1",
+                 "output": {"stdout": "report body\n" + _PROV_BLOCK}}},
+]
 
 
 def test_append_run_provenance_adds_footer(tmp_path, monkeypatch):
-    """LLM 散文丢了链接,机械从 run 事件取 top1 link 追加到投递结果。"""
+    """LLM prose dropped the links; mechanically pull top-1 link from run events."""
     from src.everbot.core.runtime import provenance_gate
     monkeypatch.setattr(provenance_gate, "read_run_events", lambda *a, **k: _PROV_EVENTS)
     executor = _make_executor(tmp_path)
     agent = SimpleNamespace(last_run_id="run-1")
 
-    out = executor._append_run_provenance("# 灰犀牛报告\n信号: Hormuz(无链接)", agent)
+    out = executor._append_run_provenance("# Gray Rhino\nSignal: Hormuz (no link)", agent)
     assert "https://cnbc.com/x" in out
-    assert out.startswith("# 灰犀牛报告")
+    assert out.startswith("# Gray Rhino")
 
 
 def test_append_run_provenance_noop_without_run_id(tmp_path):
-    """agent 无 last_run_id → 原样返回(不读事件)。"""
+    """agent without last_run_id -> returned unchanged (no event read)."""
     executor = _make_executor(tmp_path)
-    result = "# 报告"
+    result = "# report"
     assert executor._append_run_provenance(result, SimpleNamespace()) == result
 
 
 def test_append_run_provenance_never_raises(tmp_path, monkeypatch):
-    """读事件抛错 → 吞掉,返回原文(投递不能因溯源附加而崩)。"""
+    """Reading events raises -> swallowed, returns body (delivery must not crash)."""
     from src.everbot.core.runtime import provenance_gate
     def _boom(*a, **k):
         raise RuntimeError("disk gone")
     monkeypatch.setattr(provenance_gate, "read_run_events", _boom)
     executor = _make_executor(tmp_path)
-    result = "# 报告"
+    result = "# report"
     assert executor._append_run_provenance(result, SimpleNamespace(last_run_id="r")) == result
 
 
 @pytest.mark.asyncio
 async def test_isolated_agent_delivers_footer_appended_result(tmp_path, monkeypatch):
-    """端到端接线:LLM 散文丢了链接,投递出去的报告仍带 top1 原文链接。"""
+    """End-to-end wiring: LLM prose dropped links, delivered report still carries them."""
     from src.everbot.core.runtime import provenance_gate
     monkeypatch.setattr(provenance_gate, "read_run_events", lambda *a, **k: _PROV_EVENTS)
 
@@ -1042,14 +1051,14 @@ async def test_isolated_agent_delivers_footer_appended_result(tmp_path, monkeypa
         captured["result"] = result
     executor.delivery._emit_realtime = AsyncMock(side_effect=_capture)
 
-    run_agent = AsyncMock(return_value="# 灰犀牛报告\nHormuz(LLM 把链接摘了)")
-    task = SimpleNamespace(id="t1", title="灰犀牛", description="d",
+    run_agent = AsyncMock(return_value="# Gray Rhino\nHormuz (LLM stripped the link)")
+    task = SimpleNamespace(id="t1", title="Gray Rhino", description="d",
                            timeout_seconds=30, job=None)
 
     out = await executor._run_isolated_agent(task, "run-1", run_agent=run_agent)
 
-    assert "https://cnbc.com/x" in out                      # 返回值带链接
-    assert "https://cnbc.com/x" in captured["result"]       # 推送(_emit_realtime)带链接
-    # detail(deposit_job_event)也带链接 —— 投递三路一致
+    assert "https://cnbc.com/x" in out                      # return value carries link
+    assert "https://cnbc.com/x" in captured["result"]       # push (_emit_realtime) carries link
+    # detail (deposit_job_event) carries it too — all three delivery paths consistent
     _, kwargs = executor.delivery.deposit_job_event.call_args
     assert "https://cnbc.com/x" in kwargs["detail"]

--- a/tests/unit/test_cron_executor.py
+++ b/tests/unit/test_cron_executor.py
@@ -984,3 +984,72 @@ class TestTranscriptWorthyDelivery:
 
         assert out == "AGENT REPORT"
         assert executor.delivery._emit_realtime.call_args.kwargs.get("transcript_worthy") is True
+
+
+# ---- #130 T1: provenance footer wiring (CronExecutor._append_run_provenance) ----
+
+_PROV_BLOCK = ('<PROVENANCE>{"signals":[{"title":"Hormuz","url":"https://cnbc.com/x"}]}'
+               '</PROVENANCE>')
+_PROV_EVENTS = [{"type": "tool.responded",
+                 "payload": {"output": {"stdout": "报告正文\n" + _PROV_BLOCK}}}]
+
+
+def test_append_run_provenance_adds_footer(tmp_path, monkeypatch):
+    """LLM 散文丢了链接,机械从 run 事件取 top1 link 追加到投递结果。"""
+    from src.everbot.core.runtime import provenance_gate
+    monkeypatch.setattr(provenance_gate, "read_run_events", lambda *a, **k: _PROV_EVENTS)
+    executor = _make_executor(tmp_path)
+    agent = SimpleNamespace(last_run_id="run-1")
+
+    out = executor._append_run_provenance("# 灰犀牛报告\n信号: Hormuz(无链接)", agent)
+    assert "https://cnbc.com/x" in out
+    assert out.startswith("# 灰犀牛报告")
+
+
+def test_append_run_provenance_noop_without_run_id(tmp_path):
+    """agent 无 last_run_id → 原样返回(不读事件)。"""
+    executor = _make_executor(tmp_path)
+    result = "# 报告"
+    assert executor._append_run_provenance(result, SimpleNamespace()) == result
+
+
+def test_append_run_provenance_never_raises(tmp_path, monkeypatch):
+    """读事件抛错 → 吞掉,返回原文(投递不能因溯源附加而崩)。"""
+    from src.everbot.core.runtime import provenance_gate
+    def _boom(*a, **k):
+        raise RuntimeError("disk gone")
+    monkeypatch.setattr(provenance_gate, "read_run_events", _boom)
+    executor = _make_executor(tmp_path)
+    result = "# 报告"
+    assert executor._append_run_provenance(result, SimpleNamespace(last_run_id="r")) == result
+
+
+@pytest.mark.asyncio
+async def test_isolated_agent_delivers_footer_appended_result(tmp_path, monkeypatch):
+    """端到端接线:LLM 散文丢了链接,投递出去的报告仍带 top1 原文链接。"""
+    from src.everbot.core.runtime import provenance_gate
+    monkeypatch.setattr(provenance_gate, "read_run_events", lambda *a, **k: _PROV_EVENTS)
+
+    executor = _make_executor(tmp_path)
+    agent = SimpleNamespace(last_run_id="run-1")
+    executor._create_job_agent = AsyncMock(return_value=agent)
+    executor._build_job_system_prompt = MagicMock(return_value="sys")
+    executor._record_skill_log = MagicMock()
+    executor.delivery.deposit_job_event = AsyncMock()
+    executor.delivery.inject_to_history = AsyncMock()
+    captured = {}
+    async def _capture(result, run_id, **k):
+        captured["result"] = result
+    executor.delivery._emit_realtime = AsyncMock(side_effect=_capture)
+
+    run_agent = AsyncMock(return_value="# 灰犀牛报告\nHormuz(LLM 把链接摘了)")
+    task = SimpleNamespace(id="t1", title="灰犀牛", description="d",
+                           timeout_seconds=30, job=None)
+
+    out = await executor._run_isolated_agent(task, "run-1", run_agent=run_agent)
+
+    assert "https://cnbc.com/x" in out                      # 返回值带链接
+    assert "https://cnbc.com/x" in captured["result"]       # 推送(_emit_realtime)带链接
+    # detail(deposit_job_event)也带链接 —— 投递三路一致
+    _, kwargs = executor.delivery.deposit_job_event.call_args
+    assert "https://cnbc.com/x" in kwargs["detail"]

--- a/tests/unit/test_gray_rhino_evidence.py
+++ b/tests/unit/test_gray_rhino_evidence.py
@@ -96,3 +96,19 @@ def test_text_report_lists_source_link_for_signal(tmp_path, monkeypatch):
     text = rr.format_text_report(result)
     # text 报告里逐条信号应能看到来源链接(粗粒度 cite 的节点据此可下钻)
     assert "https://finance.sina/cu1" in text or "https://finance.sina/al2" in text
+
+
+def test_text_report_appends_parseable_provenance_block(tmp_path, monkeypatch):
+    """#130 T1:text 报告末尾机械追加 PROVENANCE 块,且能被投递侧提取器解析。
+    每条信号 top1 {title,url},url 取自真实 evidence。"""
+    from src.everbot.core.runtime.provenance_footer import extract_provenance_block
+
+    monkeypatch.setattr(rr, "NewsFetcher", _fake_fetcher_cls(_items()))
+    result = rr.generate_report(save_snapshot=False, history_dir=str(tmp_path))
+    text = rr.format_text_report(result)
+
+    signals = extract_provenance_block(text)
+    assert signals, "text 报告末尾应有可解析的 PROVENANCE 块"
+    for s in signals:
+        assert s["title"] and s["url"]
+        assert s["url"] in {"https://finance.sina/cu1", "https://finance.sina/al2"}

--- a/tests/unit/test_gray_rhino_evidence.py
+++ b/tests/unit/test_gray_rhino_evidence.py
@@ -99,8 +99,8 @@ def test_text_report_lists_source_link_for_signal(tmp_path, monkeypatch):
 
 
 def test_text_report_appends_parseable_provenance_block(tmp_path, monkeypatch):
-    """#130 T1:text 报告末尾机械追加 PROVENANCE 块,且能被投递侧提取器解析。
-    每条信号 top1 {title,url},url 取自真实 evidence。"""
+    """#130 T1: the text report appends a machine PROVENANCE block parseable by the
+    delivery-side extractor. Top-1 {title,url} per signal, url from real evidence."""
     from src.everbot.core.runtime.provenance_footer import extract_provenance_block
 
     monkeypatch.setattr(rr, "NewsFetcher", _fake_fetcher_cls(_items()))
@@ -108,7 +108,7 @@ def test_text_report_appends_parseable_provenance_block(tmp_path, monkeypatch):
     text = rr.format_text_report(result)
 
     signals = extract_provenance_block(text)
-    assert signals, "text 报告末尾应有可解析的 PROVENANCE 块"
+    assert signals, "text report should end with a parseable PROVENANCE block"
     for s in signals:
         assert s["title"] and s["url"]
         assert s["url"] in {"https://finance.sina/cu1", "https://finance.sina/al2"}

--- a/tests/unit/test_provenance_footer.py
+++ b/tests/unit/test_provenance_footer.py
@@ -1,0 +1,138 @@
+"""#130 T1 — 投递时机械给报告每条信号附 top1 原文链接。
+
+footer 由确定性函数从 milkie run 事件里的 PROVENANCE 块构建,独立于 LLM 散文
+(LLM 可能把链接摘掉,机械追加不依赖它)。纯函数,无 IO。"""
+
+import json
+
+from src.everbot.core.runtime.provenance_footer import (
+    extract_provenance_block,
+    append_provenance_footer,
+    extract_signals_from_events,
+    render_provenance_footer,
+)
+
+
+def test_extract_block_happy_path():
+    """text 里的 <PROVENANCE>{...}</PROVENANCE> 被解析成 signals 列表。"""
+    text = (
+        "# 报告正文……\n"
+        '<PROVENANCE>{"signals":[{"title":"Trump on Hormuz","url":"https://cnbc.com/x"}]}</PROVENANCE>\n'
+    )
+    signals = extract_provenance_block(text)
+    assert signals == [{"title": "Trump on Hormuz", "url": "https://cnbc.com/x"}]
+
+
+def test_extract_no_block_returns_empty():
+    """没有 PROVENANCE 块(老脚本/纯散文)→ [] ,绝不抛。"""
+    assert extract_provenance_block("just prose, no block") == []
+
+
+def test_extract_malformed_json_returns_empty():
+    """块在但 JSON 坏 → [] ,绝不抛(投递路径不能因此崩)。"""
+    assert extract_provenance_block("<PROVENANCE>{not json}</PROVENANCE>") == []
+
+
+def test_extract_filters_signals_missing_title_or_url():
+    """缺 title 或 url 的条目被丢弃,只留两者俱全的。"""
+    text = (
+        "<PROVENANCE>" + json.dumps({"signals": [
+            {"title": "good", "url": "https://u"},
+            {"title": "no url"},
+            {"url": "https://only-url"},
+            {"title": "", "url": "https://empty-title"},
+        ]}) + "</PROVENANCE>"
+    )
+    assert extract_provenance_block(text) == [{"title": "good", "url": "https://u"}]
+
+
+def test_extract_empty_signals_returns_empty():
+    assert extract_provenance_block('<PROVENANCE>{"signals":[]}</PROVENANCE>') == []
+
+
+def test_render_empty_signals_returns_empty_string():
+    """无 signals → 不追加任何 footer(空串),投递正文不变。"""
+    assert render_provenance_footer([]) == ""
+
+
+def test_render_lists_title_and_url_per_signal():
+    """每条信号渲染一行 标题 — url,带可辨识表头。"""
+    footer = render_provenance_footer([
+        {"title": "Trump on Hormuz", "url": "https://cnbc.com/x"},
+        {"title": "Crimea power", "url": "https://bbc.co.uk/y"},
+    ])
+    assert "Trump on Hormuz" in footer and "https://cnbc.com/x" in footer
+    assert "Crimea power" in footer and "https://bbc.co.uk/y" in footer
+    # 两条信号 → footer 里有两条链接行
+    assert footer.count("https://") == 2
+    # footer 与正文有可视分隔(避免和报告糊在一起)
+    assert footer.startswith("\n")
+
+
+def _responded(stdout):
+    """milkie run 事件:run_command 的 tool.responded(output.stdout 带工具 stdout)。"""
+    return {"type": "tool.responded",
+            "payload": {"toolName": "run_command",
+                        "output": {"stdout": stdout, "exitCode": 0}}}
+
+
+def test_signals_from_events_picks_block_in_tool_stdout():
+    """从 run 事件里 run_command 的 stdout 取出 PROVENANCE 块。"""
+    report = (
+        "灰犀牛报告正文……\n"
+        '<PROVENANCE>{"signals":[{"title":"Hormuz","url":"https://cnbc.com/x"}]}</PROVENANCE>'
+    )
+    events = [
+        {"type": "tool.requested", "payload": {"toolName": "run_command"}},
+        _responded("SKILL.md 内容,无块"),   # 加载技能那步,无 PROVENANCE
+        _responded(report),                  # 报告脚本那步,有块
+    ]
+    assert extract_signals_from_events(events) == [
+        {"title": "Hormuz", "url": "https://cnbc.com/x"}]
+
+
+def test_signals_from_events_no_block_anywhere_returns_empty():
+    events = [_responded("纯文本"), {"type": "llm.responded", "payload": {}}]
+    assert extract_signals_from_events(events) == []
+
+
+def test_signals_from_events_tolerates_nonstring_output():
+    """output 非 dict / stdout 非 str / 缺 payload —— 不抛。"""
+    events = [
+        {"type": "tool.responded", "payload": {"output": None}},
+        {"type": "tool.responded", "payload": {"output": {"stdout": 123}}},
+        {"type": "tool.responded"},
+    ]
+    assert extract_signals_from_events(events) == []
+
+
+def test_append_adds_footer_when_evidence_present():
+    """有 evidence → result 末尾追加 footer(原文链接进推送)。"""
+    report = '<PROVENANCE>{"signals":[{"title":"Hormuz","url":"https://cnbc.com/x"}]}</PROVENANCE>'
+    events = [_responded(report)]
+    out = append_provenance_footer("# 报告\n内容", events)
+    assert out.startswith("# 报告\n内容")
+    assert "https://cnbc.com/x" in out and "Hormuz" in out
+
+
+def test_append_noop_when_no_evidence():
+    """无 evidence(老脚本/未带块)→ 原样返回,不动正文。"""
+    result = "# 报告\n内容"
+    assert append_provenance_footer(result, [_responded("无块")]) == result
+
+
+def test_append_strips_echoed_block_from_result():
+    """LLM 若把脚本的 <PROVENANCE> 机器块抄进散文,投递前剥掉,只留干净 footer。"""
+    block = '<PROVENANCE>{"signals":[{"title":"H","url":"https://u"}]}</PROVENANCE>'
+    result = "# 报告\n正文\n" + block          # LLM 把机器块抄进了报告
+    out = append_provenance_footer(result, [_responded(block)])
+    assert "<PROVENANCE>" not in out            # 原始机器块不外泄给用户
+    assert "https://u" in out                   # 链接以 footer 形式在场
+    assert out.count("https://u") == 1          # 不重复
+
+
+def test_append_strips_echoed_block_even_when_no_evidence_events():
+    """即便事件里取不到 evidence,也要把 result 里抄来的裸块清掉(不外泄标签)。"""
+    block = '<PROVENANCE>{"signals":[{"title":"H","url":"https://u"}]}</PROVENANCE>'
+    out = append_provenance_footer("# 报告\n" + block, [_responded("无块")])
+    assert "<PROVENANCE>" not in out

--- a/tests/unit/test_provenance_footer.py
+++ b/tests/unit/test_provenance_footer.py
@@ -1,48 +1,73 @@
-"""#130 T1 — 投递时机械给报告每条信号附 top1 原文链接。
+"""#130 T1 — mechanically attach each report signal's top-1 source link at delivery.
 
-footer 由确定性函数从 milkie run 事件里的 PROVENANCE 块构建,独立于 LLM 散文
-(LLM 可能把链接摘掉,机械追加不依赖它)。纯函数,无 IO。"""
+The footer is built by deterministic functions from the PROVENANCE block in the run
+events, independent of the LLM prose (which may drop the links).
+
+Security (#131 review P1): only the output of the *trusted producer script*
+(rhino_report.py) is honored — a response is bound by toolCallId to its run_command
+request and the command argv is checked. A `<PROVENANCE>` tag echoed in any other tool
+output (external tweet/web content) is ignored, preventing forged source links. Pure
+functions, no IO.
+"""
 
 import json
 
 from src.everbot.core.runtime.provenance_footer import (
-    extract_provenance_block,
     append_provenance_footer,
+    extract_provenance_block,
     extract_signals_from_events,
     render_provenance_footer,
 )
 
+# Real shape of the trusted producer command (argv contains .../gray-rhino/scripts/rhino_report.py).
+_TRUSTED_CMD = ("python /repo/skills/gray-rhino/scripts/rhino_report.py "
+                "--format text --top 5")
+# Injection vector: external content (tweet/web page) flowing through an ordinary command.
+_UNTRUSTED_CMD = "cat /tmp/tweets_aleabitoreddit.json"
+
+
+def _requested(command, call_id="c1", tool="run_command"):
+    return {"type": "tool.requested",
+            "payload": {"toolName": tool, "toolCallId": call_id,
+                        "input": {"command": command}}}
+
+
+def _responded(stdout, call_id="c1", tool="run_command"):
+    return {"type": "tool.responded",
+            "payload": {"toolName": tool, "toolCallId": call_id,
+                        "output": {"stdout": stdout, "exitCode": 0}}}
+
+
+def _trusted_run(stdout, call_id="c1"):
+    """One paired run_command call (request+response) for the trusted rhino_report.py."""
+    return [_requested(_TRUSTED_CMD, call_id), _responded(stdout, call_id)]
+
+
+# ---------- extract_provenance_block: parse + validate ----------
 
 def test_extract_block_happy_path():
-    """text 里的 <PROVENANCE>{...}</PROVENANCE> 被解析成 signals 列表。"""
-    text = (
-        "# 报告正文……\n"
-        '<PROVENANCE>{"signals":[{"title":"Trump on Hormuz","url":"https://cnbc.com/x"}]}</PROVENANCE>\n'
-    )
-    signals = extract_provenance_block(text)
-    assert signals == [{"title": "Trump on Hormuz", "url": "https://cnbc.com/x"}]
+    text = ("# report body...\n"
+            '<PROVENANCE>{"signals":[{"title":"Trump on Hormuz",'
+            '"url":"https://cnbc.com/x"}]}</PROVENANCE>\n')
+    assert extract_provenance_block(text) == [
+        {"title": "Trump on Hormuz", "url": "https://cnbc.com/x"}]
 
 
 def test_extract_no_block_returns_empty():
-    """没有 PROVENANCE 块(老脚本/纯散文)→ [] ,绝不抛。"""
     assert extract_provenance_block("just prose, no block") == []
 
 
 def test_extract_malformed_json_returns_empty():
-    """块在但 JSON 坏 → [] ,绝不抛(投递路径不能因此崩)。"""
     assert extract_provenance_block("<PROVENANCE>{not json}</PROVENANCE>") == []
 
 
 def test_extract_filters_signals_missing_title_or_url():
-    """缺 title 或 url 的条目被丢弃,只留两者俱全的。"""
-    text = (
-        "<PROVENANCE>" + json.dumps({"signals": [
-            {"title": "good", "url": "https://u"},
-            {"title": "no url"},
-            {"url": "https://only-url"},
-            {"title": "", "url": "https://empty-title"},
-        ]}) + "</PROVENANCE>"
-    )
+    text = ("<PROVENANCE>" + json.dumps({"signals": [
+        {"title": "good", "url": "https://u"},
+        {"title": "no url"},
+        {"url": "https://only-url"},
+        {"title": "", "url": "https://empty-title"},
+    ]}) + "</PROVENANCE>")
     assert extract_provenance_block(text) == [{"title": "good", "url": "https://u"}]
 
 
@@ -50,89 +75,141 @@ def test_extract_empty_signals_returns_empty():
     assert extract_provenance_block('<PROVENANCE>{"signals":[]}</PROVENANCE>') == []
 
 
+def test_extract_drops_non_http_url_scheme():
+    """Drop javascript:/file:/data: schemes, keep only http(s) (no malicious clicks)."""
+    text = ("<PROVENANCE>" + json.dumps({"signals": [
+        {"title": "evil", "url": "javascript:alert(1)"},
+        {"title": "ftp", "url": "file:///etc/passwd"},
+        {"title": "ok", "url": "https://u"},
+        {"title": "ok2", "url": "http://u2"},
+    ]}) + "</PROVENANCE>")
+    assert extract_provenance_block(text) == [
+        {"title": "ok", "url": "https://u"}, {"title": "ok2", "url": "http://u2"}]
+
+
+def test_extract_flattens_newlines_in_title():
+    """Title newlines/CRs are flattened so they cannot break the Markdown list."""
+    text = ("<PROVENANCE>" + json.dumps({"signals": [
+        {"title": "real\n- https://evil.com fake-row", "url": "https://u"}]})
+        + "</PROVENANCE>")
+    sig = extract_provenance_block(text)[0]
+    assert "\n" not in sig["title"] and "\r" not in sig["title"]
+
+
+def test_extract_caps_signal_count():
+    """Signal count is capped to avoid flooding the push with a huge footer."""
+    sigs = [{"title": f"t{i}", "url": f"https://u/{i}"} for i in range(50)]
+    text = "<PROVENANCE>" + json.dumps({"signals": sigs}) + "</PROVENANCE>"
+    assert len(extract_provenance_block(text)) <= 20
+
+
+def test_extract_rejects_overlong_url():
+    """Over-long URLs (>500) are dropped."""
+    text = ("<PROVENANCE>" + json.dumps({"signals": [
+        {"title": "x", "url": "https://u/" + "a" * 600},
+        {"title": "ok", "url": "https://short"}]}) + "</PROVENANCE>")
+    assert extract_provenance_block(text) == [{"title": "ok", "url": "https://short"}]
+
+
+# ---------- render_provenance_footer ----------
+
 def test_render_empty_signals_returns_empty_string():
-    """无 signals → 不追加任何 footer(空串),投递正文不变。"""
     assert render_provenance_footer([]) == ""
 
 
 def test_render_lists_title_and_url_per_signal():
-    """每条信号渲染一行 标题 — url,带可辨识表头。"""
     footer = render_provenance_footer([
         {"title": "Trump on Hormuz", "url": "https://cnbc.com/x"},
         {"title": "Crimea power", "url": "https://bbc.co.uk/y"},
     ])
     assert "Trump on Hormuz" in footer and "https://cnbc.com/x" in footer
     assert "Crimea power" in footer and "https://bbc.co.uk/y" in footer
-    # 两条信号 → footer 里有两条链接行
     assert footer.count("https://") == 2
-    # footer 与正文有可视分隔(避免和报告糊在一起)
     assert footer.startswith("\n")
 
 
-def _responded(stdout):
-    """milkie run 事件:run_command 的 tool.responded(output.stdout 带工具 stdout)。"""
-    return {"type": "tool.responded",
-            "payload": {"toolName": "run_command",
-                        "output": {"stdout": stdout, "exitCode": 0}}}
+# ---------- extract_signals_from_events: trusted-command binding ----------
 
-
-def test_signals_from_events_picks_block_in_tool_stdout():
-    """从 run 事件里 run_command 的 stdout 取出 PROVENANCE 块。"""
-    report = (
-        "灰犀牛报告正文……\n"
-        '<PROVENANCE>{"signals":[{"title":"Hormuz","url":"https://cnbc.com/x"}]}</PROVENANCE>'
-    )
-    events = [
-        {"type": "tool.requested", "payload": {"toolName": "run_command"}},
-        _responded("SKILL.md 内容,无块"),   # 加载技能那步,无 PROVENANCE
-        _responded(report),                  # 报告脚本那步,有块
-    ]
+def test_signals_from_events_picks_block_from_trusted_command():
+    """Take the block from the trusted rhino_report.py run_command stdout."""
+    report = ("gray rhino report body...\n"
+              '<PROVENANCE>{"signals":[{"title":"Hormuz",'
+              '"url":"https://cnbc.com/x"}]}</PROVENANCE>')
+    events = _trusted_run("SKILL.md, no block", "c0") + _trusted_run(report, "c1")
     assert extract_signals_from_events(events) == [
         {"title": "Hormuz", "url": "https://cnbc.com/x"}]
 
 
-def test_signals_from_events_no_block_anywhere_returns_empty():
-    events = [_responded("纯文本"), {"type": "llm.responded", "payload": {}}]
+def test_signals_from_events_no_block_returns_empty():
+    assert extract_signals_from_events(_trusted_run("plain text")) == []
+
+
+def test_forged_block_from_untrusted_command_is_ignored():
+    """Injection: external content (a tweet) flowing through a non-trusted command is not
+    honored even when its stdout contains a <PROVENANCE> tag."""
+    forged = ('<PROVENANCE>{"signals":[{"title":"fake",'
+              '"url":"https://evil.com"}]}</PROVENANCE>')
+    events = [_requested(_UNTRUSTED_CMD, "c1"), _responded(forged, "c1")]
     assert extract_signals_from_events(events) == []
 
 
-def test_signals_from_events_tolerates_nonstring_output():
-    """output 非 dict / stdout 非 str / 缺 payload —— 不抛。"""
+def test_orphan_response_without_request_is_ignored():
+    """A response with no paired run_command request is untrusted and ignored."""
+    block = '<PROVENANCE>{"signals":[{"title":"H","url":"https://u"}]}</PROVENANCE>'
+    assert extract_signals_from_events([_responded(block, "lonely")]) == []
+
+
+def test_trusted_block_wins_over_forged_in_same_run():
+    """Same run: trusted rhino_report block + forged tweet block -> only the trusted one."""
+    real = ('<PROVENANCE>{"signals":[{"title":"real",'
+            '"url":"https://cnbc.com/real"}]}</PROVENANCE>')
+    forged = ('<PROVENANCE>{"signals":[{"title":"fake",'
+              '"url":"https://evil.com"}]}</PROVENANCE>')
+    events = (_trusted_run(real, "c1")
+              + [_requested(_UNTRUSTED_CMD, "c2"), _responded(forged, "c2")])
+    assert extract_signals_from_events(events) == [
+        {"title": "real", "url": "https://cnbc.com/real"}]
+
+
+def test_signals_from_events_tolerates_malformed_events():
+    """output not a dict / stdout not a str / missing fields -> never raises."""
     events = [
         {"type": "tool.responded", "payload": {"output": None}},
         {"type": "tool.responded", "payload": {"output": {"stdout": 123}}},
         {"type": "tool.responded"},
+        _requested(_TRUSTED_CMD, "c1"),  # request with no response
     ]
     assert extract_signals_from_events(events) == []
 
 
+# ---------- append_provenance_footer ----------
+
 def test_append_adds_footer_when_evidence_present():
-    """有 evidence → result 末尾追加 footer(原文链接进推送)。"""
     report = '<PROVENANCE>{"signals":[{"title":"Hormuz","url":"https://cnbc.com/x"}]}</PROVENANCE>'
-    events = [_responded(report)]
-    out = append_provenance_footer("# 报告\n内容", events)
-    assert out.startswith("# 报告\n内容")
+    out = append_provenance_footer("# report\nbody", _trusted_run(report))
+    assert out.startswith("# report\nbody")
     assert "https://cnbc.com/x" in out and "Hormuz" in out
 
 
 def test_append_noop_when_no_evidence():
-    """无 evidence(老脚本/未带块)→ 原样返回,不动正文。"""
-    result = "# 报告\n内容"
-    assert append_provenance_footer(result, [_responded("无块")]) == result
+    result = "# report\nbody"
+    assert append_provenance_footer(result, _trusted_run("no block")) == result
 
 
 def test_append_strips_echoed_block_from_result():
-    """LLM 若把脚本的 <PROVENANCE> 机器块抄进散文,投递前剥掉,只留干净 footer。"""
+    """If the LLM echoes the raw <PROVENANCE> block into prose, strip it before delivery
+    and keep only the clean footer."""
     block = '<PROVENANCE>{"signals":[{"title":"H","url":"https://u"}]}</PROVENANCE>'
-    result = "# 报告\n正文\n" + block          # LLM 把机器块抄进了报告
-    out = append_provenance_footer(result, [_responded(block)])
-    assert "<PROVENANCE>" not in out            # 原始机器块不外泄给用户
-    assert "https://u" in out                   # 链接以 footer 形式在场
-    assert out.count("https://u") == 1          # 不重复
+    result = "# report\nbody\n" + block
+    out = append_provenance_footer(result, _trusted_run(block))
+    assert "<PROVENANCE>" not in out
+    assert "https://u" in out
+    assert out.count("https://u") == 1
 
 
-def test_append_strips_echoed_block_even_when_no_evidence_events():
-    """即便事件里取不到 evidence,也要把 result 里抄来的裸块清掉(不外泄标签)。"""
+def test_append_strips_echoed_block_even_when_no_trusted_evidence():
+    """Even with no trusted evidence in events, strip a raw block echoed into the body
+    (never leak the tag)."""
     block = '<PROVENANCE>{"signals":[{"title":"H","url":"https://u"}]}</PROVENANCE>'
-    out = append_provenance_footer("# 报告\n" + block, [_responded("无块")])
+    out = append_provenance_footer("# report\n" + block, _trusted_run("no block"))
     assert "<PROVENANCE>" not in out


### PR DESCRIPTION
## 问题(#130 动机案例)

报告型 isolated job 投递到交互会话时,LLM 散文化会把每条信号的原文 URL 摘掉;消费侧又是 `selfOnly`、runId 轴被砍,够不着源 run → 用户追问"这条信号原文地址哪来的"只能答"报告没给 URL"。数据层其实是有真实 CNBC/BBC 链接的,断在投递这一跳。

## 本 PR:T1 —— 投递机械内联 top1 原文链接(选项 A)

**机械,不靠提示词**(提示词约定 LLM 可无视):

1. `rhino_report.py` text 输出末尾机械追加每条信号 top1 `{title,url}` 的 `<PROVENANCE>` 块(来自真实 evidence)。
2. 投递前(`_run_isolated_agent` 中 `result` 拿到后、三路投递前)从 run 事件 `tool.responded.output.stdout` 取出该块,机械渲染 `📎 原文链接` footer 追加到 **推送 + detail + history** —— **独立于 LLM 散文**。
3. 顺手剥掉 LLM 可能抄进散文的裸机器块(不外泄 `<PROVENANCE>` 标签)。
4. 任何失败一律吞掉返回原文(投递不能因溯源附加而崩)。

### 效果(端到端可视化)
LLM 散文丢了链接,投递出去的内容仍机械带:
```
# 🦏 灰犀牛预警
- 霍尔木兹(来源:CNBC Top、BBC World)  ← LLM 没给 URL

📎 原文链接（机械附加，未经 LLM 改写）
- Trump claims Iran won't toll Strait of Hormuz — https://cnbc.com/hormuz
- Biggest city in Crimea without power — https://bbc.co.uk/crimea
```

## 不在本 PR(范围边界)
- **T2 深挖轨**(消费侧用 `producedBy.runId` 走白名单 `get_execution`/`get_lineage` 取全量血缘)依赖 **xforce-io/milkie#200**(selfOnly 投递域白名单 deref),框架侧落地后再接。
- **L1 强制执行**(#127 observe→enforce)、L3 逐条铸 object:另议。

## 测试(端到端 TDD)
- `provenance_footer`(新纯函数模块):14 测,覆盖解析/渲染/事件提取/组合/剥裸块,含无块·坏JSON·缺字段·异常不抛等边界。
- `cron` 接线:3 单测 + 1 集成(并以「禁用接线→RED→恢复→GREEN」证明接线被真实覆盖)。
- 脚本↔投递**契约**测:脚本产出的块能被投递侧同一提取器解析。
- 全量 `tests/unit` **1910 passed**,无新增告警(base=2/mine=2 已核)。

## 运行时
`~/.alfred/skills/gray-rhino` 是指向 repo 的符号链接 → 脚本改动即时生效;alfred Python 改动需重启 everbot daemon 才在线上生效。

## 关联
- Closes #130 的 T1 部分(T2 待 milkie#200)
- 框架依赖: xforce-io/milkie#200
- 承接: #124(L2)、#127(L1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
