### PR TITLE
fix(runtime): 溯源/计划元工具不再占用 job 工具预算 (#136)

### DIFF
--- a/src/everbot/core/runtime/turn_orchestrator.py
+++ b/src/everbot/core/runtime/turn_orchestrator.py
@@ -590,6 +590,25 @@ class TurnOrchestrator:
         _recent_fps: list[str] = []  # sliding window of recent fingerprints
         _LOOP_WINDOW = max(8, policy.max_consecutive_similar_llm_rounds)
         seen_progress_fingerprints: set[str] = set()
+        # Idempotent meta-tools (e.g. update_step): identical repeat calls are
+        # dropped as no-ops. Keyed by name + content-normalized args so that
+        # key-order variance in the provider's JSON serialization still dedupes.
+        seen_idempotent_calls: set[str] = set()
+
+        def _is_idempotent_noop(name: str, args: str) -> bool:
+            if name not in policy.idempotent_tools:
+                return False
+            normalized = (args or "").strip()
+            try:
+                parsed = json.loads(normalized)
+                normalized = json.dumps(parsed, sort_keys=True, ensure_ascii=False)
+            except (json.JSONDecodeError, TypeError):
+                normalized = re.sub(r"\s+", " ", normalized)
+            key = f"{name}:{normalized}"
+            if key in seen_idempotent_calls:
+                return True
+            seen_idempotent_calls.add(key)
+            return False
 
         def _flush_trajectory() -> None:
             """Save trajectory before early return (loop/error abort).
@@ -708,6 +727,10 @@ class TurnOrchestrator:
                     fail_sig = None  # set in completed/failed branch below
 
                     if status in ("running", "processing"):
+                        # Identical repeat of an idempotent meta-tool → drop as a
+                        # no-op: no budget, no intent counting, no emit.
+                        if _is_idempotent_noop(s_name, s_args):
+                            continue
                         # A *novel* tool call means the round made progress: tool-use
                         # native models legitimately call tools without any narration
                         # text, so "tool call + no text" is NOT a degradation signal on
@@ -901,6 +924,10 @@ class TurnOrchestrator:
                     # text-less round that repeats a tool intent counts toward the
                     # empty/think-only loop guards.
                     t_args_raw = progress.get("args", "")
+                    # Identical repeat of an idempotent meta-tool → drop as a no-op
+                    # (parity with the skill branch above).
+                    if status in ("running", "processing") and _is_idempotent_noop(t_name, t_args_raw):
+                        continue
                     intent_sig = _extract_tool_intent_signature(t_name, t_args_raw)
                     made_progress = bool(intent_sig) and tool_intent_signatures.get(intent_sig, 0) == 0
                     if made_progress:

--- a/src/everbot/core/runtime/turn_policy.py
+++ b/src/everbot/core/runtime/turn_policy.py
@@ -97,6 +97,11 @@ class TurnPolicy:
     max_phantom_tool_calls: int = 1
     # Internal helper tools excluded from tool-call budget counting.
     budget_exempt_tools: frozenset = field(default_factory=frozenset)
+    # Tools whose identical repeat calls (same name + same args) are dropped as
+    # no-ops: they neither consume the tool-call budget nor trip the
+    # repeated-intent guard. Distinct calls still count. Catches benign loops
+    # like update_step marking the same step+status again.
+    idempotent_tools: frozenset = field(default_factory=frozenset)
     # Directory patterns to exclude from grep-like tool searches.
     grep_exclude_patterns: List[str] = field(default_factory=lambda: [
         ".venv", "node_modules", "__pycache__", ".git", "site-packages",
@@ -118,12 +123,21 @@ HEARTBEAT_POLICY = TurnPolicy(
     timeout_seconds=120,
 )
 
+# Provenance/plan meta-tools are not external work: `cite` scales with report
+# quality (one per sourced claim) and `create_plan` runs ~once, so counting them
+# against the data-gathering budget makes well-sourced reports fail. `update_step`
+# stays counted but identical repeats are dropped (see idempotent_tools).
+_PROVENANCE_EXEMPT = frozenset({"cite", "create_plan"})
+_IDEMPOTENT_META = frozenset({"update_step"})
+
 JOB_POLICY = TurnPolicy(
     max_attempts=1,
     max_tool_calls=20,
     max_failed_tool_outputs=5,
     max_tool_output_preview_chars=12000,
     timeout_seconds=600,
+    budget_exempt_tools=_PROVENANCE_EXEMPT,
+    idempotent_tools=_IDEMPOTENT_META,
 )
 
 WORKFLOW_POLICY = TurnPolicy(
@@ -132,6 +146,8 @@ WORKFLOW_POLICY = TurnPolicy(
     max_failed_tool_outputs=8,
     max_tool_output_preview_chars=12000,
     timeout_seconds=300,
+    budget_exempt_tools=_PROVENANCE_EXEMPT,
+    idempotent_tools=_IDEMPOTENT_META,
 )
 
 
@@ -223,6 +239,8 @@ def build_job_policy(
         max_failed_tool_outputs=JOB_POLICY.max_failed_tool_outputs,
         max_tool_output_preview_chars=JOB_POLICY.max_tool_output_preview_chars,
         timeout_seconds=timeout,
+        budget_exempt_tools=JOB_POLICY.budget_exempt_tools,
+        idempotent_tools=JOB_POLICY.idempotent_tools,
     )
 
 
@@ -238,4 +256,6 @@ def build_workflow_policy(
         max_failed_tool_outputs=WORKFLOW_POLICY.max_failed_tool_outputs,
         max_tool_output_preview_chars=WORKFLOW_POLICY.max_tool_output_preview_chars,
         timeout_seconds=timeout,
+        budget_exempt_tools=WORKFLOW_POLICY.budget_exempt_tools,
+        idempotent_tools=WORKFLOW_POLICY.idempotent_tools,
     )

--- a/tests/unit/test_turn_orchestrator.py
+++ b/tests/unit/test_turn_orchestrator.py
@@ -2694,3 +2694,142 @@ async def test_phantom_tool_guard_disabled_without_callback():
     assert len(errors) == 0
     outputs = [e for e in events if e.type == TurnEventType.TOOL_OUTPUT]
     assert all("not a registered tool" not in o.tool_output for o in outputs)
+
+
+# ---------------------------------------------------------------------------
+# Provenance / plan meta-tools: budget exemption + idempotent dedup (issue #136)
+# ---------------------------------------------------------------------------
+
+
+def test_job_policy_exempts_provenance_and_idempotent_step():
+    """job 预算只约束外部工作:cite/create_plan 不计预算,update_step 幂等去重。"""
+    p = build_job_policy()
+    assert "cite" in p.budget_exempt_tools
+    assert "create_plan" in p.budget_exempt_tools
+    assert "update_step" in p.idempotent_tools
+
+
+def test_workflow_policy_exempts_provenance_and_idempotent_step():
+    p = build_workflow_policy()
+    assert "cite" in p.budget_exempt_tools
+    assert "create_plan" in p.budget_exempt_tools
+    assert "update_step" in p.idempotent_tools
+
+
+@pytest.mark.asyncio
+async def test_idempotent_repeated_skill_not_counted():
+    """同 stepId+status 的重复 update_step 是 no-op:不占预算、只算一次。"""
+    script = []
+    for i in range(6):  # 6 identical, > budget 3
+        script.append(_progress_event(
+            _skill_call("update_step", '{"stepId": 3, "status": "done"}', pid=f"u{i}")
+        ))
+    script.append(_progress_event(_llm_delta("done", pid="llm")))
+    agent = _ScriptedAgent(script)
+    orch = TurnOrchestrator(TurnPolicy(
+        max_attempts=1, max_tool_calls=3,
+        idempotent_tools=frozenset({"update_step"}),
+        max_consecutive_empty_llm_rounds=99,
+    ))
+    events = [te async for te in orch.run_turn(agent, "go")]
+    errors = [e for e in events if e.type == TurnEventType.TURN_ERROR]
+    assert errors == [], f"idempotent repeats must not trip a guard: {[e.error for e in errors]}"
+    complete = next(e for e in events if e.type == TurnEventType.TURN_COMPLETE)
+    assert complete.tool_call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_idempotent_repeat_does_not_trip_intent_guard():
+    """重复 no-op 不应触发 REPEATED_TOOL_INTENT(否则只是把失败模式换个名字)。"""
+    script = [
+        _progress_event(_skill_call("update_step", '{"stepId": 3, "status": "done"}', pid=f"u{i}"))
+        for i in range(7)
+    ]
+    script.append(_progress_event(_llm_delta("ok", pid="llm")))
+    agent = _ScriptedAgent(script)
+    orch = TurnOrchestrator(TurnPolicy(
+        max_attempts=1, max_tool_calls=20, max_same_tool_intent=2,
+        idempotent_tools=frozenset({"update_step"}),
+        max_consecutive_empty_llm_rounds=99,
+    ))
+    events = [te async for te in orch.run_turn(agent, "go")]
+    errors = [e for e in events if e.type == TurnEventType.TURN_ERROR]
+    assert errors == [], f"unexpected guard: {[e.error for e in errors]}"
+
+
+@pytest.mark.asyncio
+async def test_distinct_idempotent_tool_calls_still_counted():
+    """不同 stepId 的 update_step 是真实进展,仍计预算(防无界放行)。"""
+    script = [
+        _progress_event(_skill_call("update_step", f'{{"stepId": {i}, "status": "done"}}', pid=f"u{i}"))
+        for i in range(5)  # 5 distinct, > budget 3
+    ]
+    agent = _ScriptedAgent(script)
+    orch = TurnOrchestrator(TurnPolicy(
+        max_attempts=1, max_tool_calls=3,
+        idempotent_tools=frozenset({"update_step"}),
+        max_consecutive_empty_llm_rounds=99,
+    ))
+    events = [te async for te in orch.run_turn(agent, "go")]
+    errors = [e for e in events if e.type == TurnEventType.TURN_ERROR]
+    assert any("TOOL_CALL_BUDGET_EXCEEDED" in e.error for e in errors)
+
+
+@pytest.mark.asyncio
+async def test_idempotent_key_ignores_json_key_order():
+    """同内容不同键序视为同一 no-op(milkie 序列化键序不稳定)。"""
+    script = [
+        _progress_event(_skill_call("update_step", '{"stepId": 1, "status": "done"}', pid="a")),
+        _progress_event(_skill_call("update_step", '{"status": "done", "stepId": 1}', pid="b")),
+        _progress_event(_llm_delta("ok", pid="llm")),
+    ]
+    agent = _ScriptedAgent(script)
+    orch = TurnOrchestrator(TurnPolicy(
+        max_attempts=1, max_tool_calls=1,
+        idempotent_tools=frozenset({"update_step"}),
+        max_consecutive_empty_llm_rounds=99,
+    ))
+    events = [te async for te in orch.run_turn(agent, "go")]
+    errors = [e for e in events if e.type == TurnEventType.TURN_ERROR]
+    assert errors == [], f"key-order variants must dedupe: {[e.error for e in errors]}"
+    complete = next(e for e in events if e.type == TurnEventType.TURN_COMPLETE)
+    assert complete.tool_call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_issue136_real_run_no_longer_trips_budget():
+    """回归:复现 routine_38364fe6 失败那次的真实调用序列(milkie run
+    3023528f),在真实 JOB_POLICY 下不再误报 TOOL_CALL_BUDGET_EXCEEDED。
+
+    构成:1 create_plan(豁免) + 7 run_command(真实数据) + 11 cite(豁免)
+    + update_step(5 个不同状态 + 6 次重复 stepId3/done 应被幂等丢弃)。
+    """
+    script = [_progress_event(_skill_call("create_plan", '{"steps": ["a", "b", "c", "d"]}', pid="plan"))]
+    # 7 次真实数据采集(各不相同)
+    for i, cmd in enumerate(["cat skill", "cat rhino", "rhino_report",
+                             "inv scan", "inv infer", "value AAPL", "inv report"]):
+        script.append(_progress_event(_skill_call("run_command", cmd, pid=f"rc{i}")))
+    # update_step:5 个真实状态变更 + 6 次重复(应被幂等丢弃)
+    for sid, st, pid in [(0, "done", "s0"), (1, "done", "s1"), (1, "pending", "s2"),
+                         (1, "done", "s3"), (2, "done", "s4")]:
+        script.append(_progress_event(
+            _skill_call("update_step", f'{{"stepId": {sid}, "status": "{st}"}}', pid=pid)
+        ))
+    for i in range(7):  # stepId3/done ×7:首个计数,后 6 个重复丢弃
+        script.append(_progress_event(
+            _skill_call("update_step", '{"stepId": 3, "status": "done"}', pid=f"s3done{i}")
+        ))
+    # 11 条溯源(各不相同,均豁免)
+    for i in range(11):
+        script.append(_progress_event(_skill_call("cite", f'{{"claim": "c{i}"}}', pid=f"cite{i}")))
+    script.append(_progress_event(_llm_delta("综合信号报告已生成", pid="llm")))
+
+    agent = _ScriptedAgent(script)
+    orch = TurnOrchestrator(JOB_POLICY)  # 真实预设,max_tool_calls=20
+    events = [te async for te in orch.run_turn(agent, "go")]
+
+    errors = [e for e in events if e.type == TurnEventType.TURN_ERROR]
+    assert errors == [], f"must not trip any guard: {[e.error for e in errors]}"
+    complete = next(e for e in events if e.type == TurnEventType.TURN_COMPLETE)
+    # 7 run_command + 5 个不同 update_step = 12;cite/create_plan 豁免,重复 step 丢弃
+    assert complete.tool_call_count == 12, complete.tool_call_count


### PR DESCRIPTION
Fixes #136

## 背景
证据密集型 job 任务（投资信号 `routine_38364fe6`、灰犀牛、吸引子等）反复误报 `TOOL_CALL_BUDGET_EXCEEDED: tool_calls=21, limit=20`，报告仍下发但任务被判失败。

从失败那次的 milkie run（`3023528f-…jsonl`，`agent.run.completed`）逐条还原：真正的数据采集只有 **7 次 `run_command`**，撑爆 20 次预算的是 **11 次 `cite` + 12 次 `update_step` + `create_plan`** 这些溯源/计划元操作。它们与真正数据命令共用同一预算 → 「报告引用的来源越多越容易失败」，与 milkie「可追溯可解释为第一目标」相反。

## 改动
- **`turn_policy.py`**：`JOB_POLICY` / `WORKFLOW_POLICY` 设 `budget_exempt_tools={cite, create_plan}`，纯溯源/规划元操作不计入工具预算；新增 `TurnPolicy.idempotent_tools` 字段；`build_job_policy` / `build_workflow_policy` 一并透传（原会丢这两个字段）。
- **`turn_orchestrator.py`**：新增 `_is_idempotent_noop()`——同名 + 内容归一化 args（解析 JSON 后 `sort_keys`，规避 milkie 序列化键序不稳）的重复 `update_step` 直接丢弃，**既不计预算也不触发 `REPEATED_TOOL_INTENT`**；不同 step 仍计数，保留对真实循环的防护（不直接豁免）。在 skill / tool_call 两处计数点对称插入。

## 为什么不直接调高上限 / 超时
- 真实数据工作仅 7 次，抬高上限只会把元操作开销纳入预算、掩盖未来真实数据循环。
- 失败是次数触顶（run 仅 ~100s），与 `timeout_seconds` 无关。

## 测试
- 6 个新单测 RED→GREEN：策略豁免、幂等不计数、幂等不触发 intent 守卫、不同 step 仍计数、键序无关去重。
- 真实场景回归 `test_issue136_real_run_no_longer_trips_budget`：用真实 `JOB_POLICY` 复现失败序列（1 create_plan + 7 run_command + 5 个不同 update_step + 6 次重复 + 11 cite）→ 不再报错，最终计数 **12 ≤ 20**。
- 全量 unit **1942 passed**，无回归。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
