### PR TITLE
feat: unify routine retry ownership

### DIFF
--- a/docs/design/142-unified-routine-retry.md
+++ b/docs/design/142-unified-routine-retry.md
@@ -1,0 +1,40 @@
+# 统一 Routine 重试策略（#142）
+
+> 最后更新：2026-07-10  
+> Issue: https://github.com/xforce-io/alfred/issues/142  
+> 分支：`feat/142-unified-routine-retry`
+
+## 目标
+
+Alfred 成为 routine 重试调度的唯一所有者。移除 isolated-agent 内部固定重试循环，
+让 `Task.max_retry`、持久化状态、用户提示和实际调度共享同一个决策结果。
+
+## 策略
+
+- 初始执行不计入 retry；`max_retry` 表示初始执行之后最多重试次数。
+- 结构化 provider 错误优先读取 `retryable`；旧错误字符串分类仅作兼容回退。
+- 非 retryable 错误直接终止当前周期。
+- 默认延迟保留 5 分钟、15 分钟；更大的 `max_retry` 使用封顶指数退避。
+- jitter 可配置，clock/random 通过依赖注入保证测试确定性。
+
+纯策略函数输出 `retry | terminal`、delay、attempt/max_retry、next_run_at 和错误元数据。
+持久化和 `format_retry_hint` 必须消费同一个决策对象，禁止重复推导。
+
+## 状态与兼容
+
+持久化 attempt、`last_error_code`、retryable 和 next_run_at。旧 HEARTBEAT 记录缺少
+新字段时按默认值加载；现有 `retry` 字段保持可读并迁移为权威 attempt 语义，不改变
+既有 schedule。
+
+## 测试计划
+
+- **单元测试**：`max_retry=0/1/3/5`、可重试/终止错误、封顶退避和确定性 jitter。
+- **集成测试**：任务保存再加载后，claim、hint 和调度仍使用同一 attempt。
+- **功能测试**：isolated routine 首次 transient 失败、仅调度一次重试后成功；终止错误不重试。
+- **端到端测试**：Alfred → 真 Milkie sidecar → 确定性模型 stub 先失败后成功；只产生
+  两个 run attempt 和一次最终投递。
+- **配置验证**：旧 HEARTBEAT JSON 无需迁移即可加载，daemon smoke 保持通过。
+
+## 非目标
+
+不实现 provider failover、Milkie 内部重试、stage checkpoint 或通用 workflow engine。

--- a/src/everbot/core/agent/provider/milkie/provider.py
+++ b/src/everbot/core/agent/provider/milkie/provider.py
@@ -232,6 +232,28 @@ class MilkieAgentHandle:
     last_run_id: Optional[str] = None
 
 
+class MilkieAgentError(RuntimeError):
+    """A structured failure returned by the Milkie serve SSE boundary."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        envelope: Optional[dict[str, Any]] = None,
+        run_id: Optional[str] = None,
+    ) -> None:
+        super().__init__(f"milkie agent run failed: {message}")
+        detail = envelope or {}
+        self.code = detail.get("code")
+        self.retryable = detail.get("retryable")
+        self.phase = detail.get("phase")
+        self.provider = detail.get("provider")
+        self.model = detail.get("model")
+        self.status = detail.get("status")
+        self.run_id = run_id
+        self.envelope = dict(detail)
+
+
 class MilkieProvider:
     def __init__(
         self,
@@ -415,6 +437,7 @@ class MilkieProvider:
         parser = SSEParser()
         text = message if isinstance(message, str) else str(message)
         payload = {"contextId": handle.context_id, "input": text, "goal": text}
+        pending_error: Optional[dict[str, Any]] = None
         try:
             # lease 与流同生命周期(#43):turn 在飞期间该 agent 的 sidecar 重生被推迟。
             async with self._lease_base_url(handle) as base_url, client.stream(
@@ -442,9 +465,8 @@ class MilkieProvider:
                         # so the orchestrator retries transient failures, and genuine
                         # errors propagate their real cause instead of an empty string.
                         if event == "error":
-                            raise RuntimeError(
-                                f"milkie agent error: {data.get('message') or data}"
-                            )
+                            pending_error = data
+                            continue
                         if event == "agent.run.completed":
                             # #47: 捕获本轮 runId(milkie#140)到 handle —— 必须在
                             # 下面 error 抛出之前,失败 run 才同样可被留证。runId 是
@@ -453,16 +475,28 @@ class MilkieProvider:
                             if run_id:
                                 handle.last_run_id = run_id
                             if data.get("status") == "error":
+                                detail = data.get("error")
+                                if not isinstance(detail, dict) and pending_error:
+                                    candidate = pending_error.get("error")
+                                    detail = candidate if isinstance(candidate, dict) else None
                                 msg = (
-                                    data.get("error")
+                                    (detail or {}).get("message")
+                                    or data.get("message")
                                     or data.get("output")
                                     or data.get("lastTextOutput")
+                                    or (pending_error or {}).get("message")
+                                    or (data.get("error") if isinstance(data.get("error"), str) else None)
                                     or "unknown error"
                                 )
-                                raise RuntimeError(f"milkie agent run failed: {msg}")
+                                raise MilkieAgentError(msg, envelope=detail, run_id=run_id)
                         item = milkie_event_to_progress(event, data)
                         if item is not None:
                             yield {"_progress": [item]}
+                if pending_error is not None:
+                    detail = pending_error.get("error")
+                    detail = detail if isinstance(detail, dict) else None
+                    msg = (detail or {}).get("message") or pending_error.get("message") or "unknown error"
+                    raise MilkieAgentError(msg, envelope=detail)
         finally:
             if owns_client:
                 await client.aclose()

--- a/src/everbot/core/runtime/cron.py
+++ b/src/everbot/core/runtime/cron.py
@@ -21,7 +21,15 @@ from typing import Any, Callable, List, Optional
 
 from ..jobs.llm_errors import LLMConfigError, LLMTransientError
 from ..tasks.execution_gate import GateVerdict, TaskExecutionGate
-from ..tasks.task_manager import Task, TaskList, TaskState, get_due_tasks
+from ..tasks.task_manager import (
+    RetryDecision,
+    Task,
+    TaskList,
+    TaskState,
+    build_retry_decision,
+    format_retry_hint,
+    get_due_tasks,
+)
 from .cron_delivery import CronDelivery
 from .heartbeat_utils import (
     build_isolated_task_prompt,
@@ -71,6 +79,34 @@ def _is_permanent_error(exc: BaseException) -> bool:
         return True
     text = str(exc).lower()
     return any(marker in text for marker in _PERMANENT_ERROR_MARKERS)
+
+
+def _is_retryable_error(exc: BaseException) -> bool:
+    structured = getattr(exc, "retryable", None)
+    if isinstance(structured, bool):
+        return structured
+    if isinstance(exc, asyncio.TimeoutError):
+        return True
+    if _is_permanent_error(exc):
+        return False
+    from .heartbeat import _is_transient_llm_error
+    if _is_transient_llm_error(exc):
+        return True
+    return True
+
+
+def _decision_for_failure(task: Task, exc: BaseException) -> RetryDecision:
+    existing = getattr(exc, "_routine_retry_decision", None)
+    if isinstance(existing, RetryDecision):
+        return existing
+    return build_retry_decision(task, retryable=_is_retryable_error(exc))
+
+
+def _attach_retry_decision(exc: BaseException, decision: RetryDecision) -> None:
+    try:
+        setattr(exc, "_routine_retry_decision", decision)
+    except Exception:
+        pass
 
 
 
@@ -437,14 +473,35 @@ class CronExecutor:
             )
 
         except asyncio.TimeoutError:
-            self.routine_manager.update_task_state(task, TaskState.FAILED, error_message="timeout")
-            self._write_event("task_failed", task_id=task.id, title=task.title, error="timeout")
+            decision = build_retry_decision(task, retryable=True)
+            self.routine_manager.update_task_state(
+                task, TaskState.FAILED, error_message="timeout",
+                retryable=True, error_code="TIMEOUT", retry_decision=decision,
+            )
+            self._write_event(
+                "task_failed", task_id=task.id, title=task.title, error="timeout",
+                retryable=True, retry_number=decision.retry_number,
+                max_retry=decision.max_retry, next_run_at=decision.next_run_at,
+            )
             self.routine_manager.flush(task_list)
             return TaskResult(task_id=task.id, status="timeout", error="timeout")
 
         except Exception as exc:
-            self.routine_manager.update_task_state(task, TaskState.FAILED, error_message=str(exc))
-            self._write_event("task_failed", task_id=task.id, title=task.title, error=str(exc)[:200])
+            decision = _decision_for_failure(task, exc)
+            self.routine_manager.update_task_state(
+                task, TaskState.FAILED, error_message=str(exc),
+                retryable=_is_retryable_error(exc),
+                error_code=getattr(exc, "code", None),
+                retry_decision=decision,
+            )
+            self._write_event(
+                "task_failed", task_id=task.id, title=task.title, error=str(exc)[:200],
+                error_code=getattr(exc, "code", None),
+                retryable=_is_retryable_error(exc),
+                retry_number=decision.retry_number,
+                max_retry=decision.max_retry,
+                next_run_at=decision.next_run_at,
+            )
             self.routine_manager.flush(task_list)
             return TaskResult(task_id=task.id, status="failed", error=str(exc))
 
@@ -540,14 +597,35 @@ class CronExecutor:
                 task_id=task.id, status="done",
                 output=f"ISOLATED_DONE:{task.id}", execution_path=exec_path,
             )
-        except asyncio.TimeoutError:
-            self.routine_manager.update_task_state(task, TaskState.FAILED, error_message="timeout")
-            self._write_event("task_failed", task_id=task.id, title=task.title, error="timeout")
+        except asyncio.TimeoutError as exc:
+            decision = _decision_for_failure(task, exc)
+            self.routine_manager.update_task_state(
+                task, TaskState.FAILED, error_message="timeout",
+                retryable=True, error_code="TIMEOUT", retry_decision=decision,
+            )
+            self._write_event(
+                "task_failed", task_id=task.id, title=task.title, error="timeout",
+                error_code="TIMEOUT", retryable=True,
+                retry_number=decision.retry_number, max_retry=decision.max_retry,
+                next_run_at=decision.next_run_at,
+            )
             self.routine_manager.flush(task_list)
             return TaskResult(task_id=task.id, status="timeout", error="timeout", execution_path=exec_path)
         except Exception as exc:
-            self.routine_manager.update_task_state(task, TaskState.FAILED, error_message=str(exc))
-            self._write_event("task_failed", task_id=task.id, title=task.title, error=str(exc)[:200])
+            decision = _decision_for_failure(task, exc)
+            retryable = _is_retryable_error(exc)
+            self.routine_manager.update_task_state(
+                task, TaskState.FAILED, error_message=str(exc),
+                retryable=retryable,
+                error_code=getattr(exc, "code", None),
+                retry_decision=decision,
+            )
+            self._write_event(
+                "task_failed", task_id=task.id, title=task.title, error=str(exc)[:200],
+                error_code=getattr(exc, "code", None), retryable=retryable,
+                retry_number=decision.retry_number, max_retry=decision.max_retry,
+                next_run_at=decision.next_run_at,
+            )
             self.routine_manager.flush(task_list)
             return TaskResult(task_id=task.id, status="failed", error=str(exc), execution_path=exec_path)
 
@@ -609,8 +687,9 @@ class CronExecutor:
                 detail=str(exc),
                 run_id=run_id,
             )
-            from ..tasks.task_manager import format_retry_hint
-            retry_hint = format_retry_hint(task)
+            decision = build_retry_decision(task, retryable=_is_retryable_error(exc))
+            _attach_retry_decision(exc, decision)
+            retry_hint = format_retry_hint(task, decision)
             fail_msg = f"Task failed: {task_title or task.id}\n{exc}"
             if retry_hint:
                 fail_msg += f"\n\n{retry_hint}"
@@ -626,27 +705,10 @@ class CronExecutor:
         agent = await self._create_job_agent(job_session_id)
         job_system_prompt = self._build_job_system_prompt(agent, task)
         try:
-            max_attempts = 2
-            result = ""
-            for attempt in range(1, max_attempts + 1):
-                try:
-                    result = await asyncio.wait_for(
-                        run_agent(agent, prompt, system_prompt_override=job_system_prompt),
-                        timeout=task.timeout_seconds,
-                    )
-                    break
-                except Exception as exc:
-                    from .heartbeat import _is_transient_llm_error
-                    if attempt >= max_attempts or not _is_transient_llm_error(exc):
-                        raise
-                    logger.warning(
-                        "Transient isolated-agent LLM failure for %s (attempt %d/%d): %s",
-                        task.id,
-                        attempt,
-                        max_attempts,
-                        exc,
-                    )
-                    await asyncio.sleep(min(3, attempt))
+            result = await asyncio.wait_for(
+                run_agent(agent, prompt, system_prompt_override=job_system_prompt),
+                timeout=task.timeout_seconds,
+            )
             await self.session_manager.save_session(job_session_id, agent)
             await self.session_manager.mark_session_archived(job_session_id)
 
@@ -697,8 +759,9 @@ class CronExecutor:
                 detail=str(exc),
                 run_id=run_id,
             )
-            from ..tasks.task_manager import format_retry_hint
-            retry_hint = format_retry_hint(task)
+            decision = build_retry_decision(task, retryable=_is_retryable_error(exc))
+            _attach_retry_decision(exc, decision)
+            retry_hint = format_retry_hint(task, decision)
             fail_msg = f"Task failed: {task_title or task.id}\n{exc}"
             if retry_hint:
                 fail_msg += f"\n\n{retry_hint}"

--- a/src/everbot/core/runtime/heartbeat_utils.py
+++ b/src/everbot/core/runtime/heartbeat_utils.py
@@ -46,6 +46,8 @@ def task_snapshot(task: Any) -> dict[str, Any]:
         "min_execution_interval": getattr(task, "min_execution_interval", None),
         "retry": int(getattr(task, "retry", 0) or 0),
         "max_retry": int(getattr(task, "max_retry", 3) or 3),
+        "last_error_code": getattr(task, "last_error_code", None),
+        "last_error_retryable": getattr(task, "last_error_retryable", None),
         "last_run_at": getattr(task, "last_run_at", None),
     }
 

--- a/src/everbot/core/tasks/routine_manager.py
+++ b/src/everbot/core/tasks/routine_manager.py
@@ -17,6 +17,7 @@ from .task_manager import (
     Task,
     TaskList,
     TaskState,
+    RetryDecision,
     ParseStatus,
     parse_heartbeat_md,
     write_task_block,
@@ -406,9 +407,20 @@ class RoutineManager:
         *,
         error_message: Optional[str] = None,
         now: Optional[datetime] = None,
+        retryable: bool = True,
+        error_code: Optional[str] = None,
+        retry_decision: Optional[RetryDecision] = None,
     ) -> None:
         """Transition a task to a new state."""
-        update_task_state(task, new_state, error_message=error_message, now=now)
+        update_task_state(
+            task,
+            new_state,
+            error_message=error_message,
+            now=now,
+            retryable=retryable,
+            error_code=error_code,
+            retry_decision=retry_decision,
+        )
 
     def flush(self, task_list: TaskList) -> None:
         """Persist task_list state to HEARTBEAT.md atomically.

--- a/src/everbot/core/tasks/task_manager.py
+++ b/src/everbot/core/tasks/task_manager.py
@@ -46,6 +46,8 @@ class Task:
     retry: int = 0
     max_retry: int = 3
     error_message: Optional[str] = None
+    last_error_code: Optional[str] = None
+    last_error_retryable: Optional[bool] = None
     created_at: Optional[str] = None
     # Job fields (internal cron job modules, e.g. memory_review, health_check)
     job: Optional[str] = None  # Job name (e.g., "memory-review")
@@ -294,23 +296,78 @@ def claim_task(task: Task, now: Optional[datetime] = None) -> bool:
 
 
 _RETRY_BACKOFF = [300, 900]  # 5 min, 15 min
+_MAX_RETRY_BACKOFF = 21600  # 6 hours
 
 
-def format_retry_hint(task: Task) -> Optional[str]:
+@dataclass(frozen=True)
+class RetryDecision:
+    """One authoritative scheduling decision for a failed task attempt."""
+
+    should_retry: bool
+    retry_number: int
+    max_retry: int
+    delay_seconds: Optional[int]
+    next_run_at: Optional[str]
+    reason: str
+
+
+def _retry_backoff_seconds(retry_number: int) -> int:
+    if retry_number <= len(_RETRY_BACKOFF):
+        return _RETRY_BACKOFF[max(0, retry_number - 1)]
+    return min(
+        _RETRY_BACKOFF[-1] * (2 ** (retry_number - len(_RETRY_BACKOFF))),
+        _MAX_RETRY_BACKOFF,
+    )
+
+
+def build_retry_decision(
+    task: Task,
+    *,
+    retryable: bool,
+    now: Optional[datetime] = None,
+    jitter_ratio: float = 0.0,
+    random_value: float = 0.5,
+) -> RetryDecision:
+    """Build the retry decision used by persistence, hints, and scheduling."""
+    if now is None:
+        now = datetime.now(timezone.utc)
+    elif now.tzinfo is None:
+        now = now.replace(tzinfo=timezone.utc)
+
+    max_retry = max(0, int(getattr(task, "max_retry", 3)))
+    retry_number = max(0, int(getattr(task, "retry", 0))) + 1
+    if not retryable:
+        return RetryDecision(False, retry_number, max_retry, None, None, "non_retryable")
+    if retry_number > max_retry:
+        return RetryDecision(False, retry_number, max_retry, None, None, "exhausted")
+
+    ratio = min(1.0, max(0.0, float(jitter_ratio)))
+    sample = min(1.0, max(0.0, float(random_value)))
+    base_delay = _retry_backoff_seconds(retry_number)
+    delay = max(1, round(base_delay * (1 + ratio * ((2 * sample) - 1))))
+    next_run_at = (now + timedelta(seconds=delay)).isoformat()
+    return RetryDecision(True, retry_number, max_retry, delay, next_run_at, "retryable")
+
+
+def format_retry_hint(
+    task: Task,
+    decision: Optional[RetryDecision] = None,
+    *,
+    retryable: bool = True,
+) -> Optional[str]:
     """Return a human-readable retry hint based on current task state.
 
     Called *before* update_task_state, so uses task.retry (pre-increment)
     to predict the next backoff.
     """
-    next_retry = task.retry + 1
-    if next_retry - 1 < len(_RETRY_BACKOFF):
-        backoff = _RETRY_BACKOFF[next_retry - 1]
-        if backoff >= 60:
-            label = f"{backoff // 60}分钟"
-        else:
-            label = f"{backoff}秒"
-        return f"将在{label}后重试 ({next_retry}/{len(_RETRY_BACKOFF)})"
-    return None
+    decision = decision or build_retry_decision(task, retryable=retryable)
+    if not decision.should_retry or decision.delay_seconds is None:
+        return None
+    if decision.delay_seconds >= 60:
+        label = f"{decision.delay_seconds // 60}分钟"
+    else:
+        label = f"{decision.delay_seconds}秒"
+    return f"将在{label}后重试 ({decision.retry_number}/{decision.max_retry})"
 
 
 def update_task_state(
@@ -319,6 +376,9 @@ def update_task_state(
     *,
     error_message: Optional[str] = None,
     now: Optional[datetime] = None,
+    retryable: bool = True,
+    error_code: Optional[str] = None,
+    retry_decision: Optional[RetryDecision] = None,
 ) -> None:
     """Transition a task to a new state, updating metadata fields."""
     if now is None:
@@ -334,6 +394,8 @@ def update_task_state(
         task.last_run_at = now.isoformat()
         task.retry = 0
         task.error_message = None
+        task.last_error_code = None
+        task.last_error_retryable = None
         if task.schedule:
             task.state = TaskState.PENDING.value
             task.next_run_at = _compute_next_run(task.schedule, now, task.timezone)
@@ -342,14 +404,17 @@ def update_task_state(
             task.state = TaskState.PENDING.value
     elif new_state == TaskState.FAILED:
         task.error_message = error_message
-        task.retry += 1
-        if task.retry - 1 < len(_RETRY_BACKOFF):
-            # Re-arm as pending for retry with fixed backoff table
-            backoff_seconds = _RETRY_BACKOFF[task.retry - 1]
+        task.last_error_code = error_code
+        task.last_error_retryable = retryable
+        decision = retry_decision or build_retry_decision(
+            task, retryable=retryable, now=now,
+        )
+        if decision.should_retry:
+            task.retry = decision.retry_number
             task.state = TaskState.PENDING.value
-            task.next_run_at = (now + timedelta(seconds=backoff_seconds)).isoformat()
+            task.next_run_at = decision.next_run_at
         elif task.schedule:
-            # Scheduled task: reset retry counter and re-arm for next cycle
+            # A scheduled task remains schedulable in its next normal cycle.
             task.retry = 0
             task.state = TaskState.PENDING.value
             task.next_run_at = _compute_next_run(task.schedule, now, task.timezone)

--- a/tests/e2e/test_routine_retry_e2e.py
+++ b/tests/e2e/test_routine_retry_e2e.py
@@ -1,0 +1,189 @@
+"""Cross-repository E2E for Alfred-owned retries over a real Milkie sidecar."""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+from datetime import datetime, timedelta, timezone
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.everbot.core.agent.provider.milkie.provider import MilkieAgentHandle, MilkieProvider
+from src.everbot.core.agent.provider.milkie.sidecar import MilkieSidecar
+from src.everbot.core.runtime.cron import CronExecutor
+from src.everbot.core.runtime.cron_delivery import CronDelivery
+from src.everbot.core.tasks.routine_manager import RoutineManager
+
+
+def _milkie_cli() -> Path:
+    configured = os.environ.get("MILKIE_CLI")
+    if configured:
+        return Path(configured).expanduser().resolve()
+    return Path(__file__).resolve().parents[2].parent / "milkie" / "dist" / "cli" / "index.js"
+
+
+class _TransientThenSuccessHandler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+    requests_seen = 0
+
+    def do_POST(self):  # noqa: N802
+        type(self).requests_seen += 1
+        length = int(self.headers.get("content-length", 0))
+        request = json.loads(self.rfile.read(length) or "{}")
+        if type(self).requests_seen <= 3:
+            body = json.dumps({
+                "error": {
+                    "message": "temporary provider failure",
+                    "type": "server_error",
+                    "code": "server_error",
+                }
+            }).encode()
+            self.send_response(503)
+            self.send_header("content-type", "application/json")
+            self.send_header("content-length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            return
+
+        model = request.get("model", "fake")
+        frames = [
+            "data: " + json.dumps({
+                "id": "c", "object": "chat.completion.chunk", "created": 0,
+                "model": model,
+                "choices": [{
+                    "index": 0, "delta": {"content": "final report"},
+                    "finish_reason": None,
+                }],
+            }),
+            "data: " + json.dumps({
+                "id": "c", "object": "chat.completion.chunk", "created": 0,
+                "model": model,
+                "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+            }),
+            "data: [DONE]",
+        ]
+        body = ("\n\n".join(frames) + "\n\n").encode()
+        self.send_response(200)
+        self.send_header("content-type", "text/event-stream")
+        self.send_header("content-length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *args):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_transient_model_failure_retries_once_and_delivers_once(tmp_path):
+    cli = _milkie_cli()
+    if not cli.exists():
+        pytest.skip(f"milkie dist not built: {cli}")
+
+    _TransientThenSuccessHandler.requests_seen = 0
+    server = HTTPServer(("127.0.0.1", 0), _TransientThenSuccessHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    data_dir = tmp_path / "milkie"
+    data_dir.mkdir()
+    agent_file = data_dir / "agent.md"
+    agent_file.write_text(
+        "---\n"
+        "agentId: retry-agent\n"
+        "version: 1.0.0\n"
+        "fsm:\n  states:\n    - name: react\n      type: llm\n"
+        "model:\n  provider: local-stub\n  model: retry-model\n"
+        "  adapter: openai-compatible\n"
+        f"  baseUrl: http://127.0.0.1:{server.server_address[1]}/v1\n"
+        "---\nRespond with the report.\n",
+        encoding="utf-8",
+    )
+    sidecar = MilkieSidecar(
+        [
+            "node", str(cli), "serve", "--agent", str(agent_file), "--port", "0",
+            "--state-store", "sqlite", "--data-dir", str(data_dir),
+        ],
+        env={**os.environ, "OPENAI_API_KEY": "test-key"},
+        ready_timeout=20,
+    )
+    await sidecar.start()
+
+    try:
+        provider = MilkieProvider(sidecar.base_url)
+        handles = [
+            MilkieAgentHandle(sidecar.base_url, "retry-attempt-1", name="retry-agent"),
+            MilkieAgentHandle(sidecar.base_url, "retry-attempt-2", name="retry-agent"),
+        ]
+
+        session_manager = AsyncMock()
+        session_manager.get_primary_session_id.return_value = "primary"
+        session_manager.get_heartbeat_session_id.return_value = "heartbeat"
+        delivery = CronDelivery(
+            session_manager=session_manager,
+            primary_session_id="primary",
+            heartbeat_session_id="heartbeat",
+            agent_name="retry-agent",
+            realtime_push=False,
+        )
+        delivery.deposit_job_event = AsyncMock()
+        delivery.inject_to_history = AsyncMock()
+        delivery._emit_realtime = AsyncMock()
+
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        manager = RoutineManager(workspace)
+        manager.add_routine(
+            title="Retry E2E", schedule="1h", execution_mode="isolated",
+            next_run_at=(datetime.now(timezone.utc) - timedelta(seconds=1)).isoformat(),
+        )
+        task_list = manager.load_task_list()
+        task = task_list.tasks[0]
+        task.max_retry = 1
+        manager.flush(task_list)
+
+        executor = CronExecutor(
+            agent_name="retry-agent", workspace_path=workspace,
+            session_manager=session_manager, agent_factory=AsyncMock(),
+            routine_manager=manager, delivery=delivery,
+        )
+        executor._create_job_agent = AsyncMock(side_effect=handles)
+        executor._build_job_system_prompt = MagicMock(return_value="system")
+        executor._record_skill_log = MagicMock()
+
+        async def run_agent(handle, prompt, **kwargs):
+            chunks = []
+            async for event in provider.run_turn(handle, prompt):
+                chunks.extend(
+                    item["delta"] for item in event.get("_progress", [])
+                    if item.get("stage") == "llm" and item.get("delta")
+                )
+            return "".join(chunks)
+
+        first = await executor.tick(
+            task_list, run_agent=run_agent, inject_context=AsyncMock(), run_id="cron-1",
+        )
+        assert first.failed == 1
+        assert task.state == "pending"
+        assert task.retry == 1
+        assert task.last_error_code == "MODEL_BAD_RESPONSE", task.error_message
+        assert task.last_error_retryable is True
+
+        task.next_run_at = (datetime.now(timezone.utc) - timedelta(seconds=1)).isoformat()
+        second = await executor.tick(
+            task_list, run_agent=run_agent, inject_context=AsyncMock(), run_id="cron-2",
+        )
+        assert second.executed == 1
+        assert executor._create_job_agent.await_count == 2
+        successful_pushes = [
+            call for call in delivery._emit_realtime.await_args_list
+            if call.kwargs.get("transcript_worthy") is True
+        ]
+        assert len(successful_pushes) == 1
+        assert successful_pushes[0].args[0] == "final report"
+    finally:
+        await sidecar.close()
+        server.shutdown()

--- a/tests/unit/test_cron_executor.py
+++ b/tests/unit/test_cron_executor.py
@@ -14,6 +14,7 @@ from src.everbot.core.tasks.execution_gate import GateVerdict
 from src.everbot.core.tasks.routine_manager import RoutineManager
 from src.everbot.core.tasks.task_manager import TaskState
 from src.everbot.core.jobs.llm_errors import LLMTransientError, LLMConfigError
+from src.everbot.core.agent.provider.milkie.provider import MilkieAgentError
 
 
 def _make_executor(tmp_path: Path, **overrides) -> CronExecutor:
@@ -679,7 +680,7 @@ class TestInvokeJobLLMErrorHandling:
 
 class TestIsolatedAgentRetries:
     @pytest.mark.asyncio
-    async def test_transient_remote_disconnect_retries_once(self, tmp_path):
+    async def test_transient_remote_disconnect_is_not_retried_inside_agent_runner(self, tmp_path):
         mgr = _seed_task(tmp_path, title="Transient task", execution_mode="isolated")
         executor = _make_executor(tmp_path, routine_manager=mgr)
         task = mgr.load_task_list().tasks[0]
@@ -687,18 +688,69 @@ class TestIsolatedAgentRetries:
         agent = MagicMock()
         agent.executor.context = MagicMock()
         executor._create_job_agent = AsyncMock(return_value=agent)
-        run_agent = AsyncMock(side_effect=[
-            ConnectionError("peer closed connection without sending complete message body"),
-            "final result",
-        ])
+        run_agent = AsyncMock(
+            side_effect=ConnectionError("peer closed connection without sending complete message body")
+        )
 
         with patch.object(executor, "_build_job_system_prompt", return_value="system"):
-            result = await executor._run_isolated_agent(task, "run_123", run_agent=run_agent)
+            with pytest.raises(ConnectionError):
+                await executor._run_isolated_agent(task, "run_123", run_agent=run_agent)
 
-        assert result == "final result"
-        assert run_agent.await_count == 2
+        assert run_agent.await_count == 1
         executor.session_manager.save_session.assert_awaited()
         executor.session_manager.mark_session_archived.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_scheduler_owns_retry_then_delivers_success_once(self, tmp_path):
+        mgr = _seed_task(
+            tmp_path, title="Transient task", execution_mode="isolated",
+        )
+        task_list = mgr.load_task_list()
+        task = task_list.tasks[0]
+        task.max_retry = 1
+        mgr.flush(task_list)
+
+        executor = _make_executor(tmp_path, routine_manager=mgr)
+        agent = SimpleNamespace(last_run_id="milkie-run")
+        executor._create_job_agent = AsyncMock(return_value=agent)
+        executor._build_job_system_prompt = MagicMock(return_value="system")
+        executor._record_skill_log = MagicMock()
+        executor.delivery.deposit_job_event = AsyncMock()
+        executor.delivery.inject_to_history = AsyncMock()
+        executor.delivery._emit_realtime = AsyncMock()
+
+        error = MilkieAgentError(
+            "Model provider connection failed.",
+            envelope={
+                "code": "MODEL_CONNECTION_ERROR", "retryable": True,
+                "phase": "stream_open", "provider": "volcengine", "model": "glm-5.2",
+            },
+            run_id="failed-run",
+        )
+        run_agent = AsyncMock(side_effect=[error, "final report"])
+
+        first = await executor.tick(
+            task_list, run_agent=run_agent, inject_context=AsyncMock(), run_id="cron-1",
+        )
+        assert first.failed == 1
+        assert run_agent.await_count == 1
+        assert task.state == "pending"
+        assert task.retry == 1
+        assert task.last_error_code == "MODEL_CONNECTION_ERROR"
+        assert task.last_error_retryable is True
+
+        task.next_run_at = (datetime.now(timezone.utc) - timedelta(seconds=1)).isoformat()
+        second = await executor.tick(
+            task_list, run_agent=run_agent, inject_context=AsyncMock(), run_id="cron-2",
+        )
+        assert second.executed == 1
+        assert run_agent.await_count == 2
+        successful_pushes = [
+            call for call in executor.delivery._emit_realtime.await_args_list
+            if call.kwargs.get("transcript_worthy") is True
+        ]
+        assert len(successful_pushes) == 1
+        assert successful_pushes[0].args[0] == "final report"
 
 
 class TestSkillLogRecording:

--- a/tests/unit/test_heartbeat_runner_core.py
+++ b/tests/unit/test_heartbeat_runner_core.py
@@ -639,9 +639,16 @@ class TestExecuteStructuredTasksErrors:
         task = runner._task_list.tasks[0]
         assert task.error_message == "timeout"
         # The cron executor should have recorded the failure event
-        runner._cron._write_event.assert_any_call(
-            "task_failed", task_id="timeout_task", title="Due Task", error="timeout"
+        failure = next(
+            call for call in runner._cron._write_event.call_args_list
+            if call.args == ("task_failed",)
         )
+        assert failure.kwargs["task_id"] == "timeout_task"
+        assert failure.kwargs["error"] == "timeout"
+        assert failure.kwargs["retryable"] is True
+        assert failure.kwargs["retry_number"] == 1
+        assert failure.kwargs["max_retry"] == 3
+        assert failure.kwargs["next_run_at"] is not None
 
     @pytest.mark.asyncio
     async def test_inline_task_exception(self, tmp_path: Path, monkeypatch):
@@ -676,9 +683,16 @@ class TestExecuteStructuredTasksErrors:
         # Verify error was recorded on the task (re-armed as pending due to retries/schedule)
         task = runner._task_list.tasks[0]
         assert task.error_message == "agent crashed"
-        runner._cron._write_event.assert_any_call(
-            "task_failed", task_id="fail_task", title="Due Task", error="agent crashed"
+        failure = next(
+            call for call in runner._cron._write_event.call_args_list
+            if call.args == ("task_failed",)
         )
+        assert failure.kwargs["task_id"] == "fail_task"
+        assert failure.kwargs["error"] == "agent crashed"
+        assert failure.kwargs["retryable"] is True
+        assert failure.kwargs["retry_number"] == 1
+        assert failure.kwargs["max_retry"] == 3
+        assert failure.kwargs["next_run_at"] is not None
 
 
 # ============================================================

--- a/tests/unit/test_milkie_provider.py
+++ b/tests/unit/test_milkie_provider.py
@@ -10,7 +10,11 @@ import httpx
 import pytest
 
 from src.everbot.core.agent.provider.milkie import provider as provider_mod
-from src.everbot.core.agent.provider.milkie.provider import MilkieAgentHandle, MilkieProvider
+from src.everbot.core.agent.provider.milkie.provider import (
+    MilkieAgentError,
+    MilkieAgentHandle,
+    MilkieProvider,
+)
 
 
 def _sse(*frames: tuple[str, dict]) -> str:
@@ -119,6 +123,39 @@ async def test_run_turn_raises_on_error_frame():
             _ = [e async for e in p.run_turn(MilkieAgentHandle("http://sidecar", "c"), "hi")]
     finally:
         await client.aclose()
+
+
+async def test_run_turn_preserves_structured_error_and_waits_for_terminal_runid():
+    envelope = {
+        "code": "MODEL_CONNECTION_ERROR",
+        "message": "Model provider connection failed.",
+        "phase": "stream_open",
+        "provider": "volcengine",
+        "model": "glm-5.2",
+        "retryable": True,
+    }
+    sse = _sse(
+        ("error", {"message": envelope["message"], "error": envelope}),
+        ("agent.run.completed", {
+            "status": "error", "message": envelope["message"],
+            "error": envelope, "runId": "run-structured",
+        }),
+    )
+    p, client = _provider(sse)
+    handle = MilkieAgentHandle("http://sidecar", "c")
+    try:
+        with pytest.raises(MilkieAgentError) as raised:
+            _ = [e async for e in p.run_turn(handle, "hi")]
+    finally:
+        await client.aclose()
+
+    assert raised.value.code == "MODEL_CONNECTION_ERROR"
+    assert raised.value.retryable is True
+    assert raised.value.phase == "stream_open"
+    assert raised.value.provider == "volcengine"
+    assert raised.value.model == "glm-5.2"
+    assert raised.value.run_id == "run-structured"
+    assert handle.last_run_id == "run-structured"
 
 
 # ── #47: capture milkie's per-run id off the terminal frame (milkie#140) ──

--- a/tests/unit/test_task_manager.py
+++ b/tests/unit/test_task_manager.py
@@ -11,6 +11,7 @@ from src.everbot.core.tasks.task_manager import (
     ParseStatus,
     _RETRY_BACKOFF,
     format_retry_hint,
+    build_retry_decision,
     parse_heartbeat_md,
     get_due_tasks,
     claim_task,
@@ -266,10 +267,10 @@ class TestTaskStateTransitions:
         # Backoff: first retry → 30s delay
         assert task.next_run_at is not None
 
-    def test_failed_at_max_retry_stays_failed(self):
+    def test_last_configured_retry_is_scheduled(self):
         task = _sample_task(retry=2, max_retry=3)
         update_task_state(task, TaskState.FAILED, error_message="timeout")
-        assert task.state == "failed"
+        assert task.state == "pending"
         assert task.retry == 3
 
     def test_timeout_marks_failed(self):
@@ -344,10 +345,30 @@ class TestTaskStateTransitions:
         expected = now + timedelta(seconds=_RETRY_BACKOFF[1])
         assert next_dt == expected, f"Expected {expected}, got {next_dt}"
 
-    def test_failed_beyond_backoff_table_stays_failed(self):
-        """After exhausting backoff table, one-shot task stays failed."""
+    def test_max_retry_is_authoritative_beyond_legacy_backoff_table(self):
         now = datetime(2026, 2, 25, 12, 0, tzinfo=timezone.utc)
-        task = _sample_task(retry=len(_RETRY_BACKOFF), max_retry=20)
+        task = _sample_task(retry=2, max_retry=5)
+        update_task_state(task, TaskState.FAILED, error_message="err", now=now)
+        assert task.state == "pending"
+        assert task.retry == 3
+        assert datetime.fromisoformat(task.next_run_at) == now + timedelta(minutes=30)
+
+    def test_non_retryable_failure_terminates_one_shot_immediately(self):
+        now = datetime(2026, 2, 25, 12, 0, tzinfo=timezone.utc)
+        task = _sample_task(retry=0, max_retry=5)
+        update_task_state(
+            task, TaskState.FAILED, error_message="auth failed", now=now,
+            retryable=False, error_code="MODEL_AUTH_ERROR",
+        )
+        assert task.state == "failed"
+        assert task.retry == 0
+        assert task.last_error_code == "MODEL_AUTH_ERROR"
+        assert task.last_error_retryable is False
+
+    def test_failed_after_max_retry_stays_failed(self):
+        """After exhausting the configured retry budget, one-shot task stays failed."""
+        now = datetime(2026, 2, 25, 12, 0, tzinfo=timezone.utc)
+        task = _sample_task(retry=20, max_retry=20)
         update_task_state(task, TaskState.FAILED, error_message="err", now=now)
         assert task.state == "failed"
 
@@ -366,7 +387,7 @@ class TestTaskStateTransitions:
         state with retry=3/3. The code at task_manager.py:287-293 should handle
         this by resetting retry=0 and re-arming as pending.
         """
-        task = _sample_task(retry=2, max_retry=3, schedule="1d")
+        task = _sample_task(retry=3, max_retry=3, schedule="1d")
         task.timezone = "Asia/Shanghai"
         now = datetime(2026, 2, 25, 12, 0, tzinfo=timezone.utc)
         update_task_state(task, TaskState.FAILED, error_message="Request timed out.", now=now)
@@ -383,7 +404,7 @@ class TestTaskStateTransitions:
     def test_scheduled_task_at_max_retry_clears_error_on_rearm(self):
         """After auto-reset, the error_message should still be set (for diagnostics)
         but the task should be schedulable."""
-        task = _sample_task(retry=2, max_retry=3, schedule="1d")
+        task = _sample_task(retry=3, max_retry=3, schedule="1d")
         now = datetime(2026, 2, 25, 12, 0, tzinfo=timezone.utc)
         update_task_state(task, TaskState.FAILED, error_message="Connection error.", now=now)
         # Task is re-armed; error_message is preserved for diagnostics
@@ -407,8 +428,13 @@ class TestTaskStateTransitions:
         assert task.state == "pending"
         assert task.retry == 2
 
-        # Fail 3: max_retry reached → scheduled task auto-resets for next cycle
+        # Fail 3: the final configured retry is scheduled.
         update_task_state(task, TaskState.FAILED, error_message="err3", now=now)
+        assert task.state == "pending"
+        assert task.retry == 3
+
+        # Fail 4: retry budget exhausted → reset for the next schedule cycle.
+        update_task_state(task, TaskState.FAILED, error_message="err4", now=now)
         assert task.state == "pending", "Scheduled task should reset, not stay failed"
         assert task.retry == 0, "Retry counter should reset after max_retry cycle"
         assert task.next_run_at is not None
@@ -420,17 +446,45 @@ class TestFormatRetryHint:
     def test_first_retry_hint(self):
         task = _sample_task(retry=0)
         hint = format_retry_hint(task)
-        assert hint == "将在5分钟后重试 (1/2)"
+        assert hint == "将在5分钟后重试 (1/3)"
 
     def test_second_retry_hint(self):
         task = _sample_task(retry=1)
         hint = format_retry_hint(task)
-        assert hint == "将在15分钟后重试 (2/2)"
+        assert hint == "将在15分钟后重试 (2/3)"
 
-    def test_no_hint_when_exhausted(self):
+    def test_third_retry_hint_uses_extended_backoff(self):
         task = _sample_task(retry=2)
         hint = format_retry_hint(task)
+        assert hint == "将在30分钟后重试 (3/3)"
+
+    def test_no_hint_when_exhausted(self):
+        task = _sample_task(retry=3)
+        hint = format_retry_hint(task)
         assert hint is None
+
+
+class TestRetryDecision:
+    @pytest.mark.parametrize("max_retry", [0, 1, 3, 5])
+    def test_respects_max_retry(self, max_retry):
+        now = datetime(2026, 2, 25, 12, 0, tzinfo=timezone.utc)
+        task = _sample_task(retry=0, max_retry=max_retry)
+        decision = build_retry_decision(task, retryable=True, now=now)
+        assert decision.should_retry is (max_retry > 0)
+        assert decision.max_retry == max_retry
+
+    def test_non_retryable_is_terminal_even_with_budget(self):
+        task = _sample_task(retry=0, max_retry=5)
+        decision = build_retry_decision(task, retryable=False)
+        assert decision.should_retry is False
+        assert decision.reason == "non_retryable"
+
+    def test_jitter_is_injectable_and_deterministic(self):
+        task = _sample_task(retry=0, max_retry=3)
+        high = build_retry_decision(task, retryable=True, jitter_ratio=0.1, random_value=1.0)
+        low = build_retry_decision(task, retryable=True, jitter_ratio=0.1, random_value=0.0)
+        assert high.delay_seconds == 330
+        assert low.delay_seconds == 270
 
 
 # ── _compute_next_run edge cases ─────────────────────────────────


### PR DESCRIPTION
Closes #142

## Summary
- preserve Milkie structured model errors across the SSE provider boundary
- make the scheduler the single retry owner and treat `max_retry` as retries after the initial attempt
- use one retry decision for state transitions, events, and user-facing notifications
- add deterministic backoff and cross-repo process E2E coverage

Depends on xforce-io/milkie#203 for the structured error envelope.

## Test evidence
- `312 passed, 1 skipped` across touched Alfred unit suites (the skip is the env-gated cross-repo E2E)
- cross-repo E2E with real Milkie sidecar: `1 passed`
- full `pytest -q` collection remains blocked by four existing `tests/e2e/web` package import errors (`tests.e2e.web.conftest`)
- Ruff is not installed in the repository virtualenv