### PR TITLE
Remove Claude CLI dependency from twitter-watch

### DIFF
--- a/skills/twitter-watch/SKILL.md
+++ b/skills/twitter-watch/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: twitter-watch
-description: Fetch a given X (Twitter) user's latest tweets and run a deep analysis with claude code. Use when the user wants to watch/track an X account or analyze someone's recent tweets.
+description: Fetch a given X (Twitter) user's latest tweets and run a deep analysis with the configured OpenAI-compatible model route. Use when the user wants to watch/track an X account or analyze someone's recent tweets.
 version: "1.0.0"
-tags: [twitter, x, social, analysis, claude, watch]
+tags: [twitter, x, social, analysis, watch]
 ---
 
 # Twitter Watch Skill
 
-抓取指定 X(Twitter)用户的最新推文,并用 **claude code**(`claude -p`)做**深度分析**,产出结构化中文报告。可手动调用,也可注册为每日定时任务。
+抓取指定 X(Twitter)用户的最新推文,并用当前 `config/models.yaml` 配置的 OpenAI-compatible 模型做**深度分析**,产出结构化中文报告。可手动调用,也可注册为每日定时任务。
 
 ## When to Use
 
@@ -19,7 +19,7 @@ tags: [twitter, x, social, analysis, claude, watch]
 ## 前置依赖(已就绪,无需安装)
 
 - 抓取复用同级 **`web`** 技能的 Playwright 浏览器(端口 9222)及其**已登录 X** 的持久化 profile。脚本会在 server 未起时自动 `web/server.sh &` 拉起。
-- 分析用 `claude` CLI(claude code),已在 PATH。
+- 分析用 `config/models.yaml` 的模型路由；不依赖本机特定分析 CLI。
 
 ## 用法
 
@@ -31,7 +31,7 @@ TW="$SKILL_DIR/scripts"
 # 1) 抓最新 3 条(默认 handle 见 config/.env;也可显式传 handle)
 python "$TW/fetch_tweets.py" aleabitoreddit --count 3 > /tmp/tweets.json
 
-# 2) 深度分析(claude code),输出中文报告
+# 2) 深度分析(配置模型),输出中文报告
 python "$TW/analyze.py" --input /tmp/tweets.json
 
 # 或一行管道
@@ -43,7 +43,7 @@ python "$TW/fetch_tweets.py" aleabitoreddit --count 3 | python "$TW/analyze.py"
 ## 脚本
 
 - `scripts/fetch_tweets.py <handle> [--count N]` — 抓最新 N 条非置顶推文,按时间倒序,输出 JSON(正文/时间/URL/互动数)。**未登录/cookie 失效时退出码 3 并提示去 `web` profile 重登,绝不伪造内容。**
-- `scripts/analyze.py [--input f] [--model M] [--timeout S]` — 读推文 JSON(默认 stdin),调 `claude -p` 产出逐条解读 / 投资信号与标的 / 整体主题 / 作者立场 的中文报告。
+- `scripts/analyze.py [--input f] [--model LLM_NAME] [--fast] [--timeout S]` — 读推文 JSON(默认 stdin),调用 `config/models.yaml` 中的 OpenAI-compatible 路由产出逐条解读 / 投资信号与标的 / 整体主题 / 作者立场 的中文报告。`--model` 使用 `llms` 里的配置名；未指定时使用 default，`--fast` 使用 fast 档。
 
 ## 已知限制
 

--- a/skills/twitter-watch/scripts/analyze.py
+++ b/skills/twitter-watch/scripts/analyze.py
@@ -1,10 +1,8 @@
 #!/usr/bin/env python3
-"""把抓到的推文喂给 claude code(``claude -p`` headless)做深度分析,产出中文报告。
+"""Analyze fetched tweets with the configured OpenAI-compatible model route.
 
 输入:fetch_tweets.py 的 JSON(从 stdin 读,或 --input 指定文件)。
-输出:claude 生成的结构化深度分析报告(stdout)。
-
-纯文本分析,不开 --dangerously-skip-permissions(claude 只读 prompt、不动文件)。
+输出:模型生成的结构化深度分析报告(stdout)。
 
 用法:
     python fetch_tweets.py aleabitoreddit --count 3 | python analyze.py
@@ -13,9 +11,19 @@
 from __future__ import annotations
 
 import argparse
+import asyncio
 import json
-import subprocess
 import sys
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from src.everbot.core.agent.provider.model_config import load_model_config  # noqa: E402
 
 _PROMPT_TEMPLATE = """你是资深投资与科技分析师。下面是 X 用户 @{handle} 最新的 {n} 条推文(含互动数据 metrics)。请做**深度分析**,用**中文**输出结构化报告。要求基于推文内容分析,保留关键原文引用,**不要编造推文未提及的信息**。
 
@@ -48,30 +56,56 @@ def build_prompt(data: dict) -> str:
     )
 
 
-def run_claude(prompt: str, model: str | None, timeout: int) -> str:
-    cmd = ["claude", "-p", prompt]
-    if model:
-        cmd += ["--model", model]
+async def run_analysis(prompt: str, model: str | None, timeout: int, fast: bool = False) -> str:
     try:
-        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
-    except FileNotFoundError:
-        sys.exit("[analyze] 未找到 claude CLI — 确认 claude code 已安装且在 PATH")
-    except subprocess.TimeoutExpired:
-        sys.exit(f"[analyze] claude 分析超时(>{timeout}s)")
-    if proc.returncode != 0:
-        sys.stderr.write(proc.stderr)
-        sys.exit(f"[analyze] claude 退出码 {proc.returncode}")
-    out = proc.stdout.strip()
+        cfg = load_model_config()
+        route = cfg.route_for(model) if model else cfg.route(fast=fast)
+    except Exception as exc:
+        sys.exit(f"[analyze] 模型配置错误: {exc}")
+
+    payload: dict[str, Any] = {
+        "model": route.model,
+        "messages": [{"role": "user", "content": prompt}],
+        "temperature": 0.3,
+        "stream": False,
+        **route.extra_body,
+    }
+    headers = {
+        "Authorization": f"Bearer {route.api_key}",
+        "content-type": "application/json",
+        **route.headers,
+    }
+    base = route.base_url
+    url = base if base.endswith("/chat/completions") else f"{base}/chat/completions"
+
+    try:
+        async with httpx.AsyncClient(timeout=httpx.Timeout(float(timeout)), trust_env=False) as client:
+            resp = await client.post(url, json=payload, headers=headers)
+    except httpx.TimeoutException:
+        sys.exit(f"[analyze] 模型分析超时(>{timeout}s)")
+    except Exception as exc:
+        sys.exit(f"[analyze] 模型调用失败: {exc}")
+
+    if resp.status_code >= 400:
+        sys.stderr.write(resp.text)
+        sys.exit(f"[analyze] 模型接口 HTTP {resp.status_code}")
+
+    try:
+        data = resp.json()
+        out = (data["choices"][0]["message"]["content"] or "").strip()
+    except Exception as exc:
+        sys.exit(f"[analyze] 模型返回格式无效: {exc}")
     if not out:
-        sys.exit("[analyze] claude 返回空报告")
+        sys.exit("[analyze] 模型返回空报告")
     return out
 
 
 def main() -> None:
-    ap = argparse.ArgumentParser(description="用 claude code 深度分析推文")
+    ap = argparse.ArgumentParser(description="用已配置模型深度分析推文")
     ap.add_argument("--input", help="推文 JSON 文件(默认从 stdin 读)")
-    ap.add_argument("--model", default=None, help="指定 claude 模型(默认用 claude 默认)")
-    ap.add_argument("--timeout", type=int, default=180, help="claude 超时秒数(默认 180)")
+    ap.add_argument("--model", default=None, help="指定 config/models.yaml 里的 llm 名称(默认用 default)")
+    ap.add_argument("--fast", action="store_true", help="未指定 --model 时使用 fast 档")
+    ap.add_argument("--timeout", type=int, default=180, help="模型调用超时秒数(默认 180)")
     args = ap.parse_args()
 
     raw = open(args.input, encoding="utf-8").read() if args.input else sys.stdin.read()
@@ -82,7 +116,7 @@ def main() -> None:
     if not data.get("tweets"):
         sys.exit("[analyze] 输入无 tweets,无可分析内容")
 
-    report = run_claude(build_prompt(data), args.model, args.timeout)
+    report = asyncio.run(run_analysis(build_prompt(data), args.model, args.timeout, fast=args.fast))
     print(report)
 
 

--- a/tests/unit/test_twitter_watch_provenance.py
+++ b/tests/unit/test_twitter_watch_provenance.py
@@ -4,8 +4,14 @@ tweet 的 url 本就进了喂给 LLM 的数据,但分析 prompt 没要求报告*
 原文链接 → 生成的报告会漏。补 prompt 指令,让 Serenity 这类报告可溯源到单条推文。
 """
 import importlib.util
+import asyncio
+import json
 import sys
 from pathlib import Path
+
+import httpx
+
+from src.everbot.core.agent.provider.model_config import ModelConfig
 
 _SCRIPTS = Path(__file__).resolve().parents[2] / "skills" / "twitter-watch" / "scripts"
 if str(_SCRIPTS) not in sys.path:
@@ -43,3 +49,38 @@ def test_prompt_requires_per_tweet_source_link():
     """指令层:prompt 明确要求报告逐条带原文链接(L2a 可溯源)。"""
     prompt = az.build_prompt(_data())
     assert "原文链接" in prompt
+
+
+def test_analyze_uses_configured_openai_compatible_route(monkeypatch):
+    """twitter-watch analysis should not shell out to Claude CLI."""
+    cfg = ModelConfig(
+        llms={"m": {"cloud": "c", "model_name": "mm"}},
+        clouds={"c": {"api": "http://fake/v1", "api_key": "k"}},
+        default_model="m",
+        fast_model="m",
+    )
+    monkeypatch.setattr(az, "load_model_config", lambda: cfg)
+    cap = {}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        cap["url"] = str(req.url)
+        cap["auth"] = req.headers.get("authorization")
+        cap["json"] = json.loads(req.content.decode("utf-8"))
+        return httpx.Response(200, json={"choices": [{"message": {"content": " 报告 "}}]})
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    monkeypatch.setattr(az.httpx, "AsyncClient", lambda *a, **k: client)
+
+    out = asyncio.run(az.run_analysis("prompt", None, 30))
+
+    assert out == "报告"
+    assert cap["url"] == "http://fake/v1/chat/completions"
+    assert cap["auth"] == "Bearer k"
+    assert cap["json"]["model"] == "mm"
+    assert cap["json"]["messages"][0]["content"] == "prompt"
+
+
+def test_analyze_script_no_longer_references_claude_cli():
+    src = (_SCRIPTS / "analyze.py").read_text(encoding="utf-8")
+    assert '"claude"' not in src
+    assert "claude -p" not in src


### PR DESCRIPTION
## Summary

- replace `twitter-watch` analysis shell-out to `claude -p` with the configured OpenAI-compatible model route from `config/models.yaml`
- update the skill instructions so agents no longer learn Claude CLI usage for tweet analysis
- add regression coverage for configured-route analysis and no Claude CLI references

Closes #139

## Tests

- `PYTHONPATH=src .venv/bin/python -m pytest tests/unit/test_twitter_watch_provenance.py tests/unit/test_fetch_tweets.py -q`
- `.venv/bin/python -m py_compile skills/twitter-watch/scripts/analyze.py`
