### PR TITLE
feat: add routine checkpoints and delivery dedupe

### DIFF
--- a/docs/design/143-routine-checkpoints.md
+++ b/docs/design/143-routine-checkpoints.md
@@ -1,0 +1,42 @@
+# Isolated Routine 检查点与投递幂等（#143）
+
+> 最后更新：2026-07-10  
+> Issue: https://github.com/xforce-io/alfred/issues/143  
+> 分支：`feat/143-routine-checkpoints`
+
+## 目标
+
+在不引入通用 DAG/workflow engine 的前提下，为 isolated routine 提供可选的
+`fetch -> analyze -> deliver` 阶段检查点，并保证含糊投递失败后的重试不会产生重复通知。
+
+## 执行身份与存储
+
+- `execution_id = task_id + scheduled_for`，重试时间不改变身份。
+- 每阶段原子写入 manifest：输入 hash、输出 artifact 引用/hash、完成时间、producing run id。
+- manifest 位于 agent workspace 的 runtime 区，不写入版本化 skill 目录。
+- retry 从第一个未完成或校验失败的阶段继续；输入变化使所有下游阶段失效。
+- manifest 不保存 secret。
+
+## 投递幂等
+
+`delivery_key = execution_id + output_hash + destination`。投递前记录 `pending`，确认后记录
+`delivered`。重试先查询 channel outbox；已投递 key 不再写用户消息、history 或 projection。
+
+## Skill 契约与兼容
+
+routine 可选声明 staged execution descriptor，指向阶段命令与 artifact。未声明的现有
+free-form routine 继续走单 prompt 路径。首个端到端测试使用确定性 fixture；生产 Serenity
+只有在 twitter-watch 已暴露稳定阶段 artifact 后才显式迁移。
+
+## 测试计划
+
+- **单元测试**：execution/delivery key、manifest 校验、原子状态迁移、下游失效和脱敏。
+- **集成测试**：fetch 后崩溃从 analyze 恢复；输入变化触发下游失效；daemon 重启后状态仍在。
+- **功能测试**：含糊 channel failure 重试后只有一条 history、projection 和用户可见消息。
+- **端到端测试**：真 Alfred daemon + 真 Milkie sidecar + staged fixture；fetch 后模型失败，
+  重启服务，再从 analyze 继续且只投递一次，核对 artifact hash 和 run 链接。
+- **配置验证**：旧 routine JSON 不带 staged 字段仍沿用 legacy 路径。
+
+## 非目标
+
+不实现通用 DAG、分布式事务，也不自动迁移所有历史技能。

--- a/src/everbot/core/runtime/cron.py
+++ b/src/everbot/core/runtime/cron.py
@@ -31,6 +31,11 @@ from ..tasks.task_manager import (
     get_due_tasks,
 )
 from .cron_delivery import CronDelivery
+from .routine_checkpoint import (
+    RoutineCheckpointStore,
+    build_delivery_key,
+    content_hash,
+)
 from .heartbeat_utils import (
     build_isolated_task_prompt,
     build_job_session_id,
@@ -704,11 +709,19 @@ class CronExecutor:
 
         agent = await self._create_job_agent(job_session_id)
         job_system_prompt = self._build_job_system_prompt(agent, task)
+        checkpoint_store: Optional[RoutineCheckpointStore] = None
         try:
-            result = await asyncio.wait_for(
-                run_agent(agent, prompt, system_prompt_override=job_system_prompt),
-                timeout=task.timeout_seconds,
-            )
+            staged = getattr(task, "staged", None)
+            if staged:
+                result, checkpoint_store = await self._run_staged_agent(
+                    task, agent, run_id, run_agent=run_agent,
+                    system_prompt=job_system_prompt,
+                )
+            else:
+                result = await asyncio.wait_for(
+                    run_agent(agent, prompt, system_prompt_override=job_system_prompt),
+                    timeout=task.timeout_seconds,
+                )
             await self.session_manager.save_session(job_session_id, agent)
             await self.session_manager.mark_session_archived(job_session_id)
 
@@ -728,18 +741,43 @@ class CronExecutor:
             projection_anchor = getattr(agent, "last_run_id", None) or job_session_id
 
             summary = f"{task_title or task.id} completed"
-            await self.delivery.deposit_job_event(
-                event_type="job_completed",
-                source_session_id=job_session_id,
-                summary=summary,
-                detail=result,
-                run_id=run_id,
-            )
-            await self.delivery.inject_to_history(result, run_id)
-            await self.delivery._emit_realtime(
-                result, run_id, transcript_worthy=True,
-                source_session_id=projection_anchor,  # #130 T2: milkie runId, deref-able
-            )
+            if checkpoint_store is None:
+                await self.delivery.deposit_job_event(
+                    event_type="job_completed",
+                    source_session_id=job_session_id,
+                    summary=summary,
+                    detail=result,
+                    run_id=run_id,
+                )
+                await self.delivery.inject_to_history(result, run_id)
+                await self.delivery._emit_realtime(
+                    result, run_id, transcript_worthy=True,
+                    source_session_id=projection_anchor,  # #130 T2: milkie runId, deref-able
+                )
+            else:
+                destination = str(getattr(task, "staged", {}).get("destination") or "primary")
+                delivery_key = build_delivery_key(task.execution_id, result, destination)
+                await checkpoint_store.run_delivery_step(
+                    "mailbox", delivery_key,
+                    lambda: self.delivery.deposit_job_event(
+                        event_type="job_completed",
+                        source_session_id=job_session_id,
+                        summary=summary,
+                        detail=result,
+                        run_id=run_id,
+                    ),
+                )
+                await checkpoint_store.run_delivery_step(
+                    "history", delivery_key,
+                    lambda: self.delivery.inject_to_history(result, run_id),
+                )
+                await checkpoint_store.run_delivery_step(
+                    "realtime", delivery_key,
+                    lambda: self.delivery._emit_realtime(
+                        result, run_id, transcript_worthy=True,
+                        source_session_id=projection_anchor,
+                    ),
+                )
 
             # SLM: record skill invocations from this isolated agent run.
             # Reads the just-written trajectory to find _load_resource_skill
@@ -767,6 +805,59 @@ class CronExecutor:
                 fail_msg += f"\n\n{retry_hint}"
             await self.delivery._emit_realtime(fail_msg, run_id)
             raise
+
+    async def _run_staged_agent(
+        self,
+        task: Task,
+        agent: Any,
+        run_id: str,
+        *,
+        run_agent: Callable,
+        system_prompt: str,
+    ) -> tuple[str, RoutineCheckpointStore]:
+        """Run the fixed fetch/analyze shape and reuse valid durable artifacts."""
+        staged = getattr(task, "staged", None)
+        if not isinstance(staged, dict):
+            raise ValueError("staged routine descriptor must be an object")
+        execution_id = str(getattr(task, "execution_id", "") or "")
+        if not execution_id:
+            raise ValueError("staged routine requires a claimed execution identity")
+
+        prompts: dict[str, str] = {}
+        for name in ("fetch", "analyze"):
+            stage = staged.get(name)
+            prompt = stage.get("prompt") if isinstance(stage, dict) else None
+            if not isinstance(prompt, str) or not prompt.strip():
+                raise ValueError(f"staged routine requires {name}.prompt")
+            prompts[name] = prompt.strip()
+
+        store = RoutineCheckpointStore(self.workspace_path, execution_id, task.id)
+
+        async def fetch() -> str:
+            return await asyncio.wait_for(
+                run_agent(agent, prompts["fetch"], system_prompt_override=system_prompt),
+                timeout=task.timeout_seconds,
+            )
+
+        fetched = await store.run_stage(
+            "fetch", prompts["fetch"], fetch,
+            run_id=getattr(agent, "last_run_id", None) or run_id,
+        )
+        analyze_prompt = f"{prompts['analyze']}\n\nFetch artifact:\n{fetched}"
+
+        async def analyze() -> str:
+            return await asyncio.wait_for(
+                run_agent(agent, analyze_prompt, system_prompt_override=system_prompt),
+                timeout=task.timeout_seconds,
+            )
+
+        analyzed = await store.run_stage(
+            "analyze",
+            f"{prompts['analyze']}\0{content_hash(fetched)}",
+            analyze,
+            run_id=getattr(agent, "last_run_id", None) or run_id,
+        )
+        return analyzed, store
 
     def _observe_provenance(self, task: Task, agent: Any) -> None:
         """#127 L1 (observe-only): log a backing verdict for this isolated report

--- a/src/everbot/core/runtime/routine_checkpoint.py
+++ b/src/everbot/core/runtime/routine_checkpoint.py
@@ -1,0 +1,128 @@
+"""Durable checkpoints for the fixed fetch/analyze/deliver routine shape."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Awaitable, Callable
+
+from ..session.persistence import SessionPersistence
+
+
+_STAGE_ORDER = ("fetch", "analyze")
+_DELIVERY_STEPS = {"mailbox", "history", "realtime"}
+
+
+def content_hash(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def build_delivery_key(execution_id: str, output: str, destination: str) -> str:
+    material = f"{execution_id}\0{content_hash(output)}\0{destination}"
+    return content_hash(material)
+
+
+class RoutineCheckpointStore:
+    """Persist stage artifacts and delivery state under the workspace runtime area."""
+
+    def __init__(self, workspace_path: Path, execution_id: str, task_id: str):
+        directory_name = content_hash(execution_id)[:24]
+        self.directory = Path(workspace_path) / ".runtime" / "routine-checkpoints" / directory_name
+        self.manifest_path = self.directory / "manifest.json"
+        self.execution_id = execution_id
+        self.task_id = task_id
+
+    def read_manifest(self) -> dict:
+        if not self.manifest_path.exists():
+            return self._new_manifest()
+        try:
+            data = json.loads(self.manifest_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return self._new_manifest()
+        if data.get("execution_id") != self.execution_id or data.get("task_id") != self.task_id:
+            return self._new_manifest()
+        data.setdefault("stages", {})
+        return data
+
+    async def run_stage(
+        self,
+        name: str,
+        input_value: str,
+        producer: Callable[[], Awaitable[str]],
+        *,
+        run_id: str,
+    ) -> str:
+        if name not in _STAGE_ORDER:
+            raise ValueError(f"Unsupported routine stage: {name}")
+        manifest = self.read_manifest()
+        input_digest = content_hash(input_value)
+        stage = manifest["stages"].get(name)
+        if stage and stage.get("input_hash") == input_digest:
+            artifact = self.directory / str(stage.get("artifact", ""))
+            if artifact.is_file():
+                output = artifact.read_text(encoding="utf-8")
+                if content_hash(output) == stage.get("output_hash"):
+                    return output
+
+        self._invalidate_from(manifest, name)
+        output = str(await producer())
+        artifact_name = f"{name}.txt"
+        self.directory.mkdir(parents=True, exist_ok=True)
+        SessionPersistence.atomic_save(
+            self.directory / artifact_name,
+            output.encode("utf-8"),
+        )
+        manifest["stages"][name] = {
+            "input_hash": input_digest,
+            "output_hash": content_hash(output),
+            "artifact": artifact_name,
+            "completed_at": datetime.now(timezone.utc).isoformat(),
+            "producing_run_id": run_id,
+        }
+        self._write_manifest(manifest)
+        return output
+
+    async def run_delivery_step(
+        self,
+        step: str,
+        delivery_key: str,
+        operation: Callable[[], Awaitable[object]],
+    ) -> bool:
+        if step not in _DELIVERY_STEPS:
+            raise ValueError(f"Unsupported delivery step: {step}")
+        manifest = self.read_manifest()
+        delivery = manifest.get("delivery")
+        if not isinstance(delivery, dict) or delivery.get("key") != delivery_key:
+            delivery = {"key": delivery_key, "steps": {}}
+            manifest["delivery"] = delivery
+        steps = delivery.setdefault("steps", {})
+        if steps.get(step) in {"pending", "delivered"}:
+            return False
+
+        steps[step] = "pending"
+        self._write_manifest(manifest)
+        await operation()
+        steps[step] = "delivered"
+        self._write_manifest(manifest)
+        return True
+
+    def _new_manifest(self) -> dict:
+        return {
+            "version": 1,
+            "execution_id": self.execution_id,
+            "task_id": self.task_id,
+            "stages": {},
+        }
+
+    def _invalidate_from(self, manifest: dict, name: str) -> None:
+        index = _STAGE_ORDER.index(name)
+        for stage_name in _STAGE_ORDER[index:]:
+            manifest["stages"].pop(stage_name, None)
+        manifest.pop("delivery", None)
+
+    def _write_manifest(self, manifest: dict) -> None:
+        self.directory.mkdir(parents=True, exist_ok=True)
+        payload = json.dumps(manifest, ensure_ascii=False, indent=2).encode("utf-8")
+        SessionPersistence.atomic_save(self.manifest_path, payload)

--- a/src/everbot/core/tasks/routine_manager.py
+++ b/src/everbot/core/tasks/routine_manager.py
@@ -202,6 +202,7 @@ class RoutineManager:
         job: Optional[str] = None,
         scanner: Optional[str] = None,
         min_execution_interval: Optional[str] = None,
+        staged: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """Add one routine and persist task block."""
         title = str(title or "").strip()
@@ -214,6 +215,8 @@ class RoutineManager:
             description=description,
             timeout_seconds=timeout_seconds,
         )
+        if staged is not None and mode != "isolated":
+            raise ValueError("staged routines require execution_mode='isolated'")
         task_id = str(task_id or f"routine_{uuid.uuid4().hex[:8]}")
         now_dt = now or datetime.now(timezone.utc)
         if now_dt.tzinfo is None:
@@ -290,6 +293,7 @@ class RoutineManager:
             job=job,
             scanner=scanner,
             min_execution_interval=min_execution_interval,
+            staged=staged,
         )
         task_list.tasks.append(task)
         self._save_task_list(content, task_list)

--- a/src/everbot/core/tasks/task_manager.py
+++ b/src/everbot/core/tasks/task_manager.py
@@ -48,7 +48,10 @@ class Task:
     error_message: Optional[str] = None
     last_error_code: Optional[str] = None
     last_error_retryable: Optional[bool] = None
+    active_scheduled_for: Optional[str] = None
+    execution_id: Optional[str] = None
     created_at: Optional[str] = None
+    staged: Optional[Dict[str, Any]] = None
     # Job fields (internal cron job modules, e.g. memory_review, health_check)
     job: Optional[str] = None  # Job name (e.g., "memory-review")
     scanner: Optional[str] = None  # Optional scanner gate type (e.g., "session")
@@ -291,6 +294,9 @@ def claim_task(task: Task, now: Optional[datetime] = None) -> bool:
         if next_run_dt is not None and next_run_dt > now:
             return False
 
+    if not task.execution_id:
+        task.active_scheduled_for = task.next_run_at or now.isoformat()
+        task.execution_id = f"{task.id}:{task.active_scheduled_for}"
     update_task_state(task, TaskState.RUNNING, now=now)
     return True
 
@@ -396,6 +402,8 @@ def update_task_state(
         task.error_message = None
         task.last_error_code = None
         task.last_error_retryable = None
+        task.active_scheduled_for = None
+        task.execution_id = None
         if task.schedule:
             task.state = TaskState.PENDING.value
             task.next_run_at = _compute_next_run(task.schedule, now, task.timezone)
@@ -418,6 +426,8 @@ def update_task_state(
             task.retry = 0
             task.state = TaskState.PENDING.value
             task.next_run_at = _compute_next_run(task.schedule, now, task.timezone)
+            task.active_scheduled_for = None
+            task.execution_id = None
         else:
             task.state = TaskState.FAILED.value
 

--- a/tests/e2e/test_routine_checkpoint_e2e.py
+++ b/tests/e2e/test_routine_checkpoint_e2e.py
@@ -1,0 +1,191 @@
+"""Cross-process E2E for staged routine recovery over a real Milkie sidecar."""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+from datetime import datetime, timedelta, timezone
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.everbot.core.agent.provider.milkie.provider import MilkieAgentHandle, MilkieProvider
+from src.everbot.core.agent.provider.milkie.sidecar import MilkieSidecar
+from src.everbot.core.runtime.cron import CronExecutor
+from src.everbot.core.runtime.cron_delivery import CronDelivery
+from src.everbot.core.tasks.routine_manager import RoutineManager
+
+
+def _milkie_cli() -> Path:
+    configured = os.environ.get("MILKIE_CLI")
+    if configured:
+        return Path(configured).expanduser().resolve()
+    return Path(__file__).resolve().parents[2].parent / "milkie" / "dist" / "cli" / "index.js"
+
+
+class _FetchThenAnalyzeFailureHandler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+    requests_seen = 0
+
+    def do_POST(self):  # noqa: N802
+        type(self).requests_seen += 1
+        length = int(self.headers.get("content-length", 0))
+        request = json.loads(self.rfile.read(length) or "{}")
+        request_number = type(self).requests_seen
+        if 2 <= request_number <= 4:
+            body = json.dumps({"error": {"message": "analyze unavailable", "type": "server_error"}}).encode()
+            self.send_response(503)
+            self.send_header("content-type", "application/json")
+            self.send_header("content-length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            return
+
+        text = "fetched artifact" if request_number == 1 else "final report"
+        model = request.get("model", "fake")
+        frames = [
+            "data: " + json.dumps({
+                "id": "c", "object": "chat.completion.chunk", "created": 0,
+                "model": model,
+                "choices": [{"index": 0, "delta": {"content": text}, "finish_reason": None}],
+            }),
+            "data: " + json.dumps({
+                "id": "c", "object": "chat.completion.chunk", "created": 0,
+                "model": model,
+                "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+            }),
+            "data: [DONE]",
+        ]
+        body = ("\n\n".join(frames) + "\n\n").encode()
+        self.send_response(200)
+        self.send_header("content-type", "text/event-stream")
+        self.send_header("content-length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *args):
+        pass
+
+
+def _sidecar(cli: Path, agent_file: Path, data_dir: Path) -> MilkieSidecar:
+    return MilkieSidecar(
+        [
+            "node", str(cli), "serve", "--agent", str(agent_file), "--port", "0",
+            "--state-store", "sqlite", "--data-dir", str(data_dir),
+        ],
+        env={**os.environ, "OPENAI_API_KEY": "test-key"},
+        ready_timeout=20,
+    )
+
+
+@pytest.mark.asyncio
+async def test_restart_resumes_analyze_and_delivers_once(tmp_path):
+    cli = _milkie_cli()
+    if not cli.exists():
+        pytest.skip(f"milkie dist not built: {cli}")
+
+    _FetchThenAnalyzeFailureHandler.requests_seen = 0
+    server = HTTPServer(("127.0.0.1", 0), _FetchThenAnalyzeFailureHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    data_dir = tmp_path / "milkie"
+    data_dir.mkdir()
+    agent_file = data_dir / "agent.md"
+    agent_file.write_text(
+        "---\nagentId: staged-agent\nversion: 1.0.0\n"
+        "fsm:\n  states:\n    - name: react\n      type: llm\n"
+        "model:\n  provider: local-stub\n  model: staged-model\n"
+        "  adapter: openai-compatible\n"
+        f"  baseUrl: http://127.0.0.1:{server.server_address[1]}/v1\n"
+        "---\nFollow the stage prompt.\n",
+        encoding="utf-8",
+    )
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    manager = RoutineManager(workspace)
+    manager.add_routine(
+        title="Staged E2E", schedule="1h", execution_mode="isolated",
+        next_run_at=(datetime.now(timezone.utc) - timedelta(seconds=1)).isoformat(),
+        staged={
+            "fetch": {"prompt": "fetch fixture"},
+            "analyze": {"prompt": "analyze fixture"},
+            "destination": "primary",
+        },
+    )
+    task_list = manager.load_task_list()
+    task_list.tasks[0].max_retry = 1
+    manager.flush(task_list)
+
+    session_manager = AsyncMock()
+    session_manager.get_primary_session_id.return_value = "primary"
+    session_manager.get_heartbeat_session_id.return_value = "heartbeat"
+    delivery = CronDelivery(
+        session_manager=session_manager, primary_session_id="primary",
+        heartbeat_session_id="heartbeat", agent_name="staged-agent", realtime_push=False,
+    )
+    delivery.deposit_job_event = AsyncMock()
+    delivery.inject_to_history = AsyncMock()
+    delivery._emit_realtime = AsyncMock()
+
+    async def execute(sidecar: MilkieSidecar, run_id: str, tasks):
+        provider = MilkieProvider(sidecar.base_url)
+        handle = MilkieAgentHandle(sidecar.base_url, run_id, name="staged-agent")
+        executor = CronExecutor(
+            agent_name="staged-agent", workspace_path=workspace,
+            session_manager=session_manager, agent_factory=AsyncMock(),
+            routine_manager=RoutineManager(workspace), delivery=delivery,
+        )
+        executor._create_job_agent = AsyncMock(return_value=handle)
+        executor._build_job_system_prompt = MagicMock(return_value="system")
+        executor._record_skill_log = MagicMock()
+
+        async def run_agent(agent, prompt, **kwargs):
+            chunks = []
+            async for event in provider.run_turn(agent, prompt):
+                chunks.extend(
+                    item["delta"] for item in event.get("_progress", [])
+                    if item.get("stage") == "llm" and item.get("delta")
+                )
+            return "".join(chunks)
+
+        return await executor.tick(
+            tasks, run_agent=run_agent, inject_context=AsyncMock(), run_id=run_id,
+        )
+
+    first_sidecar = _sidecar(cli, agent_file, data_dir)
+    await first_sidecar.start()
+    try:
+        first = await execute(first_sidecar, "cron-1", task_list)
+        assert first.failed == 1
+        assert _FetchThenAnalyzeFailureHandler.requests_seen == 4
+    finally:
+        await first_sidecar.close()
+
+    restarted_manager = RoutineManager(workspace)
+    restarted_tasks = restarted_manager.load_task_list()
+    restarted_tasks.tasks[0].next_run_at = (datetime.now(timezone.utc) - timedelta(seconds=1)).isoformat()
+    restarted_manager.flush(restarted_tasks)
+    second_sidecar = _sidecar(cli, agent_file, data_dir)
+    await second_sidecar.start()
+    try:
+        second = await execute(second_sidecar, "cron-2", restarted_tasks)
+        assert second.executed == 1
+        assert _FetchThenAnalyzeFailureHandler.requests_seen == 5
+        successful_pushes = [
+            call for call in delivery._emit_realtime.await_args_list
+            if call.kwargs.get("transcript_worthy") is True
+        ]
+        assert len(successful_pushes) == 1
+        assert successful_pushes[0].args[0] == "final report"
+        manifests = list((workspace / ".runtime" / "routine-checkpoints").glob("*/manifest.json"))
+        assert len(manifests) == 1
+        manifest = json.loads(manifests[0].read_text(encoding="utf-8"))
+        assert set(manifest["stages"]) == {"fetch", "analyze"}
+        assert all(state == "delivered" for state in manifest["delivery"]["steps"].values())
+    finally:
+        await second_sidecar.close()
+        server.shutdown()

--- a/tests/unit/test_cron_executor.py
+++ b/tests/unit/test_cron_executor.py
@@ -752,6 +752,48 @@ class TestIsolatedAgentRetries:
         assert len(successful_pushes) == 1
         assert successful_pushes[0].args[0] == "final report"
 
+    @pytest.mark.asyncio
+    async def test_staged_agent_resumes_from_analyze_after_restart(self, tmp_path):
+        executor = _make_executor(tmp_path)
+        agent = SimpleNamespace(last_run_id="milkie-run")
+        executor._create_job_agent = AsyncMock(return_value=agent)
+        executor._build_job_system_prompt = MagicMock(return_value="system")
+        executor._append_run_provenance = MagicMock(side_effect=lambda result, _agent: result)
+        executor._observe_provenance = MagicMock()
+        executor._record_skill_log = MagicMock()
+        executor.delivery.deposit_job_event = AsyncMock()
+        executor.delivery.inject_to_history = AsyncMock()
+        executor.delivery._emit_realtime = AsyncMock()
+        task = SimpleNamespace(
+            id="staged", title="Staged", description="", timeout_seconds=30,
+            job=None, execution_id="staged:2026-07-10T10:00:00Z",
+            staged={
+                "fetch": {"prompt": "fetch fixture"},
+                "analyze": {"prompt": "analyze fixture"},
+                "destination": "primary",
+            },
+        )
+        run_agent = AsyncMock(side_effect=["fetched artifact", ConnectionError("model down"), "final report"])
+
+        with pytest.raises(ConnectionError):
+            await executor._run_isolated_agent(task, "cron-1", run_agent=run_agent)
+        await executor._run_isolated_agent(task, "cron-2", run_agent=run_agent)
+
+        assert run_agent.await_count == 3
+        assert run_agent.await_args_list[2].args[1].startswith("analyze fixture")
+        assert "fetched artifact" in run_agent.await_args_list[2].args[1]
+        completed_events = [
+            call for call in executor.delivery.deposit_job_event.await_args_list
+            if call.kwargs.get("event_type") == "job_completed"
+        ]
+        assert len(completed_events) == 1
+        executor.delivery.inject_to_history.assert_awaited_once()
+        successful_pushes = [
+            call for call in executor.delivery._emit_realtime.await_args_list
+            if call.kwargs.get("transcript_worthy") is True
+        ]
+        assert len(successful_pushes) == 1
+
 
 class TestSkillLogRecording:
     """Lock in: isolated-agent runs MUST record skill invocations to skill_logs.

--- a/tests/unit/test_routine_checkpoint.py
+++ b/tests/unit/test_routine_checkpoint.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from src.everbot.core.runtime.routine_checkpoint import RoutineCheckpointStore
+
+
+@pytest.mark.asyncio
+async def test_completed_stage_is_reused_after_store_restart(tmp_path: Path):
+    calls = 0
+
+    async def produce() -> str:
+        nonlocal calls
+        calls += 1
+        return "fetched data"
+
+    first = RoutineCheckpointStore(tmp_path, "task-1:2026-07-10T10:00:00Z", "task-1")
+    assert await first.run_stage("fetch", "source=v1", produce, run_id="run-1") == "fetched data"
+
+    restarted = RoutineCheckpointStore(tmp_path, "task-1:2026-07-10T10:00:00Z", "task-1")
+    assert await restarted.run_stage("fetch", "source=v1", produce, run_id="run-2") == "fetched data"
+    assert calls == 1
+
+
+@pytest.mark.asyncio
+async def test_changed_fetch_input_invalidates_analyze(tmp_path: Path):
+    store = RoutineCheckpointStore(tmp_path, "execution", "task-1")
+    await store.run_stage("fetch", "source=v1", lambda: _value("data-v1"), run_id="run-1")
+    await store.run_stage("analyze", "analysis:v1:data-v1", lambda: _value("report-v1"), run_id="run-1")
+
+    await store.run_stage("fetch", "source=v2", lambda: _value("data-v2"), run_id="run-2")
+    manifest = store.read_manifest()
+    assert "analyze" not in manifest["stages"]
+    assert manifest.get("delivery") is None
+
+
+@pytest.mark.asyncio
+async def test_pending_delivery_step_is_not_repeated_after_ambiguous_failure(tmp_path: Path):
+    store = RoutineCheckpointStore(tmp_path, "execution", "task-1")
+    visible: list[str] = []
+
+    async def ambiguous() -> None:
+        visible.append("sent")
+        raise ConnectionError("confirmation lost")
+
+    with pytest.raises(ConnectionError):
+        await store.run_delivery_step("realtime", "delivery-key", ambiguous)
+
+    restarted = RoutineCheckpointStore(tmp_path, "execution", "task-1")
+    ran = await restarted.run_delivery_step("realtime", "delivery-key", ambiguous)
+    assert ran is False
+    assert visible == ["sent"]
+
+
+async def _value(value: str) -> str:
+    return value

--- a/tests/unit/test_task_manager.py
+++ b/tests/unit/test_task_manager.py
@@ -211,6 +211,25 @@ class TestTaskClaim:
         assert ok is True
         assert task.state == "running"
 
+    def test_execution_identity_survives_retry_and_clears_after_success(self):
+        scheduled_for = "2026-07-10T10:00:00+00:00"
+        task = _sample_task(next_run_at=scheduled_for)
+        now = datetime(2026, 7, 10, 10, 0, tzinfo=timezone.utc)
+
+        assert claim_task(task, now=now) is True
+        execution_id = task.execution_id
+        assert execution_id == f"{task.id}:{scheduled_for}"
+        assert task.active_scheduled_for == scheduled_for
+
+        update_task_state(task, TaskState.FAILED, now=now, retryable=True)
+        retry_at = datetime.fromisoformat(task.next_run_at)
+        assert claim_task(task, now=retry_at) is True
+        assert task.execution_id == execution_id
+
+        update_task_state(task, TaskState.DONE, now=retry_at)
+        assert task.execution_id is None
+        assert task.active_scheduled_for is None
+
     def test_claim_future_task_returns_false(self):
         task = _sample_task(next_run_at="2099-01-01T00:00:00+00:00", state="pending")
         ok = claim_task(task, now=datetime(2026, 2, 11, 9, 0, tzinfo=timezone.utc))


### PR DESCRIPTION
Closes #143

Supersedes #145, which GitHub auto-closed when its stacked base branch was deleted after #144 merged.

## Summary
- add opt-in fixed `fetch -> analyze -> deliver` staged routines without introducing a general workflow engine
- persist execution identity, stage hashes/artifacts/run IDs, and delivery state in the workspace runtime directory
- resume after process restart and suppress repeated delivery steps after ambiguous failure
- keep legacy routines on the existing single-prompt path

## Test evidence
- `321 passed` across touched suites and both cross-repo E2Es
- real Milkie sidecar E2E: fetch succeeds, analyze 503s, sidecar/executor restart, analyze resumes, one final delivery
- `compileall` and `git diff --check` pass