### PR TITLE
feat(#132): 检测陈旧 per-agent skill 覆盖(遮蔽仓库修复)spec v1

### DIFF
--- a/src/everbot/cli/main.py
+++ b/src/everbot/cli/main.py
@@ -84,6 +84,9 @@ def cmd_status(args):
     # #93 件B:每 agent 生效模型 vs 配置目标(stale = 改了配置但未重启生效)。
     _print_agent_model_states()
 
+    # #132:陈旧的 per-agent skill 覆盖副本(静默遮蔽仓库修复)。
+    _print_stale_skill_overrides()
+
     hb = (snapshot.get("heartbeats", {}) if isinstance(snapshot, dict) else {}) or {}
     if hb:
         print("最近心跳:")
@@ -128,6 +131,29 @@ def _print_agent_model_states() -> None:
         cfg = s["configured"] or "?"
         flag = "  ⚠️ STALE 待重启生效" if s["stale"] else ""
         print(f"  - {s['agent']}: {eff} / {cfg}{flag}")
+
+
+def _print_stale_skill_overrides() -> None:
+    """打印每个配置 agent 的陈旧 skill 覆盖告警(#132)。
+
+    陈旧 = per-agent 覆盖副本内容偏离仓库内置版,且不比仓库新(即上游修复
+    被静默遮蔽)。只读自检,绝不因此崩。
+    """
+    try:
+        udm = get_user_data_manager()
+        config = get_config()
+        agents = list(((config.get("everbot") or {}).get("agents") or {}).keys())
+        rows = [(a, udm.list_stale_skill_overrides(a)) for a in agents]
+        rows = [(a, skills) for a, skills in rows if skills]
+    except Exception as e:  # status 是只读自检,绝不因此崩
+        logging.getLogger(__name__).debug("stale skill override check failed: %s", e)
+        return
+
+    if not rows:
+        return
+    print("陈旧 skill 覆盖(per-agent 副本遮蔽仓库修复,#132):")
+    for agent, skills in rows:
+        print(f"  - {agent}: {', '.join(skills)}  ⚠️ 建议同步或移除覆盖")
 
 
 async def cmd_start_async(args):

--- a/src/everbot/core/jobs/skill_evaluate.py
+++ b/src/everbot/core/jobs/skill_evaluate.py
@@ -95,6 +95,12 @@ async def run(context: SkillContext) -> Optional[str]:
     evaluated = 0
     unavailable = 0
     for skill_id in skill_ids:
+        # #132: warn (non-blocking) when a stale per-agent override shadows the
+        # repo baseline for this skill. Best-effort — never abort evaluation.
+        try:
+            udm.check_skill_override_drift(agent_name, skill_id)
+        except Exception as e:
+            logger.debug("skill override drift check failed for %s: %s", skill_id, e)
         try:
             result = await _evaluate_one(
                 context, seg_logger, ver_mgr, skill_id, udm.sessions_dir,

--- a/src/everbot/infra/user_data.py
+++ b/src/everbot/infra/user_data.py
@@ -4,7 +4,8 @@
 
 import os
 from pathlib import Path
-from typing import List, Dict, Optional
+from typing import List, Dict, Optional, Tuple
+import hashlib
 import re
 import logging
 
@@ -147,6 +148,102 @@ class UserDataManager:
         if repo is not None:
             dirs.append(repo)
         return dirs
+
+    # --- Per-agent skill override drift detection (#132) ---
+    #
+    # The 3-tier resolution chain above lets a per-agent override silently
+    # and permanently shadow a repo fix: once the override is created it
+    # freezes at that point-in-time, so any upstream repair never reaches the
+    # agent. These helpers detect that drift so it can be surfaced (warning at
+    # load time + `bin/everbot status`) without changing resolution priority.
+
+    @staticmethod
+    def _skill_dir_fingerprint(skill_dir: Path) -> Tuple[str, float]:
+        """Return (content_hash, max_mtime) over a skill dir's .py/.md files.
+
+        The hash covers each relevant file's repo-relative path and bytes
+        (sorted for determinism); max_mtime is the newest such file's mtime.
+        Non-(.py/.md) files are ignored on purpose — generated data must not
+        register as drift. Unreadable files degrade to empty content rather
+        than raising, so a status/health check never crashes.
+        """
+        h = hashlib.sha256()
+        max_mtime = 0.0
+        files = sorted(
+            (p for p in skill_dir.rglob("*") if p.is_file() and p.suffix in (".py", ".md")),
+            key=lambda p: p.relative_to(skill_dir).as_posix(),
+        )
+        for p in files:
+            h.update(p.relative_to(skill_dir).as_posix().encode())
+            h.update(b"\0")
+            try:
+                h.update(p.read_bytes())
+            except OSError:
+                pass
+            h.update(b"\0")
+            try:
+                mt = p.stat().st_mtime
+            except OSError:
+                mt = 0.0
+            if mt > max_mtime:
+                max_mtime = mt
+        return h.hexdigest(), max_mtime
+
+    def is_skill_override_stale(
+        self, agent_name: str, skill_id: str
+    ) -> Optional[Tuple[str, str]]:
+        """Return (agent_hash_prefix, repo_hash_prefix) if the per-agent
+        override for ``skill_id`` is stale, else None.
+
+        Stale := an override exists, its content differs from the repo
+        baseline, AND it is not newer than the baseline (newest file mtime
+        <= baseline's). An override that differs but is newer is treated as
+        an intentional customization and is left alone (avoids false
+        positives for SLM-evolved skills).
+        """
+        repo_base = self.repo_skills_dir
+        if repo_base is None:
+            return None
+        override_dir = self.get_agent_writable_skills_dir(agent_name) / skill_id
+        repo_dir = repo_base / skill_id
+        if not override_dir.is_dir() or not repo_dir.is_dir():
+            return None
+        agent_hash, agent_mtime = self._skill_dir_fingerprint(override_dir)
+        repo_hash, repo_mtime = self._skill_dir_fingerprint(repo_dir)
+        if agent_hash == repo_hash:
+            return None
+        if agent_mtime > repo_mtime:
+            return None
+        return agent_hash[:8], repo_hash[:8]
+
+    def check_skill_override_drift(
+        self, agent_name: str, skill_id: str
+    ) -> Optional[Tuple[str, str]]:
+        """Emit a structured warning if the override for ``skill_id`` is stale.
+
+        Non-blocking: returns the same value as is_skill_override_stale and
+        never alters resolution. Call this at skill-load time.
+        """
+        result = self.is_skill_override_stale(agent_name, skill_id)
+        if result is not None:
+            agent_hash, repo_hash = result
+            logger.warning(
+                "skill '%s' per-agent override is stale — differs from repo "
+                "baseline (agent: %s, repo: %s)",
+                skill_id, agent_hash, repo_hash,
+            )
+        return result
+
+    def list_stale_skill_overrides(self, agent_name: str) -> List[str]:
+        """Return the sorted skill ids whose per-agent override is stale."""
+        base = self.get_agent_writable_skills_dir(agent_name)
+        if not base.is_dir():
+            return []
+        return [
+            child.name
+            for child in sorted(base.iterdir())
+            if child.is_dir() and self.is_skill_override_stale(agent_name, child.name)
+        ]
 
     @property
     def trajectories_dir(self) -> Path:

--- a/tests/cli/test_status_stale_overrides.py
+++ b/tests/cli/test_status_stale_overrides.py
@@ -1,0 +1,74 @@
+"""`bin/everbot status` surfaces stale per-agent skill overrides (#132, AC#3)."""
+
+import os
+from pathlib import Path
+
+import importlib
+
+from src.everbot.infra.user_data import UserDataManager
+
+# NB: src.everbot.cli.__init__ re-exports a `main` function that shadows the
+# same-named submodule on attribute access, so import the module explicitly.
+main = importlib.import_module("src.everbot.cli.main")
+
+OLD = 1_700_000_000.0
+NEW = 1_700_100_000.0
+
+
+def _write(path: Path, content: str, mtime: float) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+    os.utime(path, (mtime, mtime))
+
+
+def _udm_with_stale_override(tmp_path: Path, monkeypatch) -> UserDataManager:
+    monkeypatch.setenv("ALFRED_REPO_ROOT", str(tmp_path / "repo"))
+    (tmp_path / "repo" / "skills").mkdir(parents=True)
+    udm = UserDataManager(alfred_home=tmp_path)
+    _write(udm.repo_skills_dir / "twitter-watch" / "fetch.py", "fixed\n", NEW)
+    _write(
+        udm.get_agent_writable_skills_dir("demo") / "twitter-watch" / "fetch.py",
+        "old\n", OLD,
+    )
+    return udm
+
+
+def test_status_lists_stale_override(tmp_path, monkeypatch, capsys):
+    udm = _udm_with_stale_override(tmp_path, monkeypatch)
+    monkeypatch.setattr(main, "get_user_data_manager", lambda: udm)
+    monkeypatch.setattr(
+        main, "get_config", lambda *a, **k: {"everbot": {"agents": {"demo": {}}}}
+    )
+
+    main._print_stale_skill_overrides()
+
+    out = capsys.readouterr().out
+    assert "demo" in out
+    assert "twitter-watch" in out
+
+
+def test_status_silent_when_no_stale_override(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("ALFRED_REPO_ROOT", str(tmp_path / "repo"))
+    (tmp_path / "repo" / "skills").mkdir(parents=True)
+    udm = UserDataManager(alfred_home=tmp_path)
+    monkeypatch.setattr(main, "get_user_data_manager", lambda: udm)
+    monkeypatch.setattr(
+        main, "get_config", lambda *a, **k: {"everbot": {"agents": {"demo": {}}}}
+    )
+
+    main._print_stale_skill_overrides()
+
+    assert capsys.readouterr().out == ""
+
+
+def test_status_never_crashes_on_error(monkeypatch, capsys):
+    # Degrade silently: status is a read-only self-check, must not raise.
+    def boom():
+        raise RuntimeError("config blew up")
+
+    monkeypatch.setattr(main, "get_user_data_manager", boom)
+    monkeypatch.setattr(main, "get_config", lambda *a, **k: {})
+
+    main._print_stale_skill_overrides()  # must not raise
+
+    assert capsys.readouterr().out == ""

--- a/tests/unit/test_skill_evaluate_drift_check.py
+++ b/tests/unit/test_skill_evaluate_drift_check.py
@@ -1,0 +1,90 @@
+"""skill_evaluate.run() runs drift detection per evaluated skill (#132, AC#1)."""
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from src.everbot.core.jobs import skill_evaluate
+import src.everbot.infra.user_data as user_data_mod
+
+
+class _StubSegmentLogger:
+    def __init__(self, *_a, **_k):
+        pass
+
+    def list_skills(self):
+        return ["twitter-watch", "invest"]
+
+    def cleanup(self, _skill_id):
+        pass
+
+
+class _StubVersionManager:
+    def __init__(self, *_a, **_k):
+        pass
+
+
+def test_run_checks_drift_for_each_skill(tmp_path, monkeypatch):
+    checked = []
+
+    udm = SimpleNamespace(
+        skill_logs_dir=tmp_path / "skill_logs",
+        sessions_dir=tmp_path / "sessions",
+        get_agent_writable_skills_dir=lambda a: tmp_path / "writable",
+        get_agent_read_skill_dirs=lambda a: [tmp_path / "writable"],
+        check_skill_override_drift=lambda agent, skill: checked.append((agent, skill)),
+    )
+
+    monkeypatch.setattr(user_data_mod, "get_user_data_manager", lambda: udm)
+    monkeypatch.setattr(skill_evaluate, "SegmentLogger", _StubSegmentLogger)
+    monkeypatch.setattr(skill_evaluate, "VersionManager", _StubVersionManager)
+
+    async def _stub_eval_one(*_a, **_k):
+        return None
+
+    monkeypatch.setattr(skill_evaluate, "_evaluate_one", _stub_eval_one)
+
+    context = SimpleNamespace(
+        skill_logs_dir=None,
+        skill_eval_dir=tmp_path / "skill_eval",
+        agent_name="demo",
+    )
+
+    asyncio.run(skill_evaluate.run(context))
+
+    assert checked == [("demo", "twitter-watch"), ("demo", "invest")]
+
+
+def test_run_drift_check_failure_does_not_break_evaluation(tmp_path, monkeypatch):
+    # A drift-check exception must never abort the evaluation loop.
+    udm = SimpleNamespace(
+        skill_logs_dir=tmp_path / "skill_logs",
+        sessions_dir=tmp_path / "sessions",
+        get_agent_writable_skills_dir=lambda a: tmp_path / "writable",
+        get_agent_read_skill_dirs=lambda a: [tmp_path / "writable"],
+        check_skill_override_drift=lambda agent, skill: (_ for _ in ()).throw(
+            RuntimeError("hash failed")
+        ),
+    )
+    monkeypatch.setattr(user_data_mod, "get_user_data_manager", lambda: udm)
+    monkeypatch.setattr(skill_evaluate, "SegmentLogger", _StubSegmentLogger)
+    monkeypatch.setattr(skill_evaluate, "VersionManager", _StubVersionManager)
+
+    evaluated = []
+
+    async def _stub_eval_one(_ctx, _sl, _vm, skill_id, _sessions):
+        evaluated.append(skill_id)
+        return None
+
+    monkeypatch.setattr(skill_evaluate, "_evaluate_one", _stub_eval_one)
+
+    context = SimpleNamespace(
+        skill_logs_dir=None,
+        skill_eval_dir=tmp_path / "skill_eval",
+        agent_name="demo",
+    )
+
+    asyncio.run(skill_evaluate.run(context))  # must not raise
+
+    assert evaluated == ["twitter-watch", "invest"]

--- a/tests/unit/test_skill_override_drift.py
+++ b/tests/unit/test_skill_override_drift.py
@@ -1,0 +1,175 @@
+"""Tests for stale per-agent skill override drift detection (#132).
+
+Covers spec v1 acceptance criteria:
+  (a) stale override (content differs, override not newer) -> detected + warned
+  (b) intentional override (content differs, override mtime newer) -> not stale
+  (c) no override -> not stale
+plus boundary/degradation cases:
+  - identical content (e.g. symlink to repo) -> not stale even if older
+  - no repo baseline -> not stale (nothing to compare against)
+  - only .py/.md files count toward the content hash
+  - check_skill_override_drift emits the spec-mandated warning line
+  - list_stale_skill_overrides returns only the stale skills, sorted
+"""
+
+import logging
+import os
+from pathlib import Path
+
+import pytest
+
+from src.everbot.infra.user_data import UserDataManager
+
+
+def _write(path: Path, content: str, mtime: float | None = None) -> None:
+    """Write a file (creating parents) and optionally pin its mtime."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+    if mtime is not None:
+        os.utime(path, (mtime, mtime))
+
+
+# Stable, ordered timestamps so "older / newer" is unambiguous.
+OLD = 1_700_000_000.0
+NEW = 1_700_100_000.0
+
+
+@pytest.fixture
+def udm(tmp_path: Path, monkeypatch) -> UserDataManager:
+    """A UserDataManager whose repo baseline resolves to a hermetic tmp repo."""
+    monkeypatch.setenv("ALFRED_REPO_ROOT", str(tmp_path / "repo"))
+    (tmp_path / "repo" / "skills").mkdir(parents=True)
+    return UserDataManager(alfred_home=tmp_path)
+
+
+def _override_dir(udm: UserDataManager, agent: str, skill: str) -> Path:
+    return udm.get_agent_writable_skills_dir(agent) / skill
+
+
+def _repo_dir(udm: UserDataManager, skill: str) -> Path:
+    assert udm.repo_skills_dir is not None
+    return udm.repo_skills_dir / skill
+
+
+class TestIsSkillOverrideStale:
+    def test_stale_when_content_differs_and_override_not_newer(self, udm):
+        # (a) repo got a fix; agent override is older and still has old content.
+        _write(_repo_dir(udm, "tw") / "fetch.py", "fixed\n", mtime=NEW)
+        _write(_override_dir(udm, "demo", "tw") / "fetch.py", "old\n", mtime=OLD)
+
+        result = udm.is_skill_override_stale("demo", "tw")
+
+        assert result is not None
+        agent_hash, repo_hash = result
+        assert agent_hash != repo_hash
+        assert len(agent_hash) >= 7 and len(repo_hash) >= 7
+
+    def test_not_stale_when_override_is_newer(self, udm):
+        # (b) intentional customization: differs but was edited after the repo.
+        _write(_repo_dir(udm, "tw") / "fetch.py", "baseline\n", mtime=OLD)
+        _write(_override_dir(udm, "demo", "tw") / "fetch.py", "customized\n", mtime=NEW)
+
+        assert udm.is_skill_override_stale("demo", "tw") is None
+
+    def test_not_stale_when_no_override(self, udm):
+        # (c) repo only, no per-agent copy.
+        _write(_repo_dir(udm, "tw") / "fetch.py", "baseline\n", mtime=NEW)
+
+        assert udm.is_skill_override_stale("demo", "tw") is None
+
+    def test_not_stale_when_content_identical_even_if_older(self, udm):
+        # symlink-to-repo / byte-identical copy must never warn.
+        _write(_repo_dir(udm, "tw") / "fetch.py", "same\n", mtime=NEW)
+        _write(_override_dir(udm, "demo", "tw") / "fetch.py", "same\n", mtime=OLD)
+
+        assert udm.is_skill_override_stale("demo", "tw") is None
+
+    def test_symlink_override_to_repo_not_stale(self, udm):
+        # contrarian-signals pattern: override dir is a symlink to the repo dir.
+        _write(_repo_dir(udm, "cs") / "run.py", "fixed\n", mtime=NEW)
+        link = _override_dir(udm, "demo", "cs")
+        link.parent.mkdir(parents=True, exist_ok=True)
+        link.symlink_to(_repo_dir(udm, "cs"))
+
+        assert udm.is_skill_override_stale("demo", "cs") is None
+
+    def test_not_stale_when_no_repo_baseline(self, udm):
+        # override exists but repo has no such skill -> nothing to compare.
+        _write(_override_dir(udm, "demo", "ghost") / "fetch.py", "x\n", mtime=OLD)
+
+        assert udm.is_skill_override_stale("demo", "ghost") is None
+
+    def test_not_stale_when_repo_dir_missing_entirely(self, tmp_path, monkeypatch):
+        # repo_skills_dir resolves to None -> degrade gracefully, never crash.
+        u = UserDataManager(alfred_home=tmp_path)
+        monkeypatch.setattr(type(u), "repo_skills_dir", property(lambda self: None))
+        _write(_override_dir(u, "demo", "tw") / "fetch.py", "x\n", mtime=OLD)
+
+        assert u.is_skill_override_stale("demo", "tw") is None
+
+    def test_only_py_and_md_files_count_toward_hash(self, udm):
+        # A differing non-(.py/.md) file must NOT trigger drift; .py/.md identical.
+        _write(_repo_dir(udm, "tw") / "fetch.py", "same\n", mtime=NEW)
+        _write(_repo_dir(udm, "tw") / "data.json", '{"v":1}\n', mtime=NEW)
+        _write(_override_dir(udm, "demo", "tw") / "fetch.py", "same\n", mtime=OLD)
+        _write(_override_dir(udm, "demo", "tw") / "data.json", '{"v":2}\n', mtime=OLD)
+
+        assert udm.is_skill_override_stale("demo", "tw") is None
+
+    def test_markdown_change_triggers_drift(self, udm):
+        # analyze.md missing the #124 requirement is exactly the real-world case.
+        _write(_repo_dir(udm, "tw") / "analyze.md", "must cite source\n", mtime=NEW)
+        _write(_override_dir(udm, "demo", "tw") / "analyze.md", "old prompt\n", mtime=OLD)
+
+        assert udm.is_skill_override_stale("demo", "tw") is not None
+
+    def test_nested_subdir_files_counted(self, udm):
+        # scripts/ live under the skill dir; drift there must be caught.
+        _write(_repo_dir(udm, "tw") / "scripts" / "fetch.py", "fixed\n", mtime=NEW)
+        _write(_override_dir(udm, "demo", "tw") / "scripts" / "fetch.py", "old\n", mtime=OLD)
+
+        assert udm.is_skill_override_stale("demo", "tw") is not None
+
+
+class TestCheckSkillOverrideDrift:
+    def test_emits_structured_warning_when_stale(self, udm, caplog):
+        _write(_repo_dir(udm, "tw") / "fetch.py", "fixed\n", mtime=NEW)
+        _write(_override_dir(udm, "demo", "tw") / "fetch.py", "old\n", mtime=OLD)
+
+        with caplog.at_level(logging.WARNING, logger="src.everbot.infra.user_data"):
+            result = udm.check_skill_override_drift("demo", "tw")
+
+        assert result is not None
+        msgs = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+        assert any(
+            "tw" in m and "per-agent override is stale" in m and "repo baseline" in m
+            for m in msgs
+        ), msgs
+
+    def test_silent_when_not_stale(self, udm, caplog):
+        _write(_repo_dir(udm, "tw") / "fetch.py", "same\n", mtime=NEW)
+        _write(_override_dir(udm, "demo", "tw") / "fetch.py", "same\n", mtime=OLD)
+
+        with caplog.at_level(logging.WARNING, logger="src.everbot.infra.user_data"):
+            result = udm.check_skill_override_drift("demo", "tw")
+
+        assert result is None
+        assert [r for r in caplog.records if r.levelno == logging.WARNING] == []
+
+
+class TestListStaleSkillOverrides:
+    def test_returns_only_stale_skills_sorted(self, udm):
+        # stale: differs + older.  fresh: differs + newer.  same: identical.
+        _write(_repo_dir(udm, "invest") / "a.py", "fix\n", mtime=NEW)
+        _write(_override_dir(udm, "demo", "invest") / "a.py", "old\n", mtime=OLD)
+
+        _write(_repo_dir(udm, "web") / "a.py", "base\n", mtime=OLD)
+        _write(_override_dir(udm, "demo", "web") / "a.py", "custom\n", mtime=NEW)
+
+        _write(_repo_dir(udm, "twitter-watch") / "a.py", "fix\n", mtime=NEW)
+        _write(_override_dir(udm, "demo", "twitter-watch") / "a.py", "old\n", mtime=OLD)
+
+        assert udm.list_stale_skill_overrides("demo") == ["invest", "twitter-watch"]
+
+    def test_empty_when_agent_has_no_overrides(self, udm):
+        assert udm.list_stale_skill_overrides("nobody") == []


### PR DESCRIPTION
Closes #132

## 背景

3 层 skill 解析链(agent 专属 → 全局 → 仓库内置,`user_data.py:get_agent_read_skill_dirs`)会让陈旧的 per-agent 覆盖副本**永久静默遮蔽**仓库上游修复:一旦覆盖副本生成就冻结在那个时间点,上游再怎么修都进不来,且无任何告警。这已复现并遮蔽 #65、#124 的修复(demo_agent/twitter-watch 长推文截断)。

本 PR 实现 issue #132 spec v1(已 endorse):**load 时检测漂移并发非阻断告警 + status 暴露**。

> 说明:本实现为**人工接管** —— monastery 自动 implement 在本 issue 上不可靠(reviewer 结构化输出崩、弱 model 测试三轮不收敛),故按 monastery operator 的 C 选项改人工实现,monastery 退回只做治理/审批。

## 改动(核心逻辑单一真相源在 `UserDataManager`)

- `infra/user_data.py`:
  - `_skill_dir_fingerprint` — 对 skill 目录下 `.py`/`.md` 算内容 hash + 取 max mtime(非 py/md 文件不计入,避免生成数据误判为漂移;读不了的文件退化为空,绝不崩)
  - `is_skill_override_stale` — hash 不同**且** override 不比仓库新才算陈旧;newer 视为有意定制放行(防误报 SLM 演化版)
  - `check_skill_override_drift` — load 时发结构化非阻断 warning
  - `list_stale_skill_overrides` — 供 status 列举
- `core/jobs/skill_evaluate.py`:评估循环对每个 skill best-effort 跑漂移检查(异常吞掉,绝不阻断评估)
- `cli/main.py`:`status` 新增「陈旧 skill 覆盖」段

**解析优先级不变**(AC#2)。

## 验收标准对照

| AC | 状态 |
|---|---|
| 1 load 时发结构化 warning | ✅ |
| 2 不阻断、保留优先级 | ✅ |
| 3 `bin/everbot status` 可见 | ✅ 端到端实测 |
| 4 override 更新(mtime 新)不误报 | ✅ |
| 5 单测覆盖 (a)(b)(c) | ✅ 19 个新测试 + 边界 |

## 验证

- 新测试 19/19 通过;`tests/unit` + `tests/cli` 全套 **1948 passed, 3 skipped**,无回归。
- 真实环境烟测:检测器对 demo_agent 正确识别 `daily-attractor` 为陈旧;`invest`/`web`/`paper-discovery` 因 mtime 比仓库新被判为有意定制放行(符合 AC#4)。
- `python -m src.everbot.cli status` 端到端已输出「陈旧 skill 覆盖」段。

## 后续(spec 已注明,独立 issue)

- Direction 2:覆盖创建语义收敛(只在真有定制时落副本)
- Direction 3:自动同步/失效
- Direction 4:写进 alfred_debug runbook
- 若认为「mtime 比仓库新」不足以证明有意定制(可能只是被 touch),可在后续收紧判据

🤖 Generated with [Claude Code](https://claude.com/claude-code)