### PR TITLE
feat(#155): 模型配置单一真相源 resolve_model

### DIFF
--- a/config/models.yaml.example
+++ b/config/models.yaml.example
@@ -1,0 +1,72 @@
+# 模型路由配置(#74 正名,前身 dolphin.yaml —— dolphin 已于 #38 移除,本文件是纯数据)
+# 消费方:src/everbot/core/agent/provider/model_config.py(_SkillLLMClient / OneshotLLMProvider)
+# 查找顺序:~/.alfred/models.yaml → ./config/models.yaml → repo config/models.yaml
+#         (同位置内旧名 dolphin.yaml 兜底)
+
+# #155: top-level default/fast are SYSTEM FALLBACK only (no agent context).
+# Agent intent lives in everbot.agents.<name>.model — skill scripts inherit via
+# resolve_model(agent_name=...) / EVERBOT_AGENT. Do not treat this default as
+# "the product default model".
+# Prefer volcengine glm alias (deepseek-volcengine → glm-5.2) so unattended
+# skill runs without agent env match demo_agent rather than expired kimi membership.
+default: deepseek-volcengine
+# fast 档用于后台技能任务(skill-evaluate 的 LLM Judge、reflection 打分),
+# 见 cron.py:_resolve_skill_model()。原 qwen-turbo 走阿里云,账户 key 失效后
+# 持续 403 access_denied 导致技能评估全部失败;改用 volcengine(已验证可用)。
+# #71:doubao-seed-2-0-pro 是深思模型,与 fast 档"简单打分无需 reasoning"的定位
+# 不符 —— 独立条目 doubao-nothink 经 extra_body 关 thinking,不影响主对话模型。
+fast: doubao-nothink
+
+clouds:
+  default: aliyun
+  aliyun:
+    user_id: "${ALIYUN_USER_ID}"
+    api: https://dashscope.aliyuncs.com/compatible-mode/v1
+    api_key: "${ALIYUN_API_KEY}"
+  deepseek:
+    api: https://api.deepseek.com/v1
+    api_key: "${DEEPSEEK_API_KEY}"
+  kimi:
+    api: "${KIMI_API_BASE}"
+    api_key: "${KIMI_API_KEY}"
+    headers:
+      User-Agent: "KimiCLI/0.77"
+  volcengine:
+    api: "${VOLCENGINE_API_BASE}"
+    api_key: "${VOLCENGINE_TOKEN}"
+
+llms:
+  qwen-plus:
+    cloud: aliyun
+    id: 18928543177492439044
+    model_name: qwen-plus-2025-07-28
+    type_api: openai
+  qwen-turbo:
+    cloud: aliyun
+    id: 18928543177492439044
+    model_name: qwen-turbo-latest
+    type_api: openai
+  deepseek-chat:
+    cloud: deepseek
+    model_name: deepseek-chat
+    type_api: openai
+  kimi-code:
+    cloud: kimi
+    model_name: kimi-for-coding
+    type_api: openai
+  kimi-k2.5:
+    cloud: kimi
+    model_name: kimi-k2.5
+    type_api: openai
+  deepseek-volcengine:
+    cloud: volcengine
+    model_name: glm-5.2
+    type_api: openai
+  # #71:fast 档专用 —— 同模型但关 thinking(简单打分任务不需要,且省 reasoning 计费)。
+  doubao-nothink:
+    cloud: volcengine
+    model_name: doubao-seed-2-0-pro-260215
+    type_api: openai
+    extra_body:
+      thinking:
+        type: disabled

--- a/skills/twitter-watch/SKILL.md
+++ b/skills/twitter-watch/SKILL.md
@@ -43,7 +43,7 @@ python "$TW/fetch_tweets.py" aleabitoreddit --count 3 | python "$TW/analyze.py"
 ## 脚本
 
 - `scripts/fetch_tweets.py <handle> [--count N]` — 抓最新 N 条非置顶推文,按时间倒序,输出 JSON(正文/时间/URL/互动数)。**未登录/cookie 失效时退出码 3 并提示去 `web` profile 重登,绝不伪造内容。**
-- `scripts/analyze.py [--input f] [--model LLM_NAME] [--fast] [--timeout S]` — 读推文 JSON(默认 stdin),调用 `config/models.yaml` 中的 OpenAI-compatible 路由产出逐条解读 / 投资信号与标的 / 整体主题 / 作者立场 的中文报告。`--model` 使用 `llms` 里的配置名；未指定时使用 default，`--fast` 使用 fast 档。
+- `scripts/analyze.py [--input f] [--model LLM_NAME] [--agent NAME] [--fast] [--timeout S]` — 读推文 JSON(默认 stdin),经 **#155 `resolve_model`** 调 OpenAI-compatible 路由产出中文报告。优先级:`--model` > agent 意图(`--agent` / 环境变量 `EVERBOT_AGENT`) > `models.yaml` 系统 fallback。milkie sidecar 会注入 `EVERBOT_AGENT`,isolated 任务默认跟随 agent 模型,不再静默打顶层 kimi default。
 
 ## 已知限制
 

--- a/skills/twitter-watch/scripts/analyze.py
+++ b/skills/twitter-watch/scripts/analyze.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import json
+import os
 import sys
 from pathlib import Path
 from typing import Any
@@ -23,7 +24,7 @@ _REPO_ROOT = Path(__file__).resolve().parents[3]
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
-from src.everbot.core.agent.provider.model_config import load_model_config  # noqa: E402
+from src.everbot.core.agent.provider.model_config import resolve_model  # noqa: E402
 
 _PROMPT_TEMPLATE = """你是资深投资与科技分析师。下面是 X 用户 @{handle} 最新的 {n} 条推文(含互动数据 metrics)。请做**深度分析**,用**中文**输出结构化报告。要求基于推文内容分析,保留关键原文引用,**不要编造推文未提及的信息**。
 
@@ -56,10 +57,21 @@ def build_prompt(data: dict) -> str:
     )
 
 
-async def run_analysis(prompt: str, model: str | None, timeout: int, fast: bool = False) -> str:
+async def run_analysis(
+    prompt: str,
+    model: str | None,
+    timeout: int,
+    fast: bool = False,
+    agent_name: str | None = None,
+) -> str:
     try:
-        cfg = load_model_config()
-        route = cfg.route_for(model) if model else cfg.route(fast=fast)
+        # #155: agent context wins over models.yaml top-level default (no more silent kimi).
+        resolved = resolve_model(
+            agent_name=agent_name,
+            override=model,
+            tier="fast" if fast else "default",
+        )
+        route = resolved.route
     except Exception as exc:
         sys.exit(f"[analyze] 模型配置错误: {exc}")
 
@@ -103,8 +115,17 @@ async def run_analysis(prompt: str, model: str | None, timeout: int, fast: bool 
 def main() -> None:
     ap = argparse.ArgumentParser(description="用已配置模型深度分析推文")
     ap.add_argument("--input", help="推文 JSON 文件(默认从 stdin 读)")
-    ap.add_argument("--model", default=None, help="指定 config/models.yaml 里的 llm 名称(默认用 default)")
-    ap.add_argument("--fast", action="store_true", help="未指定 --model 时使用 fast 档")
+    ap.add_argument(
+        "--model",
+        default=None,
+        help="logical llm name in models.yaml (overrides agent/system default)",
+    )
+    ap.add_argument(
+        "--agent",
+        default=None,
+        help="agent name for model intent (#155); default env EVERBOT_AGENT / ALFRED_AGENT",
+    )
+    ap.add_argument("--fast", action="store_true", help="use models.yaml fast tier when no --model")
     ap.add_argument("--timeout", type=int, default=180, help="模型调用超时秒数(默认 180)")
     args = ap.parse_args()
 
@@ -116,7 +137,21 @@ def main() -> None:
     if not data.get("tweets"):
         sys.exit("[analyze] 输入无 tweets,无可分析内容")
 
-    report = asyncio.run(run_analysis(build_prompt(data), args.model, args.timeout, fast=args.fast))
+    agent = (
+        args.agent
+        or os.environ.get("EVERBOT_AGENT")
+        or os.environ.get("ALFRED_AGENT")
+        or None
+    )
+    report = asyncio.run(
+        run_analysis(
+            build_prompt(data),
+            args.model,
+            args.timeout,
+            fast=args.fast,
+            agent_name=agent,
+        )
+    )
     print(report)
 
 

--- a/src/everbot/core/agent/provider/milkie/launcher.py
+++ b/src/everbot/core/agent/provider/milkie/launcher.py
@@ -152,6 +152,9 @@ class SidecarLauncher:
             "--state-store", "sqlite", "--data-dir", str(data_dir),
         ]
         env = dict(os.environ)
+        # #155: skill scripts (analyze.py) inherit agent model intent via env.
+        env["EVERBOT_AGENT"] = agent_name
+        env["ALFRED_AGENT"] = agent_name
         default_cloud = self._llms[default]["cloud"]  # per-agent 模型的 cloud(决定 key/VOLCENGINE 处理)
         api_key = self._clouds[default_cloud].get("api_key")
         if api_key:

--- a/src/everbot/core/agent/provider/model_config.py
+++ b/src/everbot/core/agent/provider/model_config.py
@@ -5,18 +5,24 @@
 仍耦合 dolphin;本模块用同样的查找顺序独立定位,去掉该耦合(#38 去 dolphin)。
 
 文件 schema(``config/models.yaml``):
-    default: <llm-name>        # 默认档(亦兼容旧键 default_model)
-    fast:    <llm-name>        # 快速档(亦兼容旧键 fast_llm)
+    default: <llm-name>        # 系统级 fallback(无 agent 上下文时;亦兼容旧键 default_model)
+    fast:    <llm-name>        # 后台/打分档(亦兼容旧键 fast_llm)
     clouds:  {name: {api, api_key}}
     llms:    {name: {cloud, model_name, type_api}}
 ``api``/``api_key`` 可含 ``${ENV}`` 占位符,读取时按环境变量展开。
+
+#155 单一真相源:
+- **意图**: ``everbot.agents.<name>.model`` (via :func:`resolve_agent_model`)
+- **解析表**: 本文件 ``llms`` / ``clouds``
+- **统一入口**: :func:`resolve_model` / :func:`resolve_logical_model_name`
+- skill/oneshot 有 agent 上下文时必须走 agent 意图,不得静默用顶层 ``default``
 """
 from __future__ import annotations
 
 import os
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Literal, Optional
 
 import yaml
 
@@ -125,3 +131,86 @@ def load_model_config(path: Optional[Path] = None) -> ModelConfig:
     default_model = raw.get("default_model") or raw.get("default") or next(iter(llms), "")
     fast_model = raw.get("fast_llm") or raw.get("fast") or default_model
     return ModelConfig(llms=llms, clouds=clouds, default_model=default_model, fast_model=fast_model)
+
+
+ModelTier = Literal["default", "fast"]
+ModelSource = Literal["override", "agent", "system_fast", "system_default"]
+
+
+@dataclass(frozen=True)
+class ResolvedModel:
+    """Logical name + routed credentials; ``source`` explains which intent won (#155)."""
+
+    logical_name: str
+    route: ModelRoute
+    source: ModelSource
+
+
+def resolve_logical_model_name(
+    *,
+    agent_name: Optional[str] = None,
+    tier: ModelTier = "default",
+    override: Optional[str] = None,
+    model_config: Optional[ModelConfig] = None,
+) -> tuple[str, ModelSource]:
+    """Resolve the logical llm name only (no network).
+
+    Priority (#155):
+    1. ``override`` (CLI ``--model`` / explicit call)
+    2. ``tier=default`` + agent → ``everbot.agents.<name>.model``
+    3. ``tier=fast`` → models.yaml ``fast`` (skill-eval / scoring); if empty, agent then system default
+    4. system ``default`` from models.yaml (no agent context only for default tier)
+    """
+    if override:
+        return str(override), "override"
+
+    mc = model_config or load_model_config()
+
+    if tier == "fast":
+        if mc.fast_model:
+            return mc.fast_model, "system_fast"
+        if agent_name:
+            from ..agent_config import resolve_agent_model
+
+            agent_model = resolve_agent_model(agent_name)
+            if agent_model:
+                return agent_model, "agent"
+        if mc.default_model:
+            return mc.default_model, "system_default"
+        raise ValueError("No model resolved: empty fast/default and no agent model")
+
+    # tier == default
+    if agent_name:
+        # Lazy import avoids circular import at module load
+        # (agent_config → config; model_config stays free of app config at import).
+        from ..agent_config import resolve_agent_model
+
+        agent_model = resolve_agent_model(agent_name)
+        if agent_model:
+            return agent_model, "agent"
+
+    if mc.default_model:
+        return mc.default_model, "system_default"
+    raise ValueError("No model resolved: set everbot.agents.<name>.model or models.yaml default")
+
+
+def resolve_model(
+    *,
+    agent_name: Optional[str] = None,
+    tier: ModelTier = "default",
+    override: Optional[str] = None,
+    model_config: Optional[ModelConfig] = None,
+) -> ResolvedModel:
+    """Single entry: intent → route table → :class:`ModelRoute` (#155)."""
+    mc = model_config or load_model_config()
+    logical_name, source = resolve_logical_model_name(
+        agent_name=agent_name,
+        tier=tier,
+        override=override,
+        model_config=mc,
+    )
+    return ResolvedModel(
+        logical_name=logical_name,
+        route=mc.route_for(logical_name),
+        source=source,
+    )

--- a/src/everbot/core/agent/provider/oneshot_llm.py
+++ b/src/everbot/core/agent/provider/oneshot_llm.py
@@ -15,7 +15,7 @@ from typing import Any
 
 import httpx
 
-from .model_config import load_model_config
+from .model_config import resolve_model
 
 logger = logging.getLogger(__name__)
 
@@ -23,8 +23,15 @@ logger = logging.getLogger(__name__)
 class OneshotLLMProvider:
     """无状态一次性 LLM provider(只实现 ``call_llm``)。"""
 
-    def __init__(self, *, client: "httpx.AsyncClient | None" = None) -> None:
+    def __init__(
+        self,
+        *,
+        client: "httpx.AsyncClient | None" = None,
+        agent_name: str | None = None,
+    ) -> None:
         self._client = client  # 注入便于测试;None → 每次调用一个 client
+        # #155: optional agent intent; None → system default/fast only
+        self._agent_name = agent_name
 
     async def call_llm(
         self,
@@ -35,7 +42,10 @@ class OneshotLLMProvider:
         raise_on_error: bool = True,
     ) -> str:
         try:
-            route = load_model_config().route(fast=fast)
+            route = resolve_model(
+                agent_name=self._agent_name,
+                tier="fast" if fast else "default",
+            ).route
         except Exception as exc:  # 配置缺失/模型名不存在
             msg = f"oneshot LLM 配置错误: {exc}"
             if raise_on_error:

--- a/src/everbot/core/runtime/cron.py
+++ b/src/everbot/core/runtime/cron.py
@@ -273,21 +273,22 @@ class CronExecutor:
         return result
 
     def _resolve_skill_model(self) -> str:
-        """Resolve the model for skill LLM calls.
+        """Resolve the model for skill LLM calls via #155 single entry.
 
-        Uses the 'fast' model from models.yaml (model_config) — skill jobs
-        (eval, reflection) are simple scoring tasks that don't need
-        a reasoning model.  Falls back to agent model if 'fast' is unset.
+        ``tier=fast``: models.yaml fast (scoring), then agent, then system default.
         """
-        from ..agent.provider.model_config import load_model_config
-        from ..agent.agent_config import resolve_agent_model
+        from ..agent.provider.model_config import resolve_logical_model_name
+
         try:
-            fast_model = load_model_config().fast_model
-            if fast_model:
-                return fast_model
+            name, _source = resolve_logical_model_name(
+                agent_name=self.agent_name,
+                tier="fast",
+            )
+            return name
         except Exception:
-            pass
-        return resolve_agent_model(self.agent_name)
+            from ..agent.agent_config import resolve_agent_model
+
+            return resolve_agent_model(self.agent_name)
 
     # ── Scheduler-facing task listing ─────────────────────────
 

--- a/tests/unit/test_milkie_launcher.py
+++ b/tests/unit/test_milkie_launcher.py
@@ -63,6 +63,13 @@ def test_build_injects_cloud_api_key_env(tmp_path):
     assert spec.env.get("OPENAI_API_KEY") == "sk-real"
 
 
+def test_build_injects_everbot_agent_env_for_skill_model_intent(tmp_path):
+    """#155: skill scripts inherit agent model via EVERBOT_AGENT / ALFRED_AGENT."""
+    spec = _launcher(tmp_path).build("demo_agent", system_prompt="x")
+    assert spec.env.get("EVERBOT_AGENT") == "demo_agent"
+    assert spec.env.get("ALFRED_AGENT") == "demo_agent"
+
+
 def test_build_unknown_model_fails_fast(tmp_path):
     launcher = SidecarLauncher(
         dist_path=tmp_path / "x.js", data_dir_root=tmp_path / "d", node_bin="node",

--- a/tests/unit/test_oneshot_llm.py
+++ b/tests/unit/test_oneshot_llm.py
@@ -3,18 +3,18 @@ import httpx
 import pytest
 
 from src.everbot.core.agent.provider import oneshot_llm as os_mod
-from src.everbot.core.agent.provider.model_config import ModelConfig
+from src.everbot.core.agent.provider.model_config import ModelRoute, ResolvedModel
 from src.everbot.core.agent.provider.oneshot_llm import OneshotLLMProvider
 
 
 def _patch_route(monkeypatch):
-    cfg = ModelConfig(
-        llms={"m": {"cloud": "c", "model_name": "mm"}},
-        clouds={"c": {"api": "http://fake/v1", "api_key": "k"}},
-        default_model="m", fast_model="m",
+    resolved = ResolvedModel(
+        logical_name="m",
+        route=ModelRoute(base_url="http://fake/v1", api_key="k", model="mm"),
+        source="system_default",
     )
-    # oneshot_llm 直接绑定了 load_model_config,故 patch 其模块内引用。
-    monkeypatch.setattr(os_mod, "load_model_config", lambda *a, **k: cfg)
+    # oneshot_llm binds resolve_model; patch the module reference.
+    monkeypatch.setattr(os_mod, "resolve_model", lambda **k: resolved)
 
 
 async def test_returns_content_on_success(monkeypatch):
@@ -48,8 +48,10 @@ async def test_raise_on_error_false_returns_error_string(monkeypatch):
 
 
 async def test_bad_config_raises_when_raise_on_error(monkeypatch):
-    monkeypatch.setattr(os_mod, "load_model_config",
-                        lambda *a, **k: ModelConfig({}, {}, "", ""))  # 空配置 → route KeyError
+    def _boom(**k):
+        raise ValueError("No model resolved")
+
+    monkeypatch.setattr(os_mod, "resolve_model", _boom)
     p = OneshotLLMProvider()
     with pytest.raises(RuntimeError):
         await p.call_llm(None, "x", raise_on_error=True)

--- a/tests/unit/test_resolve_model.py
+++ b/tests/unit/test_resolve_model.py
@@ -1,0 +1,129 @@
+"""#155: single-source model resolution (intent + route table)."""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from src.everbot.core.agent.provider.model_config import (
+    load_model_config,
+    resolve_logical_model_name,
+    resolve_model,
+)
+
+
+_YAML = """
+default: kimi-code
+fast: doubao-nothink
+clouds:
+  kimi:
+    api: https://api.kimi.example/v1
+    api_key: sk-kimi
+  volcengine:
+    api: https://ark.example/v3
+    api_key: sk-volc
+  deepseek:
+    api: https://api.deepseek.com/v1
+    api_key: sk-ds
+llms:
+  kimi-code:
+    cloud: kimi
+    model_name: kimi-for-coding
+  deepseek-volcengine:
+    cloud: volcengine
+    model_name: glm-5.2
+  doubao-nothink:
+    cloud: volcengine
+    model_name: doubao-seed
+  deepseek-chat:
+    cloud: deepseek
+    model_name: deepseek-chat
+"""
+
+
+def _mc(tmp_path: Path):
+    p = tmp_path / "models.yaml"
+    p.write_text(_YAML, encoding="utf-8")
+    return load_model_config(p)
+
+
+def test_override_beats_agent_and_system(tmp_path):
+    mc = _mc(tmp_path)
+    with patch(
+        "src.everbot.core.agent.agent_config.resolve_agent_model",
+        return_value="deepseek-volcengine",
+    ):
+        name, source = resolve_logical_model_name(
+            agent_name="demo_agent",
+            override="deepseek-chat",
+            model_config=mc,
+        )
+    assert name == "deepseek-chat"
+    assert source == "override"
+
+
+def test_agent_default_beats_system_default(tmp_path):
+    """With agent context, skill/oneshot default must not fall to models.yaml default (kimi)."""
+    mc = _mc(tmp_path)
+    with patch(
+        "src.everbot.core.agent.agent_config.resolve_agent_model",
+        return_value="deepseek-volcengine",
+    ):
+        resolved = resolve_model(agent_name="demo_agent", model_config=mc)
+    assert resolved.logical_name == "deepseek-volcengine"
+    assert resolved.source == "agent"
+    assert resolved.route.model == "glm-5.2"
+    assert "ark.example" in resolved.route.base_url
+
+
+def test_no_agent_uses_system_default(tmp_path):
+    mc = _mc(tmp_path)
+    resolved = resolve_model(model_config=mc)
+    assert resolved.logical_name == "kimi-code"
+    assert resolved.source == "system_default"
+    assert resolved.route.model == "kimi-for-coding"
+
+
+def test_fast_tier_uses_system_fast_even_with_agent(tmp_path):
+    """Background skill-eval keeps models.yaml fast; agent default is for default tier."""
+    mc = _mc(tmp_path)
+    with patch(
+        "src.everbot.core.agent.agent_config.resolve_agent_model",
+        return_value="deepseek-volcengine",
+    ):
+        resolved = resolve_model(agent_name="demo_agent", tier="fast", model_config=mc)
+    assert resolved.logical_name == "doubao-nothink"
+    assert resolved.source == "system_fast"
+
+
+def test_fast_tier_falls_back_to_agent_when_system_fast_empty(tmp_path):
+    yaml = _YAML.replace("fast: doubao-nothink", "fast: \"\"")
+    p = tmp_path / "models.yaml"
+    p.write_text(yaml, encoding="utf-8")
+    mc = load_model_config(p)
+    # empty fast may collapse to default in loader — force empty
+    mc.fast_model = ""
+    with patch(
+        "src.everbot.core.agent.agent_config.resolve_agent_model",
+        return_value="deepseek-volcengine",
+    ):
+        name, source = resolve_logical_model_name(
+            agent_name="demo_agent", tier="fast", model_config=mc
+        )
+    assert name == "deepseek-volcengine"
+    assert source == "agent"
+
+
+def test_unknown_logical_name_fails_on_route(tmp_path):
+    mc = _mc(tmp_path)
+    with pytest.raises(KeyError, match="not in llms"):
+        resolve_model(override="no-such-model", model_config=mc)
+
+
+def test_empty_resolution_raises():
+    from src.everbot.core.agent.provider.model_config import ModelConfig
+
+    mc = ModelConfig(llms={}, clouds={}, default_model="", fast_model="")
+    with pytest.raises(ValueError, match="No model resolved"):
+        resolve_logical_model_name(model_config=mc)

--- a/tests/unit/test_twitter_watch_provenance.py
+++ b/tests/unit/test_twitter_watch_provenance.py
@@ -11,8 +11,6 @@ from pathlib import Path
 
 import httpx
 
-from src.everbot.core.agent.provider.model_config import ModelConfig
-
 _SCRIPTS = Path(__file__).resolve().parents[2] / "skills" / "twitter-watch" / "scripts"
 if str(_SCRIPTS) not in sys.path:
     sys.path.insert(0, str(_SCRIPTS))
@@ -53,13 +51,14 @@ def test_prompt_requires_per_tweet_source_link():
 
 def test_analyze_uses_configured_openai_compatible_route(monkeypatch):
     """twitter-watch analysis should not shell out to Claude CLI."""
-    cfg = ModelConfig(
-        llms={"m": {"cloud": "c", "model_name": "mm"}},
-        clouds={"c": {"api": "http://fake/v1", "api_key": "k"}},
-        default_model="m",
-        fast_model="m",
+    from src.everbot.core.agent.provider.model_config import ModelRoute, ResolvedModel
+
+    resolved = ResolvedModel(
+        logical_name="m",
+        route=ModelRoute(base_url="http://fake/v1", api_key="k", model="mm"),
+        source="system_default",
     )
-    monkeypatch.setattr(az, "load_model_config", lambda: cfg)
+    monkeypatch.setattr(az, "resolve_model", lambda **k: resolved)
     cap = {}
 
     def handler(req: httpx.Request) -> httpx.Response:
@@ -78,6 +77,33 @@ def test_analyze_uses_configured_openai_compatible_route(monkeypatch):
     assert cap["auth"] == "Bearer k"
     assert cap["json"]["model"] == "mm"
     assert cap["json"]["messages"][0]["content"] == "prompt"
+
+
+def test_analyze_passes_agent_name_into_resolve_model(monkeypatch):
+    """#155: agent context must be forwarded so default is not models.yaml top-level."""
+    from src.everbot.core.agent.provider.model_config import ModelRoute, ResolvedModel
+
+    seen = {}
+
+    def fake_resolve(**kwargs):
+        seen.update(kwargs)
+        return ResolvedModel(
+            logical_name="deepseek-volcengine",
+            route=ModelRoute(base_url="http://fake/v1", api_key="k", model="glm-5.2"),
+            source="agent",
+        )
+
+    monkeypatch.setattr(az, "resolve_model", fake_resolve)
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"choices": [{"message": {"content": "ok"}}]})
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    monkeypatch.setattr(az.httpx, "AsyncClient", lambda *a, **k: client)
+
+    asyncio.run(az.run_analysis("p", None, 30, agent_name="demo_agent"))
+    assert seen.get("agent_name") == "demo_agent"
+    assert seen.get("override") is None
 
 
 def test_analyze_script_no_longer_references_claude_cli():


### PR DESCRIPTION
## Summary

实现 #155：模型**意图**与**路由表**分离，统一入口 `resolve_model`。

### 行为变化

| 场景 | 之前 | 之后 |
|------|------|------|
| `analyze.py` 无 `--model` | `models.yaml` 顶层 `default`（常为 kimi） | **agent 意图**（`EVERBOT_AGENT` / `--agent`）→ 否则系统 fallback |
| milkie sidecar 环境 | 无 agent 标记 | 注入 `EVERBOT_AGENT` / `ALFRED_AGENT` |
| oneshot LLM | 直接 `load_model_config().route()` | `resolve_model(tier=...)` |
| skill-eval 模型 | 手写 fast/agent fallback | `resolve_logical_model_name(tier=fast)` |
| 系统 fallback 模板 | （本地）kimi-code | `deepseek-volcengine` → glm-5.2（`config/models.yaml.example`） |

优先级：`--model` override > `everbot.agents.<name>.model` > `models.yaml` default/fast

### 非目标（本 PR 不做）

- 重命名 `deepseek-volcengine` 别名（保留兼容）
- 强制改用户本机已 ignore 的 `config/models.yaml`（提供 example）
- 续费 kimi

## Test plan

- [x] 单测：`test_resolve_model` + oneshot / twitter-watch / milkie launcher（42 passed 相关集）
- [x] 本机解析 E2E：
  - `resolve_model(agent_name='demo_agent')` → `deepseek-volcengine` / `glm-5.2` / `source=agent`
  - 无 agent → 系统 fallback `deepseek-volcengine`（非 kimi）
- [ ] 合并后重启 everbot，跑一次 `routine_3d785e79` 或 `analyze.py`：日志中模型应为火山 glm，而非 kimi-for-coding
- [ ] `everbot status` 配置意图与生效模型仍一致

Closes #155