### PR TITLE
【skills/web】search/extract 摘要卡 + content_id 全文追溯 (#161)

### DIFF
--- a/skills/web/SKILL.md
+++ b/skills/web/SKILL.md
@@ -27,16 +27,60 @@ $S "OpenAI latest news"
 # News search
 $S "Fed rate decision" --type news --timelimit d
 
-# Extract page text from top results
-$S "Python PEP 723" --extract --extract-top 2
+# Extract top pages → material cards (summary + content_id), not full text
+$S "Python PEP 723" --extract --extract-top 2 --output json
 
-# JSON output
-$S "TSLA delivery" --output json
+# Read one page of a cached extract (limit ≤ 6000 chars)
+python $SKILL_DIR/scripts/read_extract.py \
+  --content-id <64-hex> --offset 0 --limit 6000
 ```
 
-Arguments: `--backend auto|ddgs|tavily`, `--type text|news`, `--max-results N`, `--timelimit d|w|m|y`, `--extract`, `--extract-top N`, `--output text|json`, `--no-fallback`
+Arguments: `--backend auto|ddgs|tavily`, `--type text|news`, `--max-results N`, `--timelimit d|w|m|y`, `--extract`, `--extract-top N`, `--visible-chars N` (default 4000), `--output text|json`, `--no-fallback`, `--full-extract` (**debug only**)
 
-Env: `TAVILY_API_KEY` (optional, enables tavily backend)
+Env:
+
+- `TAVILY_API_KEY` (optional, enables tavily backend)
+- `ALFRED_WEB_EXTRACT_CACHE_DIR` (default `~/.alfred/cache/web-extract`)
+- `ALFRED_WEB_EXTRACT_CACHE_MAX_BYTES` (default 128 MiB)
+- `ALFRED_WEB_EXTRACT_VISIBLE_CHARS` (default 4000 when CLI not set)
+
+### Material cards (default extract output)
+
+With `--extract`, stdout is a **short structured material card**, not the full page body:
+
+- Fields: title, url, snippet, `extract.preview`, `extract.content_id`, `extract.chars_full`, `extract.read_command`, `stats`
+- All LLM-visible free text (`snippet` + `extract.preview`) shares a budget: default **≤ 4000** characters (`--visible-chars` / `ALFRED_WEB_EXTRACT_VISIBLE_CHARS`)
+- JSON is authoritative (`schema_version: 2`). `extracted_text` is a **deprecated** alias of `extract.preview` (compat only)
+- `materials_hint`: `extract_available` | `no_extract`
+  - `extract_available` only means **readable extract material exists**
+  - It does **not** mean the user's question is fully covered
+
+### Full text via content_id (paged read)
+
+1. Take `content_id` (`sha256:<hex>`) from a successful extract
+2. Page with `read_extract.py --content-id <hex> --offset N --limit 6000` (max limit **6000**)
+3. Loop `offset += limit` until `eof` / empty page; concatenate pages to restore the full body
+4. When quoting a passage, **cite the page's runtime objectId** from that `run_command` call — do **not** treat the summary-card objectId as a full-text handle
+
+**Never** `cat` cache files, invent filesystem paths, or pass `--all`. The reader only accepts a validated SHA-256 `content_id` and a safe range. Absolute cache paths are never printed.
+
+### Stop searching when materials suffice (agent judgment)
+
+After you already have **≥1 useful extract** (`materials_hint=extract_available`) and the materials cover:
+
+- key entities / claims needed for the task
+- freshness when time-sensitive
+- source diversity when required
+
+→ **stop** issuing more search queries and move to analysis. Coverage is judged by the agent, not by a forced binary “done” flag. Do not keep rotating queries just because more pages exist.
+
+### Relationship to #160 (run_command projection)
+
+Milkie/run_command may still apply a generic projection (e.g. `tail@8000`) and a raw stream cap (~30k). This skill **proactively** keeps default visible free text ≤ 4000 and requires paged reads for long bodies so agents do not rely on stuffing full extracts into one stdout.
+
+### Debug escape hatch
+
+`--full-extract` dumps large extract text into stdout for offline debugging only. **Do not use it in agent runtime** as a cite/trace path — it inflates context and may still be truncated by #160 projection.
 
 ---
 

--- a/skills/web/scripts/extract_cache.py
+++ b/skills/web/scripts/extract_cache.py
@@ -1,0 +1,354 @@
+"""Content-addressed cache for web extract full text.
+
+Stores normalized UTF-8 page bodies under a governed local directory.
+Paths are derived only from SHA-256 hex; callers never receive absolute paths
+in public APIs. Concurrent writers use atomic rename; capacity is enforced
+with LRU eviction (entries currently pinned for I/O are not evicted).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+import tempfile
+import threading
+import time
+from pathlib import Path
+
+DEFAULT_CACHE_MAX_BYTES = 128 * 1024 * 1024  # 128 MiB
+MAX_READ_LIMIT = 6000
+CONTENT_ID_RE = re.compile(r"^(?:sha256:)?([0-9a-f]{64})$")
+
+
+class CacheError(Exception):
+    """Base cache error (messages must not leak absolute paths)."""
+
+
+class CacheFullError(CacheError):
+    """Raised when the cache cannot free enough space to store new content."""
+
+    code = "cache_full"
+
+
+class CacheUnavailableError(CacheError):
+    """Raised when the cache root is not usable (permissions, etc.)."""
+
+    code = "cache_unavailable"
+
+
+class InvalidContentIdError(CacheError):
+    """Raised when content_id fails strict validation."""
+
+    code = "invalid_content_id"
+
+
+class NotFoundError(CacheError):
+    """Raised when content_id is valid but not present (or corrupted)."""
+
+    code = "not_found"
+
+
+class InvalidRangeError(CacheError):
+    """Raised for illegal offset/limit values."""
+
+    code = "invalid_range"
+
+
+def normalize_text(text: str) -> str:
+    """Normalize extract body: collapse whitespace, strip edges."""
+    return " ".join(text.split())
+
+
+def content_hash_hex(text: str) -> str:
+    """Return SHA-256 hex of normalized UTF-8 bytes."""
+    data = normalize_text(text).encode("utf-8")
+    return hashlib.sha256(data).hexdigest()
+
+
+def format_content_id(hex_digest: str) -> str:
+    """Format as sha256:<hex>."""
+    return f"sha256:{hex_digest}"
+
+
+def parse_content_id(content_id: str) -> str:
+    """Parse and validate content_id; return 64-char lowercase hex.
+
+    Rejects paths, uppercase-only mixed garbage, non-hex, wrong length.
+    """
+    if not isinstance(content_id, str) or not content_id:
+        raise InvalidContentIdError("invalid content_id")
+    # Reject path-like input early
+    if "/" in content_id or "\\" in content_id or ".." in content_id:
+        raise InvalidContentIdError("invalid content_id")
+    match = CONTENT_ID_RE.match(content_id.strip())
+    if not match:
+        raise InvalidContentIdError("invalid content_id")
+    return match.group(1)
+
+
+def default_cache_root() -> Path:
+    env = os.environ.get("ALFRED_WEB_EXTRACT_CACHE_DIR")
+    if env:
+        return Path(env).expanduser()
+    return Path.home() / ".alfred" / "cache" / "web-extract"
+
+
+def default_max_bytes() -> int:
+    env = os.environ.get("ALFRED_WEB_EXTRACT_CACHE_MAX_BYTES")
+    if env:
+        try:
+            return int(env)
+        except ValueError:
+            return DEFAULT_CACHE_MAX_BYTES
+    return DEFAULT_CACHE_MAX_BYTES
+
+
+class ExtractCache:
+    """Content-addressed extract body store with LRU capacity control."""
+
+    def __init__(
+        self,
+        root: Path | None = None,
+        max_bytes: int | None = None,
+    ) -> None:
+        self.root = Path(root) if root is not None else default_cache_root()
+        self.max_bytes = max_bytes if max_bytes is not None else default_max_bytes()
+        self._lock = threading.RLock()
+        self._pins: dict[str, int] = {}  # hex -> pin count
+        self._ensure_root()
+
+    def _ensure_root(self) -> None:
+        try:
+            self.root.mkdir(parents=True, exist_ok=True)
+            os.chmod(self.root, 0o700)
+        except OSError as exc:
+            raise CacheUnavailableError("cache unavailable") from exc
+
+    def _path_for_hex(self, hex_digest: str) -> Path:
+        # Only hex segments — never user-controlled relative paths.
+        return self.root / hex_digest[0:2] / hex_digest[2:4] / f"{hex_digest}.txt"
+
+    def _pin(self, hex_digest: str) -> None:
+        self._pins[hex_digest] = self._pins.get(hex_digest, 0) + 1
+
+    def _unpin(self, hex_digest: str) -> None:
+        count = self._pins.get(hex_digest, 0)
+        if count <= 1:
+            self._pins.pop(hex_digest, None)
+        else:
+            self._pins[hex_digest] = count - 1
+
+    def _is_pinned(self, hex_digest: str) -> bool:
+        return self._pins.get(hex_digest, 0) > 0
+
+    def _iter_entries(self) -> list[tuple[str, Path, int, float]]:
+        """Return (hex, path, size, atime) for all body files."""
+        entries: list[tuple[str, Path, int, float]] = []
+        if not self.root.exists():
+            return entries
+        for path in self.root.rglob("*.txt"):
+            name = path.name
+            if not name.endswith(".txt"):
+                continue
+            hex_digest = name[:-4]
+            if not re.fullmatch(r"[0-9a-f]{64}", hex_digest):
+                continue
+            try:
+                st = path.stat()
+            except OSError:
+                continue
+            entries.append((hex_digest, path, st.st_size, st.st_atime))
+        return entries
+
+    def _total_bytes(self) -> int:
+        return sum(size for _, _, size, _ in self._iter_entries())
+
+    def _touch(self, path: Path) -> None:
+        now = time.time()
+        try:
+            os.utime(path, (now, now))
+        except OSError:
+            pass
+
+    def _evict_until(self, need_bytes: int) -> None:
+        """Evict LRU unpinned entries until free space can hold need_bytes."""
+        while True:
+            total = self._total_bytes()
+            if total + need_bytes <= self.max_bytes:
+                return
+            candidates = [
+                e
+                for e in self._iter_entries()
+                if not self._is_pinned(e[0])
+            ]
+            if not candidates:
+                raise CacheFullError("cache_full")
+            # Oldest access time first
+            candidates.sort(key=lambda e: e[3])
+            victim_hex, victim_path, _, _ = candidates[0]
+            try:
+                victim_path.unlink(missing_ok=True)
+                # Clean empty shard dirs (best-effort)
+                parent = victim_path.parent
+                try:
+                    if parent.is_dir() and not any(parent.iterdir()):
+                        parent.rmdir()
+                    grand = parent.parent
+                    if grand.is_dir() and not any(grand.iterdir()) and grand != self.root:
+                        grand.rmdir()
+                except OSError:
+                    pass
+            except OSError:
+                # If we cannot unlink, treat as pinned/unavailable for eviction
+                raise CacheFullError("cache_full")
+
+    def store(self, text: str) -> str:
+        """Normalize UTF-8, SHA-256, atomic write; return content_id.
+
+        On hash hit: touch access time and return existing id.
+        Raises CacheFullError | CacheUnavailableError.
+        """
+        if not isinstance(text, str):
+            raise CacheError("text must be str")
+        normalized = normalize_text(text)
+        if not normalized:
+            raise CacheError("empty text")
+
+        data = normalized.encode("utf-8")
+        hex_digest = hashlib.sha256(data).hexdigest()
+        content_id = format_content_id(hex_digest)
+        path = self._path_for_hex(hex_digest)
+
+        with self._lock:
+            self._ensure_root()
+            self._pin(hex_digest)
+            try:
+                if path.is_file():
+                    # Verify integrity; repair if corrupt
+                    try:
+                        existing = path.read_bytes()
+                        if hashlib.sha256(existing).hexdigest() == hex_digest:
+                            self._touch(path)
+                            return content_id
+                        path.unlink(missing_ok=True)
+                    except OSError:
+                        path.unlink(missing_ok=True)
+
+                need = len(data)
+                if need > self.max_bytes:
+                    raise CacheFullError("cache_full")
+                self._evict_until(need)
+
+                try:
+                    path.parent.mkdir(parents=True, exist_ok=True)
+                    # Ensure shard dirs are restrictive when created under root
+                    for p in (path.parent.parent, path.parent):
+                        try:
+                            os.chmod(p, 0o700)
+                        except OSError:
+                            pass
+
+                    fd, tmp_name = tempfile.mkstemp(
+                        prefix=f".{hex_digest}.",
+                        suffix=".tmp",
+                        dir=str(path.parent),
+                    )
+                    try:
+                        with os.fdopen(fd, "wb") as tmp:
+                            tmp.write(data)
+                            tmp.flush()
+                            os.fsync(tmp.fileno())
+                        os.chmod(tmp_name, 0o600)
+                        os.replace(tmp_name, path)
+                        os.chmod(path, 0o600)
+                    except Exception:
+                        try:
+                            os.unlink(tmp_name)
+                        except OSError:
+                            pass
+                        raise
+
+                    # Post-write hash check
+                    written = path.read_bytes()
+                    if hashlib.sha256(written).hexdigest() != hex_digest:
+                        path.unlink(missing_ok=True)
+                        raise CacheUnavailableError("cache unavailable")
+                    self._touch(path)
+                    return content_id
+                except CacheError:
+                    raise
+                except OSError as exc:
+                    raise CacheUnavailableError("cache unavailable") from exc
+            finally:
+                self._unpin(hex_digest)
+
+    def read_range(self, content_id: str, offset: int, limit: int) -> str:
+        """Return text[offset:offset+limit] by Unicode character index."""
+        if not isinstance(offset, int) or offset < 0:
+            raise InvalidRangeError("invalid range")
+        if not isinstance(limit, int) or limit < 1 or limit > MAX_READ_LIMIT:
+            raise InvalidRangeError("invalid range")
+
+        hex_digest = parse_content_id(content_id)
+        path = self._path_for_hex(hex_digest)
+
+        with self._lock:
+            self._pin(hex_digest)
+            try:
+                if not path.is_file():
+                    raise NotFoundError("not found")
+                try:
+                    raw = path.read_bytes()
+                except OSError as exc:
+                    raise CacheUnavailableError("cache unavailable") from exc
+
+                if hashlib.sha256(raw).hexdigest() != hex_digest:
+                    path.unlink(missing_ok=True)
+                    raise NotFoundError("not found")
+
+                text = raw.decode("utf-8")
+                self._touch(path)
+                return text[offset : offset + limit]
+            finally:
+                self._unpin(hex_digest)
+
+    def full_char_len(self, content_id: str) -> int:
+        """Return Unicode character length of stored body."""
+        hex_digest = parse_content_id(content_id)
+        path = self._path_for_hex(hex_digest)
+        with self._lock:
+            self._pin(hex_digest)
+            try:
+                if not path.is_file():
+                    raise NotFoundError("not found")
+                try:
+                    raw = path.read_bytes()
+                except OSError as exc:
+                    raise CacheUnavailableError("cache unavailable") from exc
+                if hashlib.sha256(raw).hexdigest() != hex_digest:
+                    path.unlink(missing_ok=True)
+                    raise NotFoundError("not found")
+                text = raw.decode("utf-8")
+                self._touch(path)
+                return len(text)
+            finally:
+                self._unpin(hex_digest)
+
+    def full_text(self, content_id: str) -> str:
+        """Return full stored text (for tests / internal use)."""
+        hex_digest = parse_content_id(content_id)
+        path = self._path_for_hex(hex_digest)
+        with self._lock:
+            self._pin(hex_digest)
+            try:
+                if not path.is_file():
+                    raise NotFoundError("not found")
+                raw = path.read_bytes()
+                if hashlib.sha256(raw).hexdigest() != hex_digest:
+                    path.unlink(missing_ok=True)
+                    raise NotFoundError("not found")
+                self._touch(path)
+                return raw.decode("utf-8")
+            finally:
+                self._unpin(hex_digest)

--- a/skills/web/scripts/read_extract.py
+++ b/skills/web/scripts/read_extract.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Paged reader for web extract cache (content_id + offset/limit only)."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+# Allow running as script: ensure scripts dir on path
+_SCRIPTS = Path(__file__).resolve().parent
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+from extract_cache import (  # noqa: E402
+    MAX_READ_LIMIT,
+    CacheError,
+    ExtractCache,
+    InvalidContentIdError,
+    InvalidRangeError,
+    NotFoundError,
+    format_content_id,
+    parse_content_id,
+)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Read a page of cached web extract text by content_id",
+    )
+    parser.add_argument(
+        "--content-id",
+        required=True,
+        help="sha256 hex or sha256:<hex>",
+    )
+    parser.add_argument(
+        "--offset",
+        type=int,
+        required=True,
+        help="Unicode character offset (>= 0)",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        required=True,
+        help=f"Max characters to return (1..{MAX_READ_LIMIT})",
+    )
+    parser.add_argument(
+        "--output",
+        choices=["text", "json"],
+        default="text",
+        help="Output format",
+    )
+    # Explicitly do not support --all or path args
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    if args.offset < 0:
+        print("invalid range: offset must be >= 0", file=sys.stderr)
+        return 2
+    if args.limit < 1 or args.limit > MAX_READ_LIMIT:
+        print(
+            f"invalid range: limit must be 1..{MAX_READ_LIMIT}",
+            file=sys.stderr,
+        )
+        return 2
+
+    try:
+        hex_digest = parse_content_id(args.content_id)
+    except InvalidContentIdError:
+        print("invalid content_id", file=sys.stderr)
+        return 2
+
+    content_id = format_content_id(hex_digest)
+    cache = ExtractCache()
+
+    try:
+        chars_full = cache.full_char_len(content_id)
+        text = cache.read_range(content_id, args.offset, args.limit)
+    except InvalidContentIdError:
+        print("invalid content_id", file=sys.stderr)
+        return 2
+    except InvalidRangeError:
+        print("invalid range", file=sys.stderr)
+        return 2
+    except NotFoundError:
+        print("not found", file=sys.stderr)
+        return 1
+    except CacheError as exc:
+        code = getattr(exc, "code", "cache_error")
+        print(code, file=sys.stderr)
+        return 1
+
+    eof = args.offset + len(text) >= chars_full or args.offset >= chars_full
+
+    if args.output == "json":
+        payload = {
+            "content_id": content_id,
+            "offset": args.offset,
+            "limit": args.limit,
+            "chars_full": chars_full,
+            "chars_returned": len(text),
+            "eof": eof,
+            "text": text,
+        }
+        print(json.dumps(payload, ensure_ascii=False, indent=2))
+    else:
+        # Pure fragment for agent citation
+        sys.stdout.write(text)
+        if text and not text.endswith("\n"):
+            sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/web/scripts/search.py
+++ b/skills/web/scripts/search.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
-"""Unified multi-backend web search CLI for agent workflows."""
+"""Unified multi-backend web search CLI for agent workflows.
+
+Default extract path stores full page text in a content-addressed cache and
+returns a short structured material card (shared visible text budget).
+"""
 
 from __future__ import annotations
 
@@ -8,14 +12,48 @@ import json
 import logging
 import os
 import sys
-from dataclasses import asdict, dataclass
-from typing import Iterable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable
+
+# Allow running as script
+_SCRIPTS = Path(__file__).resolve().parent
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+from extract_cache import (  # noqa: E402
+    CacheError,
+    CacheFullError,
+    CacheUnavailableError,
+    ExtractCache,
+    MAX_READ_LIMIT,
+    format_content_id,
+    normalize_text,
+    parse_content_id,
+)
 
 logger = logging.getLogger(__name__)
+
+DEFAULT_VISIBLE_CHARS = 4000
+TITLE_MAX = 300
+URL_MAX = 2000
+META_MAX = 200
+SCHEMA_VERSION = 2
 
 
 class SearchError(RuntimeError):
     """Raised when a backend search operation fails."""
+
+
+@dataclass
+class ExtractInfo:
+    """Successful extract payload for one result."""
+
+    preview: str
+    preview_truncated: bool
+    chars_full: int
+    content_id: str
+    read_command: str
 
 
 @dataclass
@@ -30,7 +68,12 @@ class SearchResult:
     backend: str
     search_type: str
     rank: int
-    extracted_text: str | None = None
+    extracted_text: str | None = None  # deprecated alias of extract.preview
+    extract: ExtractInfo | None = None
+    extract_error: str | None = None
+    snippet_truncated: bool = False
+    # Internal: full text held until budget allocation (not serialized raw)
+    _full_text: str | None = field(default=None, repr=False, compare=False)
 
 
 @dataclass
@@ -45,19 +88,54 @@ class SearchResponse:
     count: int
     results: list[SearchResult]
     errors: list[dict]
+    materials_hint: str = "no_extract"
+    stats: dict[str, int] | None = None
+    schema_version: int = SCHEMA_VERSION
 
     def to_dict(self) -> dict:
-        """Return a JSON-serializable response."""
-        return {
+        """Return a JSON-serializable response (schema v2)."""
+        results_out: list[dict[str, Any]] = []
+        for item in self.results:
+            entry: dict[str, Any] = {
+                "title": item.title,
+                "url": item.url,
+                "snippet": item.snippet,
+                "snippet_truncated": item.snippet_truncated,
+                "source": item.source,
+                "published": item.published,
+                "backend": item.backend,
+                "search_type": item.search_type,
+                "rank": item.rank,
+                "extract": None,
+                "extracted_text": item.extracted_text,
+                "extract_error": item.extract_error,
+            }
+            if item.extract is not None:
+                entry["extract"] = {
+                    "preview": item.extract.preview,
+                    "preview_truncated": item.extract.preview_truncated,
+                    "chars_full": item.extract.chars_full,
+                    "content_id": item.extract.content_id,
+                    "read_command": item.extract.read_command,
+                }
+            results_out.append(entry)
+
+        payload: dict[str, Any] = {
+            "schema_version": self.schema_version,
             "ok": self.ok,
             "query": self.query,
             "search_type": self.search_type,
             "backend": self.backend,
             "attempted_backends": self.attempted_backends,
             "count": self.count,
-            "results": [asdict(item) for item in self.results],
+            "result_count": self.count,
+            "materials_hint": self.materials_hint,
+            "results": results_out,
             "errors": self.errors,
         }
+        if self.stats is not None:
+            payload["stats"] = self.stats
+        return payload
 
 
 class BaseBackend:
@@ -228,6 +306,130 @@ def normalize_url(url: str) -> str:
     return url.strip().rstrip("/").lower()
 
 
+def truncate_field(value: str | None, max_len: int) -> str | None:
+    """Truncate a short metadata field to a conservative max length."""
+    if value is None:
+        return None
+    if len(value) <= max_len:
+        return value
+    return value[:max_len]
+
+
+def clamp_short_fields(results: list[SearchResult]) -> None:
+    """Apply independent caps on title/url/source/published."""
+    for item in results:
+        item.title = truncate_field(item.title or "", TITLE_MAX) or ""
+        item.url = truncate_field(item.url or "", URL_MAX) or ""
+        item.source = truncate_field(item.source, META_MAX)
+        item.published = truncate_field(item.published, META_MAX)
+
+
+def resolve_visible_budget(args: argparse.Namespace | None = None) -> int:
+    """CLI --visible-chars > env > default 4000."""
+    if args is not None:
+        cli_val = getattr(args, "visible_chars", None)
+        if cli_val is not None:
+            return max(0, int(cli_val))
+    env = os.environ.get("ALFRED_WEB_EXTRACT_VISIBLE_CHARS")
+    if env:
+        try:
+            return max(0, int(env))
+        except ValueError:
+            pass
+    return DEFAULT_VISIBLE_CHARS
+
+
+def make_read_command(content_id: str) -> str:
+    """Build portable read_command using $SKILL_DIR (no absolute paths)."""
+    hex_digest = parse_content_id(content_id)
+    return (
+        f"python $SKILL_DIR/scripts/read_extract.py "
+        f"--content-id {hex_digest} --offset 0 --limit {MAX_READ_LIMIT}"
+    )
+
+
+def allocate_visible_text(
+    results: list[SearchResult],
+    budget: int,
+    *,
+    full_extract: bool = False,
+) -> dict[str, int]:
+    """Allocate shared snippet+preview budget by rank ascending.
+
+    Mutates results in place. Returns stats dict with visible_text_chars,
+    visible_text_budget, and full_chars_total.
+    """
+    remaining = max(0, budget)
+    full_chars_total = 0
+    visible = 0
+
+    for item in sorted(results, key=lambda r: r.rank):
+        snip_src = item.snippet or ""
+        if len(snip_src) <= remaining:
+            item.snippet = snip_src
+            item.snippet_truncated = False
+            remaining -= len(item.snippet)
+            visible += len(item.snippet)
+        else:
+            item.snippet = snip_src[:remaining]
+            item.snippet_truncated = True
+            visible += len(item.snippet)
+            remaining = 0
+
+        if item.extract is None and item._full_text is None:
+            continue
+
+        full_body = item._full_text
+        if full_body is None and item.extract is not None:
+            preview = item.extract.preview
+            full_chars_total += item.extract.chars_full
+            visible += len(preview)
+            item.extracted_text = preview
+            continue
+
+        assert full_body is not None
+        chars_full = len(full_body)
+        full_chars_total += chars_full
+
+        if full_extract:
+            preview = full_body
+            truncated = False
+        elif remaining <= 0:
+            preview = ""
+            truncated = chars_full > 0
+        elif len(full_body) <= remaining:
+            preview = full_body
+            truncated = False
+            remaining -= len(preview)
+        else:
+            preview = full_body[:remaining]
+            truncated = True
+            remaining = 0
+
+        visible += len(preview)
+
+        content_id = item.extract.content_id if item.extract is not None else ""
+        read_command = (
+            item.extract.read_command
+            if item.extract is not None
+            else (make_read_command(content_id) if content_id else "")
+        )
+        item.extract = ExtractInfo(
+            preview=preview,
+            preview_truncated=truncated,
+            chars_full=chars_full,
+            content_id=content_id,
+            read_command=read_command,
+        )
+        item.extracted_text = preview
+
+    return {
+        "visible_text_chars": visible,
+        "visible_text_budget": budget,
+        "full_chars_total": full_chars_total,
+    }
+
+
 def build_backend_order(selected: str) -> list[str]:
     """Resolve backend order for the requested mode."""
     if selected != "auto":
@@ -240,7 +442,12 @@ def build_backend_order(selected: str) -> list[str]:
     return order
 
 
-def search_with_fallback(args: argparse.Namespace, backend_map: dict[str, BaseBackend]) -> SearchResponse:
+def search_with_fallback(
+    args: argparse.Namespace,
+    backend_map: dict[str, BaseBackend],
+    *,
+    cache: ExtractCache | None = None,
+) -> SearchResponse:
     """Try backends in order until one succeeds."""
     attempted: list[str] = []
     errors: list[dict] = []
@@ -259,8 +466,29 @@ def search_with_fallback(args: argparse.Namespace, backend_map: dict[str, BaseBa
 
         try:
             results = backend.search(args)
+            clamp_short_fields(results)
+            budget = resolve_visible_budget(args)
+            full_extract = bool(getattr(args, "full_extract", False))
+
             if args.extract and results:
-                extract_result_pages(results, top_n=args.extract_top, timeout=args.timeout)
+                extract_result_pages(
+                    results,
+                    top_n=args.extract_top,
+                    timeout=args.timeout,
+                    cache=cache,
+                )
+
+            stats = allocate_visible_text(
+                results,
+                budget,
+                full_extract=full_extract and bool(args.extract),
+            )
+            materials_hint = (
+                "extract_available"
+                if any(r.extract is not None for r in results)
+                else "no_extract"
+            )
+
             return SearchResponse(
                 ok=True,
                 query=args.query,
@@ -270,9 +498,14 @@ def search_with_fallback(args: argparse.Namespace, backend_map: dict[str, BaseBa
                 count=len(results),
                 results=results,
                 errors=errors,
+                materials_hint=materials_hint,
+                stats=stats,
             )
         except SearchError as exc:
-            logger.warning("Search backend failed", extra={"backend": backend_name, "error": str(exc)})
+            logger.warning(
+                "Search backend failed",
+                extra={"backend": backend_name, "error": str(exc)},
+            )
             errors.append({"backend": backend_name, "error": str(exc)})
 
     return SearchResponse(
@@ -284,40 +517,109 @@ def search_with_fallback(args: argparse.Namespace, backend_map: dict[str, BaseBa
         count=0,
         results=[],
         errors=errors,
+        materials_hint="no_extract",
+        stats={
+            "visible_text_chars": 0,
+            "visible_text_budget": resolve_visible_budget(args),
+            "full_chars_total": 0,
+        },
     )
 
 
-def extract_result_pages(results: list[SearchResult], top_n: int, timeout: int) -> None:
-    """Fetch and extract readable text from top result pages."""
-    requests = _load_requests()
-    BeautifulSoup = _load_bs4()
+def extract_result_pages(
+    results: list[SearchResult],
+    top_n: int,
+    timeout: int,
+    cache: ExtractCache | None = None,
+    *,
+    html_fetcher=None,
+) -> None:
+    """Fetch and extract readable text from top result pages; store full text.
 
+    On success sets item.extract skeleton (preview filled later by budget) and
+    item._full_text. On failure sets extract=None and extract_error.
+    """
+    cache = cache or ExtractCache()
     limit = max(0, min(top_n, len(results)))
+
     for item in results[:limit]:
         try:
-            response = requests.get(
-                item.url,
-                headers={"User-Agent": "Mozilla/5.0 (everbot-web-search)"},
-                timeout=timeout,
-            )
-            response.raise_for_status()
-            soup = BeautifulSoup(response.text, "html.parser")
+            if html_fetcher is not None:
+                html = html_fetcher(item.url)
+            else:
+                requests = _load_requests()
+                response = requests.get(
+                    item.url,
+                    headers={"User-Agent": "Mozilla/5.0 (everbot-web-search)"},
+                    timeout=timeout,
+                )
+                response.raise_for_status()
+                html = response.text
+
+            BeautifulSoup = _load_bs4()
+            soup = BeautifulSoup(html, "html.parser")
             for tag in soup(["script", "style", "noscript"]):
                 tag.decompose()
-            text = " ".join(soup.get_text(" ", strip=True).split())
-            item.extracted_text = text[:1200] if text else None
+            text = normalize_text(soup.get_text(" ", strip=True))
+            if not text:
+                item.extract = None
+                item.extracted_text = None
+                item.extract_error = "empty_body"
+                item._full_text = None
+                continue
+
+            try:
+                content_id = cache.store(text)
+            except CacheFullError:
+                item.extract = None
+                item.extracted_text = None
+                item.extract_error = "cache_full"
+                item._full_text = None
+                continue
+            except CacheUnavailableError:
+                item.extract = None
+                item.extracted_text = None
+                item.extract_error = "cache_unavailable"
+                item._full_text = None
+                continue
+            except CacheError:
+                item.extract = None
+                item.extracted_text = None
+                item.extract_error = "cache_error"
+                item._full_text = None
+                continue
+
+            # Stored text may re-normalize identically
+            stored = normalize_text(text)
+            item._full_text = stored
+            item.extract = ExtractInfo(
+                preview="",  # filled by allocate_visible_text
+                preview_truncated=True,
+                chars_full=len(stored),
+                content_id=content_id,
+                read_command=make_read_command(content_id),
+            )
+            item.extracted_text = None  # set after budget
+            item.extract_error = None
         except Exception as exc:  # pragma: no cover - network behavior
+            item.extract = None
             item.extracted_text = None
-            logger.warning("Page extraction failed", extra={"url": item.url, "error": str(exc)})
+            item.extract_error = "extract_failed"
+            item._full_text = None
+            logger.warning(
+                "Page extraction failed",
+                extra={"url": item.url, "error": str(exc)},
+            )
 
 
 def format_text(response: SearchResponse) -> str:
-    """Render a human-readable text report."""
+    """Render a human-readable text report (material card style)."""
     lines = [
         f"Query: {response.query}",
         f"Type: {response.search_type}",
         f"Backend: {response.backend or 'none'}",
         f"Results: {response.count}",
+        f"materials_hint: {response.materials_hint}",
     ]
     if response.errors:
         lines.append("Errors:")
@@ -334,8 +636,23 @@ def format_text(response: SearchResponse) -> str:
             lines.append(f"Published: {item.published}")
         if item.snippet:
             lines.append(f"Snippet: {item.snippet}")
-        if item.extracted_text:
+        if item.extract is not None:
+            lines.append(f"Extracted: {item.extract.preview}")
+            lines.append(f"content_id: {item.extract.content_id}")
+            lines.append(f"Read: {item.extract.read_command}")
+            lines.append(f"chars_full: {item.extract.chars_full}")
+        elif item.extract_error:
+            lines.append(f"extract_error: {item.extract_error}")
+        elif item.extracted_text:
             lines.append(f"Extracted: {item.extracted_text}")
+
+    if response.stats:
+        lines.append("")
+        lines.append(
+            "Stats: "
+            f"visible_text_chars={response.stats.get('visible_text_chars', 0)} "
+            f"full_chars_total={response.stats.get('full_chars_total', 0)}"
+        )
     return "\n".join(lines)
 
 
@@ -368,6 +685,17 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--timeout", type=int, default=15, help="HTTP timeout in seconds")
     parser.add_argument("--extract", action="store_true", help="Extract readable page text")
     parser.add_argument("--extract-top", type=int, default=2, help="Number of top results to extract")
+    parser.add_argument(
+        "--visible-chars",
+        type=int,
+        default=None,
+        help=f"Shared snippet+preview budget (default {DEFAULT_VISIBLE_CHARS})",
+    )
+    parser.add_argument(
+        "--full-extract",
+        action="store_true",
+        help="DEBUG only: include full extract text in stdout (not for agent cite path)",
+    )
     parser.add_argument(
         "--no-fallback",
         dest="fallback",

--- a/skills/web/tests/conftest.py
+++ b/skills/web/tests/conftest.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-
 _scripts_dir = str(Path(__file__).resolve().parent.parent / "scripts")
 if _scripts_dir not in sys.path:
     sys.path.insert(0, _scripts_dir)

--- a/skills/web/tests/test_budget_schema.py
+++ b/skills/web/tests/test_budget_schema.py
@@ -1,0 +1,174 @@
+"""Unit tests for visible budget, schema v2, materials_hint (U1–U7)."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from extract_cache import ExtractCache
+from search import (
+    ExtractInfo,
+    SearchResult,
+    allocate_visible_text,
+    clamp_short_fields,
+    make_read_command,
+    resolve_visible_budget,
+)
+
+
+def _result(rank: int, snippet: str, full: str | None = None, content_id: str | None = None):
+    r = SearchResult(
+        title=f"T{rank}",
+        url=f"https://example.com/{rank}",
+        snippet=snippet,
+        source=None,
+        published=None,
+        backend="ddgs",
+        search_type="text",
+        rank=rank,
+    )
+    if full is not None:
+        cid = content_id or f"sha256:{'a' * 64}"
+        r._full_text = full
+        r.extract = ExtractInfo(
+            preview="",
+            preview_truncated=True,
+            chars_full=len(full),
+            content_id=cid,
+            read_command=make_read_command(cid),
+        )
+    return r
+
+
+def test_u1_budget_rank_priority():
+    r1 = _result(1, "S" * 100, full="P" * 5000)
+    r2 = _result(2, "Q" * 100, full="R" * 5000)
+    stats = allocate_visible_text([r1, r2], budget=400)
+    assert stats["visible_text_chars"] <= 400
+    # Rank1 gets snippet + some preview first
+    assert len(r1.snippet) + len(r1.extract.preview) >= len(r2.snippet) + len(
+        r2.extract.preview
+    )
+    # Budget exhausted: rank2 preview empty or truncated hard
+    assert r2.extract.preview_truncated is True or r2.extract.preview == ""
+    if stats["visible_text_chars"] == 400:
+        # remaining after r1 should leave little for r2
+        assert len(r2.extract.preview) < 5000
+
+
+def test_u2_visible_text_chars_matches_fields():
+    r1 = _result(1, "abc", full="defghij")
+    r2 = _result(2, "xyz", full="12345")
+    stats = allocate_visible_text([r1, r2], budget=1000)
+    actual = (
+        len(r1.snippet)
+        + len(r1.extract.preview)
+        + len(r2.snippet)
+        + len(r2.extract.preview)
+    )
+    assert stats["visible_text_chars"] == actual
+    assert stats["visible_text_chars"] <= 1000
+    assert stats["full_chars_total"] == len(r1._full_text) + len(r2._full_text)
+
+
+def test_u1_budget_exhausted_empty_preview():
+    r1 = _result(1, "S" * 300, full="BODY" * 100)
+    r2 = _result(2, "T" * 300, full="MORE" * 100)
+    stats = allocate_visible_text([r1, r2], budget=350)
+    assert stats["visible_text_chars"] <= 350
+    # r2 may have truncated snippet and empty preview
+    if len(r1.snippet) + len(r1.extract.preview) >= 350:
+        assert r2.extract.preview == ""
+        assert r2.extract.preview_truncated is True
+
+
+def test_u3_u4_schema_via_to_dict(tmp_path: Path):
+    from search import SearchResponse
+
+    r = _result(1, "snip", full="full body text here")
+    allocate_visible_text([r], budget=4000)
+    resp = SearchResponse(
+        ok=True,
+        query="q",
+        search_type="text",
+        backend="ddgs",
+        attempted_backends=["ddgs"],
+        count=1,
+        results=[r],
+        errors=[],
+        materials_hint="extract_available",
+        stats={
+            "visible_text_chars": len(r.snippet) + len(r.extract.preview),
+            "visible_text_budget": 4000,
+            "full_chars_total": r.extract.chars_full,
+        },
+    )
+    d = resp.to_dict()
+    assert d["schema_version"] == 2
+    assert d["materials_hint"] == "extract_available"
+    assert d["result_count"] == d["count"] == 1
+    assert "stats" in d
+    ex = d["results"][0]["extract"]
+    assert ex is not None
+    assert ex["content_id"].startswith("sha256:")
+    assert "read_command" in ex
+    assert "$SKILL_DIR" in ex["read_command"]
+    # U4 deprecated alias
+    assert d["results"][0]["extracted_text"] == ex["preview"]
+
+
+def test_u6_materials_hint_no_extract():
+    from search import SearchResponse
+
+    r = _result(1, "only snip")
+    allocate_visible_text([r], budget=4000)
+    resp = SearchResponse(
+        ok=True,
+        query="q",
+        search_type="text",
+        backend="ddgs",
+        attempted_backends=["ddgs"],
+        count=1,
+        results=[r],
+        errors=[],
+        materials_hint="no_extract",
+        stats={"visible_text_chars": len(r.snippet), "visible_text_budget": 4000, "full_chars_total": 0},
+    )
+    assert resp.to_dict()["materials_hint"] == "no_extract"
+    assert resp.to_dict()["results"][0]["extract"] is None
+
+
+def test_u7_short_field_truncation():
+    r = SearchResult(
+        title="T" * 500,
+        url="https://example.com/" + "u" * 3000,
+        snippet="s",
+        source="src" * 100,
+        published="pub" * 100,
+        backend="ddgs",
+        search_type="text",
+        rank=1,
+    )
+    clamp_short_fields([r])
+    assert len(r.title) <= 300
+    assert len(r.url) <= 2000
+    assert len(r.source) <= 200
+    assert len(r.published) <= 200
+
+
+def test_resolve_visible_budget_priority(monkeypatch):
+    monkeypatch.delenv("ALFRED_WEB_EXTRACT_VISIBLE_CHARS", raising=False)
+    args = argparse.Namespace(visible_chars=None)
+    assert resolve_visible_budget(args) == 4000
+    monkeypatch.setenv("ALFRED_WEB_EXTRACT_VISIBLE_CHARS", "1234")
+    assert resolve_visible_budget(args) == 1234
+    args.visible_chars = 99
+    assert resolve_visible_budget(args) == 99
+
+
+def test_preview_truncated_flag_when_cut():
+    r = _result(1, "", full="X" * 1000)
+    allocate_visible_text([r], budget=100)
+    assert r.extract.preview_truncated is True
+    assert len(r.extract.preview) == 100
+    assert r.extract.chars_full == 1000

--- a/skills/web/tests/test_extract_cache.py
+++ b/skills/web/tests/test_extract_cache.py
@@ -1,0 +1,212 @@
+"""Integration/unit tests for ExtractCache (I1–I5, I7–I8, U5, U8)."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import stat
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+
+from extract_cache import (
+    MAX_READ_LIMIT,
+    CacheFullError,
+    ExtractCache,
+    InvalidContentIdError,
+    InvalidRangeError,
+    NotFoundError,
+    content_hash_hex,
+    format_content_id,
+    parse_content_id,
+)
+
+
+def test_u5_content_id_format_and_stability(tmp_path: Path):
+    cache = ExtractCache(root=tmp_path / "c", max_bytes=10 * 1024 * 1024)
+    body = "Hello world extract body " * 50
+    cid1 = cache.store(body)
+    cid2 = cache.store(body)
+    assert cid1 == cid2
+    assert cid1.startswith("sha256:")
+    hex_part = cid1.split(":", 1)[1]
+    assert len(hex_part) == 64
+    assert all(c in "0123456789abcdef" for c in hex_part)
+    expected = content_hash_hex(body)
+    assert hex_part == expected
+
+
+def test_i1_dedupe_single_file(tmp_path: Path):
+    cache = ExtractCache(root=tmp_path / "c", max_bytes=10 * 1024 * 1024)
+    body = "same content " * 100
+    cid = cache.store(body)
+    cache.store(body)
+    hex_digest = cid.split(":")[1]
+    files = list((tmp_path / "c").rglob("*.txt"))
+    assert len(files) == 1
+    assert files[0].name == f"{hex_digest}.txt"
+
+
+def test_i3_permissions_unix(tmp_path: Path):
+    if os.name == "nt":
+        pytest.skip("unix permissions")
+    root = tmp_path / "c"
+    cache = ExtractCache(root=root, max_bytes=10 * 1024 * 1024)
+    cid = cache.store("permission body text")
+    assert stat.S_IMODE(root.stat().st_mode) == 0o700
+    hex_digest = cid.split(":")[1]
+    path = root / hex_digest[0:2] / hex_digest[2:4] / f"{hex_digest}.txt"
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600
+
+
+def test_i4_lru_eviction(tmp_path: Path):
+    # Small cache: each body ~200 bytes
+    cache = ExtractCache(root=tmp_path / "c", max_bytes=500)
+    ids = []
+    for i in range(5):
+        body = f"entry-{i}-" + ("x" * 180)
+        ids.append(cache.store(body))
+    # Older entries should be gone; latest should exist
+    with pytest.raises(NotFoundError):
+        cache.full_char_len(ids[0])
+    assert cache.full_char_len(ids[-1]) > 0
+
+
+def test_i4_read_updates_lru(tmp_path: Path):
+    cache = ExtractCache(root=tmp_path / "c", max_bytes=450)
+    a = cache.store("A" * 200)
+    b = cache.store("B" * 200)
+    # Touch A so B is older
+    cache.read_range(a, 0, 10)
+    # New entry should prefer evicting B
+    c = cache.store("C" * 200)
+    assert cache.full_char_len(a) > 0
+    assert cache.full_char_len(c) > 0
+    with pytest.raises(NotFoundError):
+        cache.full_char_len(b)
+
+
+def test_i5_cache_full_when_all_pinned(tmp_path: Path):
+    cache = ExtractCache(root=tmp_path / "c", max_bytes=300)
+    body_a = "A" * 200
+    cid = cache.store(body_a)
+    hex_a = cid.split(":")[1]
+    # Pin A so it cannot be evicted
+    cache._pin(hex_a)
+    try:
+        with pytest.raises(CacheFullError) as exc:
+            cache.store("B" * 200)
+        assert exc.value.code == "cache_full"
+    finally:
+        cache._unpin(hex_a)
+
+
+def test_i2_no_half_file_on_failed_write(tmp_path: Path, monkeypatch):
+    cache = ExtractCache(root=tmp_path / "c", max_bytes=10 * 1024 * 1024)
+    body = "atomic write body " * 20
+    hex_digest = content_hash_hex(body)
+    path = cache._path_for_hex(hex_digest)
+
+    real_replace = os.replace
+
+    def boom_replace(src, dst):
+        # Simulate crash after temp write but before replace completes:
+        # leave temp, fail replace — final path must not appear with valid id.
+        raise OSError("simulated interrupt")
+
+    monkeypatch.setattr(os, "replace", boom_replace)
+    with pytest.raises((OSError, Exception)):
+        # store wraps OSError as CacheUnavailableError
+        try:
+            cache.store(body)
+        except Exception:
+            raise
+    # No committed body file, or if any tmp remains it is not a valid content path
+    assert not path.is_file()
+    valid_txt = [p for p in (tmp_path / "c").rglob("*.txt") if p.name == f"{hex_digest}.txt"]
+    assert valid_txt == []
+
+
+def test_i7_paged_read_roundtrip(tmp_path: Path):
+    cache = ExtractCache(root=tmp_path / "c", max_bytes=50 * 1024 * 1024)
+    body = "".join(f"Line {i} content pad " for i in range(3000))  # >30k
+    assert len(body) > 30_000
+    cid = cache.store(body)
+    stored = cache.full_text(cid)
+    chunks: list[str] = []
+    offset = 0
+    while offset < len(stored):
+        page = cache.read_range(cid, offset, MAX_READ_LIMIT)
+        assert len(page) <= MAX_READ_LIMIT
+        chunks.append(page)
+        if not page:
+            break
+        offset += len(page)
+    joined = "".join(chunks)
+    assert joined == stored
+    assert hashlib.sha256(joined.encode("utf-8")).hexdigest() == cid.split(":")[1]
+
+
+def test_i8_concurrent_store_same_body(tmp_path: Path):
+    cache = ExtractCache(root=tmp_path / "c", max_bytes=10 * 1024 * 1024)
+    body = "concurrent identical body " * 100
+    results: list[str] = []
+
+    def worker():
+        results.append(cache.store(body))
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        futs = [pool.submit(worker) for _ in range(8)]
+        for f in futs:
+            f.result()
+    assert len(set(results)) == 1
+    files = list((tmp_path / "c").rglob("*.txt"))
+    assert len(files) == 1
+
+
+def test_u8_parse_content_id_rejects_paths():
+    with pytest.raises(InvalidContentIdError):
+        parse_content_id("../etc/passwd")
+    with pytest.raises(InvalidContentIdError):
+        parse_content_id("/tmp/foo")
+    with pytest.raises(InvalidContentIdError):
+        parse_content_id("sha256:nothex")
+    with pytest.raises(InvalidContentIdError):
+        parse_content_id("abc")
+    good = "a" * 64
+    assert parse_content_id(good) == good
+    assert parse_content_id(f"sha256:{good}") == good
+
+
+def test_read_range_invalid(tmp_path: Path):
+    cache = ExtractCache(root=tmp_path / "c", max_bytes=1024 * 1024)
+    cid = cache.store("hello world")
+    with pytest.raises(InvalidRangeError):
+        cache.read_range(cid, -1, 10)
+    with pytest.raises(InvalidRangeError):
+        cache.read_range(cid, 0, 0)
+    with pytest.raises(InvalidRangeError):
+        cache.read_range(cid, 0, MAX_READ_LIMIT + 1)
+
+
+def test_corrupt_file_deleted_on_read(tmp_path: Path):
+    cache = ExtractCache(root=tmp_path / "c", max_bytes=1024 * 1024)
+    cid = cache.store("good body text")
+    hex_digest = cid.split(":")[1]
+    path = cache._path_for_hex(hex_digest)
+    path.write_bytes(b"corrupted-not-matching-hash")
+    with pytest.raises(NotFoundError):
+        cache.read_range(cid, 0, 10)
+    assert not path.is_file()
+
+
+def test_offset_past_end_returns_empty(tmp_path: Path):
+    cache = ExtractCache(root=tmp_path / "c", max_bytes=1024 * 1024)
+    cid = cache.store("short")
+    assert cache.read_range(cid, 100, 10) == ""
+
+
+def test_format_content_id():
+    assert format_content_id("a" * 64) == "sha256:" + "a" * 64

--- a/skills/web/tests/test_read_extract.py
+++ b/skills/web/tests/test_read_extract.py
@@ -1,0 +1,87 @@
+"""CLI tests for read_extract.py (I6, I7)."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from extract_cache import ExtractCache, MAX_READ_LIMIT
+import read_extract
+
+
+def test_i6_invalid_args_exit_nonzero(tmp_path: Path, monkeypatch, capsys):
+    monkeypatch.setenv("ALFRED_WEB_EXTRACT_CACHE_DIR", str(tmp_path / "c"))
+    assert read_extract.main(["--content-id", "../x", "--offset", "0", "--limit", "10"]) == 2
+    assert read_extract.main(["--content-id", "a" * 64, "--offset", "-1", "--limit", "10"]) == 2
+    assert read_extract.main(["--content-id", "a" * 64, "--offset", "0", "--limit", "0"]) == 2
+    assert (
+        read_extract.main(
+            ["--content-id", "a" * 64, "--offset", "0", "--limit", str(MAX_READ_LIMIT + 1)]
+        )
+        == 2
+    )
+
+
+def test_i6_unknown_id(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("ALFRED_WEB_EXTRACT_CACHE_DIR", str(tmp_path / "c"))
+    code = read_extract.main(
+        ["--content-id", "b" * 64, "--offset", "0", "--limit", "100", "--output", "json"]
+    )
+    assert code == 1
+
+
+def test_i7_cli_paged_restore(tmp_path: Path, monkeypatch, capsys):
+    monkeypatch.setenv("ALFRED_WEB_EXTRACT_CACHE_DIR", str(tmp_path / "c"))
+    cache = ExtractCache(root=tmp_path / "c", max_bytes=50 * 1024 * 1024)
+    body = ("PAGE-CONTENT-" * 500)  # long enough
+    assert len(body) > 5000
+    cid = cache.store(body)
+    hex_id = cid.split(":")[1]
+
+    parts: list[str] = []
+    offset = 0
+    while True:
+        capsys.readouterr()
+        code = read_extract.main(
+            [
+                "--content-id",
+                hex_id,
+                "--offset",
+                str(offset),
+                "--limit",
+                str(MAX_READ_LIMIT),
+                "--output",
+                "json",
+            ]
+        )
+        assert code == 0
+        out = capsys.readouterr().out
+        payload = json.loads(out)
+        assert payload["chars_returned"] <= MAX_READ_LIMIT
+        assert "path" not in json.dumps(payload).lower() or "/Users" not in out
+        assert str(tmp_path) not in out
+        parts.append(payload["text"])
+        if payload["eof"]:
+            break
+        offset += payload["chars_returned"]
+        if payload["chars_returned"] == 0:
+            break
+
+    joined = "".join(parts)
+    assert joined == cache.full_text(cid)
+
+
+def test_text_output_is_pure_fragment(tmp_path: Path, monkeypatch, capsys):
+    monkeypatch.setenv("ALFRED_WEB_EXTRACT_CACHE_DIR", str(tmp_path / "c"))
+    cache = ExtractCache(root=tmp_path / "c", max_bytes=1024 * 1024)
+    body = "exact fragment body"
+    cid = cache.store(body)
+    code = read_extract.main(
+        ["--content-id", cid, "--offset", "0", "--limit", "100", "--output", "text"]
+    )
+    assert code == 0
+    out = capsys.readouterr().out
+    assert out.strip() == body

--- a/skills/web/tests/test_search.py
+++ b/skills/web/tests/test_search.py
@@ -1,17 +1,24 @@
-"""Tests for web-search search.py."""
+"""Tests for web-search search.py (existing + extract pipeline)."""
 
 from __future__ import annotations
 
 import argparse
+import hashlib
+from pathlib import Path
 
+from extract_cache import ExtractCache, MAX_READ_LIMIT
 from search import (
     SearchError,
     SearchResult,
     build_backend_order,
     dedupe_results,
+    extract_result_pages,
+    format_text,
     normalize_ddgs_results,
     normalize_tavily_results,
     search_with_fallback,
+    allocate_visible_text,
+    resolve_visible_budget,
 )
 
 
@@ -30,7 +37,7 @@ class DummyBackend:
     def search(self, args):
         if self.error:
             raise SearchError(self.error)
-        return self.results
+        return list(self.results)
 
 
 def make_args(**overrides):
@@ -49,6 +56,8 @@ def make_args(**overrides):
         "extract_top": 2,
         "fallback": True,
         "verbose": False,
+        "visible_chars": None,
+        "full_extract": False,
     }
     values.update(overrides)
     return argparse.Namespace(**values)
@@ -108,6 +117,8 @@ def test_search_with_fallback_uses_second_backend(monkeypatch):
     assert response.backend == "ddgs"
     assert response.attempted_backends == ["ddgs"]
     assert response.errors == []
+    assert response.materials_hint == "no_extract"
+    assert response.schema_version == 2
 
 
 def test_search_without_fallback_stops_on_first_backend(monkeypatch):
@@ -130,3 +141,177 @@ def test_auto_backend_order(monkeypatch):
 
 def test_explicit_backend_order():
     assert build_backend_order("ddgs") == ["ddgs"]
+
+
+def test_extract_pipeline_stores_and_budgets(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("ALFRED_WEB_EXTRACT_CACHE_DIR", str(tmp_path / "c"))
+    long_body = "WORD " * 10000  # >40k after normalize? "WORD " * 10000 = 50000
+    html = f"<html><body><p>{long_body}</p></body></html>"
+
+    results = [
+        SearchResult(
+            "Long Article",
+            "https://example.com/long",
+            "snippet " * 50,
+            None,
+            None,
+            "ddgs",
+            "text",
+            1,
+        )
+    ]
+    cache = ExtractCache(root=tmp_path / "c", max_bytes=50 * 1024 * 1024)
+    extract_result_pages(
+        results,
+        top_n=1,
+        timeout=5,
+        cache=cache,
+        html_fetcher=lambda url: html,
+    )
+    assert results[0].extract is not None
+    assert results[0].extract.content_id.startswith("sha256:")
+    assert results[0].extract.chars_full > 40_000
+
+    stats = allocate_visible_text(results, budget=4000)
+    assert stats["visible_text_chars"] <= 4000
+    assert results[0].extracted_text == results[0].extract.preview
+    assert len(results[0].extract.preview) < results[0].extract.chars_full
+    assert results[0].extract.preview_truncated is True
+
+    # Round-trip full text via cache
+    cid = results[0].extract.content_id
+    full = cache.full_text(cid)
+    assert len(full) == results[0].extract.chars_full
+    pages = []
+    off = 0
+    while off < len(full):
+        page = cache.read_range(cid, off, MAX_READ_LIMIT)
+        pages.append(page)
+        if not page:
+            break
+        off += len(page)
+    assert "".join(pages) == full
+
+
+def test_search_with_extract_e2e_json(tmp_path: Path, monkeypatch):
+    """E1: fixture page >40k; visible_text_chars <= 4000; content_id present."""
+    monkeypatch.setenv("ALFRED_WEB_EXTRACT_CACHE_DIR", str(tmp_path / "c"))
+    monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+    long_body = ("Deep analysis paragraph. " * 2000)
+    assert len(long_body) > 40_000
+    html = f"<html><head><script>x</script></head><body>{long_body}</body></html>"
+
+    result = SearchResult(
+        "Deep Doc",
+        "https://example.com/deep",
+        "short snip",
+        None,
+        None,
+        "ddgs",
+        "text",
+        1,
+    )
+
+    def fetcher(url: str) -> str:
+        return html
+
+    class ExtractBackend:
+        name = "ddgs"
+
+        def is_available(self):
+            return True
+
+        def search(self, args):
+            return [result]
+
+    import search as search_mod
+
+    orig = search_mod.extract_result_pages
+
+    def fake_extract(results, top_n, timeout, cache=None, html_fetcher=None):
+        return orig(
+            results,
+            top_n,
+            timeout,
+            cache=cache or ExtractCache(root=tmp_path / "c", max_bytes=50 * 1024 * 1024),
+            html_fetcher=fetcher,
+        )
+
+    monkeypatch.setattr(search_mod, "extract_result_pages", fake_extract)
+
+    response = search_with_fallback(
+        make_args(extract=True, extract_top=1, visible_chars=4000, backend="ddgs"),
+        {"ddgs": ExtractBackend()},
+        cache=ExtractCache(root=tmp_path / "c", max_bytes=50 * 1024 * 1024),
+    )
+    assert response.ok
+    d = response.to_dict()
+    assert d["schema_version"] == 2
+    assert d["materials_hint"] == "extract_available"
+    assert d["stats"]["visible_text_chars"] <= 4000
+    assert d["stats"]["full_chars_total"] > 40_000
+    ex = d["results"][0]["extract"]
+    assert ex["content_id"]
+    assert ex["chars_full"] > 40_000
+    assert d["results"][0]["extracted_text"] == ex["preview"]
+    # stdout material card is not near-full-text
+    text_out = format_text(response)
+    assert len(text_out) < 20_000
+    assert "content_id:" in text_out
+    assert "Read:" in text_out
+    assert str(tmp_path) not in text_out
+
+
+def test_e2_e3_paged_restore_over_30k(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("ALFRED_WEB_EXTRACT_CACHE_DIR", str(tmp_path / "c"))
+    body = "Z" * 35_000
+    cache = ExtractCache(root=tmp_path / "c", max_bytes=50 * 1024 * 1024)
+    cid = cache.store(body)
+    chunks = []
+    offset = 0
+    while offset < 35_000:
+        page = cache.read_range(cid, offset, MAX_READ_LIMIT)
+        assert len(page) <= MAX_READ_LIMIT
+        chunks.append(page)
+        offset += len(page)
+        if not page:
+            break
+    joined = "".join(chunks)
+    assert joined == body
+    assert hashlib.sha256(joined.encode()).hexdigest() == cid.split(":")[1]
+
+
+def test_e4_no_extract_hint(monkeypatch):
+    monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+    backend_map = {
+        "ddgs": DummyBackend(
+            "ddgs",
+            results=[
+                SearchResult("A", "https://example.com/a", "snip", None, None, "ddgs", "text", 1)
+            ],
+        ),
+    }
+    response = search_with_fallback(make_args(extract=False, backend="ddgs"), backend_map)
+    assert response.materials_hint == "no_extract"
+    assert response.results[0].extract is None
+    d = response.to_dict()
+    assert d["materials_hint"] == "no_extract"
+
+
+def test_partial_extract_failure(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("ALFRED_WEB_EXTRACT_CACHE_DIR", str(tmp_path / "c"))
+    cache = ExtractCache(root=tmp_path / "c", max_bytes=10 * 1024 * 1024)
+    r1 = SearchResult("A", "https://ok.example", "s1", None, None, "ddgs", "text", 1)
+    r2 = SearchResult("B", "https://bad.example", "s2", None, None, "ddgs", "text", 2)
+
+    def fetcher(url: str) -> str:
+        if "bad" in url:
+            raise RuntimeError("network")
+        return "<html><body>Good page content here</body></html>"
+
+    extract_result_pages([r1, r2], top_n=2, timeout=5, cache=cache, html_fetcher=fetcher)
+    assert r1.extract is not None
+    assert r2.extract is None
+    assert r2.extract_error == "extract_failed"
+    allocate_visible_text([r1, r2], budget=4000)
+    assert r1.extracted_text == r1.extract.preview

--- a/skills/web/tests/test_skill_docs.py
+++ b/skills/web/tests/test_skill_docs.py
@@ -1,0 +1,27 @@
+"""E5: SKILL.md static checks for stop-search guidance and read path."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+SKILL = Path(__file__).resolve().parent.parent / "SKILL.md"
+
+
+def test_e5_skill_md_guidance():
+    text = SKILL.read_text(encoding="utf-8")
+    assert "materials_hint" in text
+    assert "extract_available" in text
+    assert "content_id" in text
+    assert "read_extract.py" in text
+    # Coverage is agent-judged; not a forced stop signal
+    assert "覆盖度" in text or "coverage" in text.lower() or "agent" in text.lower()
+    # Stop searching when materials suffice
+    assert "停止" in text or "stop" in text.lower()
+    # Forbid cat of cache files
+    assert "cat" in text.lower() or "禁止" in text
+    # #160 boundary / tail@8000
+    assert "8000" in text or "#160" in text or "tail@" in text
+    # full-extract is debug only
+    assert "full-extract" in text or "--full-extract" in text
+    # cite page objectId, not summary as full-text handle
+    assert "objectId" in text or "cite" in text.lower()


### PR DESCRIPTION
## Summary

- Default `--extract` output is a **structured material card** (JSON schema v2 / text): title/url/snippet/`extract.preview` + `content_id` / `chars_full` / `read_command`, with shared LLM-visible budget default **≤ 4000** (`--visible-chars` / `ALFRED_WEB_EXTRACT_VISIBLE_CHARS`).
- Full extract body stored in content-addressed cache; recover via `read_extract.py --content-id … --offset --limit` (max 6000/page). No absolute cache paths in public output.
- `materials_hint` + SKILL.md stop-search guidance when materials suffice.
- Debug-only `--full-extract` escape hatch.

Closes #161

## Petri

- Worktree: `/Users/xupeng/dev/github/.worktrees/alfred-161`
- Run: `.petri/runs/run-001` — **done** (issue → design → develop → unit_test → review approved)
- Develop initially landed under `.petri/artifacts/…`; this PR integrates into real `skills/web/`.

## Design

- Issue design comment: https://github.com/xforce-io/alfred/issues/161#issuecomment-5016255379

## Test plan

- [x] `cd skills/web && python -m pytest tests/ -q` (39 passed)
- [x] Offline store → allocate(budget=4000) → paged read restores full body