### PR TITLE
fix(#47): write milkie agent manifest for trace replay

### DIFF
--- a/src/everbot/core/agent/provider/milkie/launcher.py
+++ b/src/everbot/core/agent/provider/milkie/launcher.py
@@ -22,6 +22,7 @@ logger = logging.getLogger(__name__)
 # env 告知 serve;milkie 默认 handler 读它返回真实技能列表(去 stub)。
 SKILL_MANIFEST_FILENAME = "skill-manifest.json"
 SKILL_MANIFEST_ENV = "MILKIE_SKILL_MANIFEST"
+AGENT_MANIFEST_FILENAME = "agents.json"
 
 # E2b(#108):sidecar OS 沙箱 —— launcher 给 milkie serve 套 macOS sandbox-exec,
 # 物理禁止子进程(含 run_command fork 的 shell)写共享/系统路径,半径锁在自身 workspace。
@@ -135,6 +136,15 @@ class SidecarLauncher:
         agent_md = data_dir / "agent.md"
         agent_md.write_text(
             build_milkie_agent_md(agent_name, system_prompt, tiers), encoding="utf-8"
+        )
+        agent_manifest = data_dir / AGENT_MANIFEST_FILENAME
+        agent_manifest.write_text(
+            json.dumps(
+                {"agents": [{"id": agent_name, "file": agent_md.name}]},
+                ensure_ascii=False,
+                indent=2,
+            ),
+            encoding="utf-8",
         )
         cmd = [
             self._node_bin, str(self._dist_path.expanduser()), "serve",

--- a/tests/unit/test_milkie_launcher.py
+++ b/tests/unit/test_milkie_launcher.py
@@ -4,6 +4,7 @@ import json
 import pytest
 
 from src.everbot.core.agent.provider.milkie.launcher import (
+    AGENT_MANIFEST_FILENAME,
     SidecarLauncher,
     LaunchSpec,
     SKILL_MANIFEST_ENV,
@@ -47,6 +48,14 @@ def test_build_writes_agent_md_and_returns_cmd(tmp_path):
     assert spec.cmd[spec.cmd.index("--port") + 1] == "0"
     assert spec.cmd[spec.cmd.index("--state-store") + 1] == "sqlite"
     assert spec.cmd[spec.cmd.index("--data-dir") + 1] == str(spec.data_dir)
+
+
+def test_build_writes_agent_manifest_for_trace_replay(tmp_path):
+    spec = _launcher(tmp_path).build("alice", system_prompt="You are Alice.")
+    manifest = json.loads(
+        (spec.data_dir / AGENT_MANIFEST_FILENAME).read_text(encoding="utf-8")
+    )
+    assert manifest == {"agents": [{"id": "alice", "file": "agent.md"}]}
 
 
 def test_build_injects_cloud_api_key_env(tmp_path):


### PR DESCRIPTION
## Summary

- write `agents.json` into each Milkie sidecar data-dir alongside `agent.md`
- keep `serve --agent` unchanged while satisfying `milkie trace replay --data-dir` manifest loading
- add launcher coverage for the replay manifest

## Validation

- `python -m pytest tests/unit/test_milkie_launcher.py tests/unit/test_milkie_trace.py tests/unit/test_milkie_provider.py -q -k 'agent_manifest or trace or run_id or capture_trace'`\n- isolated real sidecar E2E with fake OpenAI:\n  - captured runId `08773412-3c9d-43f2-a253-0054c3ba36a7`\n  - generated trace JSONL, size 25272 bytes\n  - generated HTML report, size 60563 bytes\n  - `trace execution --data-dir` succeeded\n  - `trace replay --data-dir` returned `status=completed` and `newRunId=08773412-3c9d-43f2-a253-0054c3ba36a7`\n\nCloses #47