### PR TITLE
fix(web): bypass proxies in browser health checks

### DIFF
--- a/skills/web/server.sh
+++ b/skills/web/server.sh
@@ -28,7 +28,7 @@ done
 mkdir -p "$TMP_DIR"
 
 health_ready() {
-    [[ "${WEB_SERVER_SKIP_HEALTH:-0}" == "1" ]] || curl -fsS --max-time 1 "$HEALTH_URL" >/dev/null 2>&1
+    [[ "${WEB_SERVER_SKIP_HEALTH:-0}" == "1" ]] || curl --noproxy '*' -fsS --max-time 1 "$HEALTH_URL" >/dev/null 2>&1
 }
 
 owned_pid() {

--- a/tests/unit/test_web_server_lifecycle.py
+++ b/tests/unit/test_web_server_lifecycle.py
@@ -9,6 +9,10 @@ from pathlib import Path
 SERVER = Path("skills/web/server.sh").resolve()
 
 
+def test_health_check_bypasses_host_proxy():
+    assert "curl --noproxy '*'" in SERVER.read_text()
+
+
 def _env(tmp_path: Path) -> dict[str, str]:
     return {
         **os.environ,


### PR DESCRIPTION
Follow-up for #147 discovered during live restart verification.

The host exports `ALL_PROXY`; browser lifecycle health checks must always connect directly to `127.0.0.1`.

## Tests
- `python -m pytest tests/unit/test_web_server_lifecycle.py -q` (3 passed)
- `bash -n skills/web/server.sh`