### PR TITLE
Fix memory review duplicate merge IDs

### DIFF
--- a/src/everbot/core/memory/manager.py
+++ b/src/everbot/core/memory/manager.py
@@ -398,10 +398,17 @@ class MemoryManager:
                 entry_map = {e.id: e for e in entries}
 
                 # 1. Merge pairs
+                consumed_merge_ids = set()
                 for pair in review.get("merge_pairs", []):
                     id_a = pair.get("id_a", "")
                     id_b = pair.get("id_b", "")
                     merged_content = pair.get("merged_content", "")
+                    if id_a == id_b:
+                        logger.warning("Merge pair references the same ID twice: %s", id_a)
+                        continue
+                    if id_a in consumed_merge_ids or id_b in consumed_merge_ids:
+                        logger.warning("Merge pair reuses already merged ID: %s, %s", id_a, id_b)
+                        continue
                     if id_a not in entry_map or id_b not in entry_map:
                         logger.warning("Merge pair references missing ID: %s, %s", id_a, id_b)
                         continue
@@ -410,6 +417,7 @@ class MemoryManager:
                     )
                     del entry_map[id_a]
                     del entry_map[id_b]
+                    consumed_merge_ids.update((id_a, id_b))
                     entry_map[merged.id] = merged
                     stats["merged"] += 1
 

--- a/tests/unit/test_self_reflection.py
+++ b/tests/unit/test_self_reflection.py
@@ -279,6 +279,43 @@ class TestApplyReview:
         result = mm.load_entries()
         assert len(result) == 1
 
+    def test_self_merge_pair_skipped(self, memory_path):
+        from src.everbot.core.memory.manager import MemoryManager
+        entries = [self._make_entry("aaa111")]
+        self._create_memory_file(memory_path, entries)
+        mm = MemoryManager(memory_path)
+        review = {
+            "merge_pairs": [
+                {"id_a": "aaa111", "id_b": "aaa111", "merged_content": "invalid self merge"}
+            ],
+        }
+        stats = mm.apply_review(review)
+        assert stats["merged"] == 0
+        result = mm.load_entries()
+        assert len(result) == 1
+        assert result[0].id == "aaa111"
+
+    def test_merge_pair_reusing_consumed_id_skipped(self, memory_path):
+        from src.everbot.core.memory.manager import MemoryManager
+        entries = [
+            self._make_entry("aaa111", "user likes python"),
+            self._make_entry("bbb222", "user prefers python"),
+            self._make_entry("ccc333", "user likes concise answers"),
+        ]
+        self._create_memory_file(memory_path, entries)
+        mm = MemoryManager(memory_path)
+        review = {
+            "merge_pairs": [
+                {"id_a": "aaa111", "id_b": "bbb222", "merged_content": "user prefers Python"},
+                {"id_a": "aaa111", "id_b": "ccc333", "merged_content": "invalid reused ID"},
+            ],
+        }
+        stats = mm.apply_review(review)
+        assert stats["merged"] == 1
+        result = mm.load_entries()
+        assert len(result) == 2
+        assert any(e.id == "ccc333" for e in result)
+
     def test_refine_updates_content(self, memory_path):
         from src.everbot.core.memory.manager import MemoryManager
         entries = [self._make_entry("aaa111", "old content")]


### PR DESCRIPTION
## Summary
- Guard memory review merge pairs against self-merge IDs
- Skip merge pairs that reuse an already consumed memory ID
- Add regression tests for malformed LLM review output

## Tests
- pytest tests/unit/test_self_reflection.py -q
- pytest tests/unit/test_memory_manager.py tests/unit/test_memory_merger.py -q