### PR TITLE
【runtime/skills】闭世界 skill_request 加载，禁止 shell 搜 SKILL.md

### DIFF
--- a/src/everbot/core/agent/provider/milkie/skills.py
+++ b/src/everbot/core/agent/provider/milkie/skills.py
@@ -1,12 +1,16 @@
-"""milkie 侧 skill 发现 —— 把磁盘上的 shell 型 markdown skill 注入 milkie agent 提示。
+"""Milkie-side skill discovery: inject shell-style markdown skills into agent prompts.
 
-dolphin 靠 ResourceSkillkit 扫目录发现 SKILL.md + `_load_resource_skill` 工具加载;
-milkie 没有这套(skill_list 是空 stub)。本模块在 alfred 侧(skill 目录所在地)做发现,
-渲染成一段「可用技能」提示,让 milkie agent 用内建 ``run_command``(milkie#134)读
-SKILL.md 并执行其脚本 —— 与 dolphin 的能力对等,但不耦合 dolphin。
+This module runs **discovery** on the alfred host (where skill directories live):
+scan skill roots, render the installed-skills prompt section, and emit the
+skill-manifest consumed by milkie ``skill_list`` / ``skill_request``.
 
-目录优先级同 dolphin factory:``<workspace>/skills`` > ``~/.alfred/skills`` > 仓库内置
-``skills/``。同名 skill 高优先级目录胜出。
+Load time (#164 closed-world): agents should prefer ``skill_request(name)`` to
+obtain ``instructions`` + authoritative ``dir``. ``run_command`` runs scripts
+under ``dir``; it is not used to discover SKILL.md.
+
+Directory priority: ``<workspace>/skills`` > ``~/.alfred/skills`` > repo
+built-in ``skills/``. Same-name skills: higher-priority dir wins. Load time only
+does name → manifest.dir (no re-scan).
 """
 from __future__ import annotations
 
@@ -219,15 +223,26 @@ def discover_skills(
 
 
 def build_milkie_skills_section(skills: List[Dict[str, Any]], workspace_root: Path) -> str:
-    """渲染面向 ``run_command`` 的「可用技能」提示段。空列表 → ""。"""
+    """Render the installed-skills prompt section for milkie agents. Empty list → "".
+
+    Load path is closed-world (#164): prefer ``skill_request(name)`` so the runtime
+    returns ``instructions`` + authoritative ``dir``. Do not guide shell find/cat
+    as the primary way to discover SKILL.md. ``run_command`` is for executing
+    scripts under ``dir`` (or known-absolute-path continuation when truncated).
+    """
     if not skills:
         return ""
     lines = [
-        "# 已安装技能（用 run_command 调用）",
+        "# 已安装技能（用 skill_request 加载说明）",
         "",
-        "下列技能可用。使用方法：用 `run_command` 执行 `cat \"<技能目录>/SKILL.md\"` 阅读其文档，"
-        "再按文档用 `run_command` 执行其脚本（用脚本的绝对路径）。文档里的 "
-        f"`$SKILL_DIR` 指该技能目录、`$WORKSPACE_ROOT` 指 `{workspace_root}`。",
+        "下列技能可用。加载说明时**优先**调用 `skill_request(\"<name>\")`，"
+        "使用返回的 `instructions` 正文与权威 `dir`；"
+        "**不要**用 `find`/`$HOME` 扫描或全盘搜索去发现 `SKILL.md`。",
+        "若返回 `truncated: true`，可对返回的 `instructionPath`（已知绝对路径）续读，"
+        "仍禁止搜索式发现。",
+        "执行脚本时用 `run_command` 调用该技能 `dir` 下脚本的绝对路径。"
+        f"文档里的 `$SKILL_DIR` 指 `skill_request`/`skill_list` 给出的 `dir`、"
+        f"`$WORKSPACE_ROOT` 指 `{workspace_root}`。",
         "",
         # 列举意图 → 走 skill_list 工具(权威完整),而非凭本段落手抄(手抄是非确定性的,
         # 实测会漏列;skill_list 由 manifest 背书,见 milkie#139 / alfred#50)。

--- a/tests/e2e/test_milkie_skill_request_e2e.py
+++ b/tests/e2e/test_milkie_skill_request_e2e.py
@@ -1,0 +1,297 @@
+"""E2E(#164 S1/S2): alfred → real milkie serve → closed-world skill_request.
+
+Proves host skill-manifest injection + milkie tool handler contract:
+
+  fake OpenAI (skill_request tool_call) → milkie serve → skill_request handler
+    → hit: instructions + dir from manifest.dir/SKILL.md only
+    → miss: not_found without HOME/full-disk SKILL.md search
+
+No API key required; milkie dist missing → skip.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from src.everbot.core.agent.provider.milkie.launcher import (
+    SKILL_MANIFEST_ENV,
+    _render_skill_manifest,
+)
+from src.everbot.core.agent.provider.milkie.pool import SidecarPool
+from src.everbot.core.agent.provider.milkie.provider import MilkieProvider
+
+
+def _milkie_cli() -> Optional[Path]:
+    configured = os.environ.get("MILKIE_CLI")
+    if configured:
+        p = Path(configured).expanduser()
+        return p if p.exists() else None
+    alfred_root = Path(__file__).resolve().parents[2]
+    for sibling in ("milkie-164", "milkie"):
+        candidate = alfred_root.parent / sibling / "dist" / "cli" / "index.js"
+        if candidate.exists():
+            return candidate
+    return None
+
+
+class _SkillRequestOpenAIHandler(BaseHTTPRequestHandler):
+    """Stateful fake OpenAI: skill_request(hit) → skill_request(miss) → final text.
+
+    Captures tool result payloads from subsequent LLM requests for assertion.
+    """
+
+    protocol_version = "HTTP/1.1"
+    # Injected before server starts
+    skill_name: str = "web"
+    unknown_name: str = "no-such-skill-xyz"
+    tool_results: List[Any] = []
+    tool_calls_seen: List[str] = []
+
+    def _send_stream(self, frames: list[dict]) -> None:
+        lines = ["data: " + json.dumps(f) for f in frames]
+        lines.append("data: [DONE]")
+        body = ("\n\n".join(lines) + "\n\n").encode("utf-8")
+        self.send_response(200)
+        self.send_header("content-type", "text/event-stream")
+        self.send_header("content-length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_POST(self):  # noqa: N802
+        length = int(self.headers.get("content-length", 0))
+        req = json.loads(self.rfile.read(length) or "{}")
+        messages = req.get("messages", [])
+
+        # Harvest tool results milkie feeds back into the next completion.
+        for m in messages:
+            if m.get("role") == "tool":
+                content = m.get("content", "")
+                try:
+                    parsed = json.loads(content) if isinstance(content, str) else content
+                except (TypeError, json.JSONDecodeError):
+                    parsed = content
+                type(self).tool_results.append(parsed)
+
+        n_tool_msgs = sum(1 for m in messages if m.get("role") == "tool")
+
+        if n_tool_msgs == 0:
+            type(self).tool_calls_seen.append("skill_request")
+            self._send_stream([
+                {"choices": [{"index": 0, "finish_reason": None, "delta": {
+                    "tool_calls": [{
+                        "index": 0, "id": "call_sr_hit", "type": "function",
+                        "function": {
+                            "name": "skill_request",
+                            "arguments": json.dumps({"name": type(self).skill_name}),
+                        },
+                    }],
+                }}]},
+                {"choices": [{"index": 0, "finish_reason": "tool_calls", "delta": {}}]},
+            ])
+        elif n_tool_msgs == 1:
+            type(self).tool_calls_seen.append("skill_request")
+            self._send_stream([
+                {"choices": [{"index": 0, "finish_reason": None, "delta": {
+                    "tool_calls": [{
+                        "index": 0, "id": "call_sr_miss", "type": "function",
+                        "function": {
+                            "name": "skill_request",
+                            "arguments": json.dumps({"name": type(self).unknown_name}),
+                        },
+                    }],
+                }}]},
+                {"choices": [{"index": 0, "finish_reason": "tool_calls", "delta": {}}]},
+            ])
+        else:
+            self._send_stream([
+                {"choices": [{"index": 0, "finish_reason": None, "delta": {
+                    "content": "skill-load-done",
+                }}]},
+                {"choices": [{"index": 0, "finish_reason": "stop", "delta": {}}]},
+            ])
+
+    def log_message(self, *args):
+        pass
+
+
+def _make_web_skill(root: Path) -> Dict[str, Any]:
+    skill = root / "skills" / "web"
+    skill.mkdir(parents=True)
+    # Body must not contain banned discovery phrases: hit tool_result embeds
+    # instructions, and trajectory assertions scan tool outputs.
+    body = (
+        "# Web\n\n"
+        "Closed-world e2e fixture for skill_request.\n\n"
+        "Load via skill_request; use returned instructions and dir.\n"
+    )
+    (skill / "SKILL.md").write_text(body, encoding="utf-8")
+    return {
+        "name": "web",
+        "title": "Web",
+        "description": "web skill e2e fixture",
+        "abs_path": str(skill.resolve()),
+    }
+
+
+def _write_agent(tmp_path: Path, fake_port: int) -> Path:
+    md = tmp_path / "skill_req_agent.md"
+    md.write_text(
+        "---\n"
+        "agentId: skillreq\n"
+        "version: 1.0.0\n"
+        "fsm:\n"
+        "  states:\n"
+        "    - name: react\n"
+        "      type: llm\n"
+        "      max_iterations: 8\n"
+        "      instructions: load skills via skill_request then answer\n"
+        "model:\n"
+        "  provider: openai\n"
+        "  model: fake-model\n"
+        "  adapter: openai-compatible\n"
+        f"  baseUrl: http://127.0.0.1:{fake_port}/v1\n"
+        "---\n"
+        "Prefer skill_request over shell discovery for SKILL.md.\n",
+        encoding="utf-8",
+    )
+    return md
+
+
+def _progress_items(events: list) -> list:
+    items = []
+    for e in events:
+        if isinstance(e, dict) and "_progress" in e:
+            items.extend(e["_progress"])
+    return items
+
+
+async def test_skill_request_hit_and_miss_through_real_sidecar(tmp_path, monkeypatch):
+    """E1+E2: installed skill → instructions+dir; unknown → not_found; no HOME find."""
+    cli = _milkie_cli()
+    if cli is None:
+        pytest.skip("milkie dist not built (set MILKIE_CLI or build milkie-164/milkie)")
+
+    skill_meta = _make_web_skill(tmp_path)
+    skill_dir = skill_meta["abs_path"]
+    manifest = _render_skill_manifest([skill_meta])
+    data_dir = tmp_path / "milkie-data" / "skillreq"
+    data_dir.mkdir(parents=True)
+    manifest_path = data_dir / "skill-manifest.json"
+    manifest_path.write_text(json.dumps(manifest, ensure_ascii=False, indent=2), encoding="utf-8")
+
+    handler_cls = type(
+        "_H",
+        (_SkillRequestOpenAIHandler,),
+        {
+            "skill_name": "web",
+            "unknown_name": "no-such-skill-xyz",
+            "tool_results": [],
+            "tool_calls_seen": [],
+        },
+    )
+    server = HTTPServer(("127.0.0.1", 0), handler_cls)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    fake_port = server.server_address[1]
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-fake")
+
+    agent_md = _write_agent(tmp_path, fake_port)
+
+    def _build(_name: str):
+        env = {
+            "OPENAI_API_KEY": "sk-fake",
+            "PATH": os.environ.get("PATH", ""),
+            SKILL_MANIFEST_ENV: str(manifest_path),
+        }
+        cmd = [
+            "node", str(cli), "serve",
+            "--agent", str(agent_md),
+            "--port", "0",
+            "--state-store", "sqlite",
+            "--data-dir", str(data_dir),
+        ]
+        return cmd, env
+
+    pool = SidecarPool(build=_build)
+    provider = MilkieProvider()
+    provider._pool = pool
+    try:
+        handle = await provider.create_agent("skillreq", "/ws-skill-req")
+        events = [e async for e in provider.run_turn(handle, "load the web skill then try missing")]
+    finally:
+        await provider.shutdown_sidecars()
+        server.shutdown()
+
+    assert events, "turn should emit progress events"
+
+    # Skill-plane tools: only skill_request (≤ 2 calls for hit+miss load path)
+    requested = [
+        i for i in _progress_items(events)
+        if i.get("stage") == "skill" and i.get("status") == "running"
+    ]
+    completed = [
+        i for i in _progress_items(events)
+        if i.get("stage") == "skill" and i.get("status") == "completed"
+    ]
+    tool_names = [i.get("skill_info", {}).get("name") for i in requested]
+    assert all(n == "skill_request" for n in tool_names), (
+        f"only skill_request allowed on load path, got {tool_names}"
+    )
+    assert 1 <= len(tool_names) <= 2, (
+        f"skill-plane calls should be ≤ 2 for load (list+request or request×2), got {len(tool_names)}"
+    )
+    # Fake issues hit then miss → exactly 2 skill_request
+    assert len(completed) == 2, f"expected hit+miss tool results, got {len(completed)}: {completed}"
+
+    def _parse_answer(item: dict) -> dict:
+        raw = item.get("answer") or ""
+        if isinstance(raw, dict):
+            return raw
+        return json.loads(raw)
+
+    hit = _parse_answer(completed[0])
+    miss = _parse_answer(completed[1])
+
+    # S1 / E1: hit returns instructions + authoritative dir
+    assert hit.get("status") == "ok", hit
+    assert hit.get("dir") == skill_dir
+    assert hit.get("instructionPath") == str(Path(skill_dir) / "SKILL.md")
+    assert "Closed-world e2e fixture" in str(hit.get("instructions") or "")
+    assert hit.get("truncated") is False
+    # Guidance fields only (not instructions body): must not teach shell discovery
+    hit_msg = str(hit.get("message") or "")
+    assert "run_command/cat" not in hit_msg
+    assert not re.search(r"find\s+\$HOME|find\s+/Users", hit_msg)
+
+    # S2 / E2: unknown name → not_found, no disk search guidance
+    assert miss.get("status") in ("not_found", "unavailable"), miss
+    assert miss.get("status") == "not_found", miss
+    assert "instructions" not in miss or miss.get("instructions") in (None, "")
+    miss_msg = str(miss.get("message") or "")
+    assert "run_command/cat" not in miss_msg
+    assert not re.search(r"find\s+\$HOME|find\s+/", miss_msg)
+
+    # Trajectory / tool plane: only skill_request — no run_command / shell discovery
+    assert "run_command" not in tool_names
+    progress = _progress_items(events)
+    plane_tools = [
+        (i.get("skill_info") or {}).get("name")
+        for i in progress
+        if i.get("stage") in ("skill", "tool") and (i.get("skill_info") or {}).get("name")
+    ]
+    assert all(n == "skill_request" for n in plane_tools), plane_tools
+    # Command args (if present on progress items) must not show HOME/root SKILL.md search
+    for item in progress:
+        info = item.get("skill_info") or {}
+        cmd_blob = json.dumps(
+            {"input": info.get("input"), "command": info.get("command"), "args": info.get("args")},
+            ensure_ascii=False,
+        )
+        assert not re.search(r"find\s+\$HOME|find\s+/Users|find\s+/ ", cmd_blob)
+    assert handler_cls.tool_calls_seen == ["skill_request", "skill_request"]

--- a/tests/unit/test_milkie_skills.py
+++ b/tests/unit/test_milkie_skills.py
@@ -78,15 +78,33 @@ def test_build_section_includes_run_command_and_paths(tmp_path):
         {"name": "web", "title": "Web", "description": "", "abs_path": "/abs/web"},
     ]
     section = msk.build_milkie_skills_section(skills, Path("/ws"))
-    assert "run_command" in section
+    assert "run_command" in section  # still for executing scripts under dir
     assert "ops" in section and "/abs/ops" in section
     # 空 description 退回 title
     assert "Web" in section
     assert "$WORKSPACE_ROOT" in section and "/ws" in section
 
 
+def test_build_section_prefers_skill_request_over_cat_skill_md(tmp_path):
+    """A1 (#164): load path is skill_request, not cat .../SKILL.md as primary."""
+    skills = [
+        {"name": "ops", "title": "Ops", "description": "运维脚本", "abs_path": "/abs/ops"},
+        {"name": "web", "title": "Web", "description": "", "abs_path": "/abs/web"},
+    ]
+    section = msk.build_milkie_skills_section(skills, Path("/ws"))
+    assert "skill_request" in section
+    assert "instructions" in section
+    # Must not teach cat SKILL.md as the primary load path
+    assert 'cat "<技能目录>/SKILL.md"' not in section
+    assert "cat " not in section or "skill_request" in section
+    # Explicit ban on HOME/find discovery
+    assert "find" in section or "搜索" in section
+    # run_command still OK for scripts
+    assert "run_command" in section
+
+
 def test_build_section_nudges_enumeration_to_skill_list(tmp_path):
-    """列举意图引导到 skill_list 工具(确定性,防漏列;alfred#50)。"""
+    """A2: 列举意图引导到 skill_list 工具(确定性,防漏列;alfred#50)。"""
     skills = [{"name": "ops", "title": "Ops", "description": "运维", "abs_path": "/abs/ops"}]
     section = msk.build_milkie_skills_section(skills, Path("/ws"))
     assert "skill_list" in section            # 指向工具
@@ -95,8 +113,31 @@ def test_build_section_nudges_enumeration_to_skill_list(tmp_path):
 
 
 def test_build_section_empty_when_no_skills():
-    # 空技能集仍 ""（不渲染指令，行为不变）。
+    # A4: 空技能集仍 ""（不渲染指令，行为不变）。
     assert msk.build_milkie_skills_section([], Path("/ws")) == ""
+
+
+def test_discover_and_manifest_dir_uses_winning_priority_path(tmp_path, monkeypatch):
+    """A3 (#164): same-name skill — discover + manifest dir from high-priority path."""
+    from src.everbot.core.agent.provider.milkie.launcher import _render_skill_manifest
+
+    hi = tmp_path / "hi"
+    lo = tmp_path / "lo"
+    _make_skill(hi, "shared", "高优先级版", "workspace 版正文应胜出")
+    _make_skill(lo, "shared", "低优先级版", "全局版")
+    monkeypatch.setattr(msk, "resolve_skill_dirs", lambda _ws: [hi, lo])
+
+    found = msk.discover_skills(tmp_path)
+    by_name = {s["name"]: s for s in found}
+    assert by_name["shared"]["abs_path"] == str((hi / "shared").resolve())
+
+    manifest = _render_skill_manifest(found)
+    shared = next(s for s in manifest["skills"] if s["name"] == "shared")
+    assert shared["dir"] == str((hi / "shared").resolve())
+    # Winning body is the hi SKILL.md content
+    hi_body = (hi / "shared" / "SKILL.md").read_text(encoding="utf-8")
+    assert "workspace 版正文应胜出" in hi_body
+    assert "低优先级版" not in hi_body
 
 
 def _setup_three(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

- Host prompt (`build_milkie_skills_section`) steers agents to **`skill_request(name)`** for `instructions` + authoritative `dir`, not `find`/`cat` discovery of SKILL.md.
- Unit tests for prompt/closed-world guidance; E2E for real milkie sidecar hit/miss.
- Pairs with milkie runtime: https://github.com/xforce-io/milkie/pull/209

## Test plan

- [x] `tests/unit/test_milkie_skills.py`
- [x] `tests/e2e/test_milkie_skill_request_e2e.py` (when milkie binary/env available)
- [ ] Manual: spawn agent → skill_request installed skill → instructions+dir; unknown → not_found

Closes #164