### PR TITLE
fix(web): detach browser owner session

### DIFF
--- a/skills/web/scripts/launch-server.py
+++ b/skills/web/scripts/launch-server.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""Launch the browser server in an independent process session."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def main() -> None:
+    if len(sys.argv) != 4:
+        raise SystemExit("usage: launch-server.py CWD LOG_FILE COMMAND")
+    cwd, log_file, command = sys.argv[1:]
+    Path(log_file).parent.mkdir(parents=True, exist_ok=True)
+    with open(log_file, "ab", buffering=0) as log:
+        process = subprocess.Popen(
+            ["bash", "-c", command],
+            cwd=cwd,
+            env=os.environ.copy(),
+            stdin=subprocess.DEVNULL,
+            stdout=log,
+            stderr=log,
+            start_new_session=True,
+        )
+    print(process.pid)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/web/server.sh
+++ b/skills/web/server.sh
@@ -71,12 +71,8 @@ start_server() {
         (cd "$SCRIPT_DIR" && npm install) || return 1
     fi
     local command="${WEB_SERVER_COMMAND:-exec npx tsx scripts/start-server.ts}"
-    (
-        cd "$SCRIPT_DIR" || exit 1
-        export HEADLESS="$HEADLESS"
-        nohup bash -c "$command" >>"$LOG_FILE" 2>&1 &
-        echo $! >"$PID_FILE"
-    )
+    export HEADLESS="$HEADLESS"
+    python3 "$SCRIPT_DIR/scripts/launch-server.py" "$SCRIPT_DIR" "$LOG_FILE" "$command" >"$PID_FILE" || return 1
     local waited=0
     while [[ $waited -lt $START_TIMEOUT ]]; do
         if owned_pid && health_ready; then

--- a/tests/unit/test_web_server_lifecycle.py
+++ b/tests/unit/test_web_server_lifecycle.py
@@ -43,6 +43,7 @@ def test_start_status_stop_uses_one_owned_pid(tmp_path):
     started = _run("start", tmp_path)
     assert started.returncode == 0, started.stderr
     pid = (tmp_path / "server.pid").read_text().strip()
+    assert os.getsid(int(pid)) == int(pid)
 
     status = _run("status", tmp_path)
     assert status.returncode == 0


### PR DESCRIPTION
Follow-up for #147 discovered during live restart verification.

An inner `nohup` still inherited the caller process session and was cleaned up when the tool session ended. The lifecycle owner now launches through `start_new_session=True` and records that independent PID.

## TDD
- added an assertion that the owner PID is its own session leader; it failed before the change and passes after it
- `python -m pytest tests/unit/test_web_server_lifecycle.py tests/unit/test_fetch_tweets.py -q` (11 passed)
- `bash -n skills/web/server.sh`