### PR TITLE
【channel/runtime】chat 软超时与 deferred 结果投递可观测、可送达

### DIFF
--- a/docs/design/168-chat-soft-timeout-deferred.md
+++ b/docs/design/168-chat-soft-timeout-deferred.md
@@ -1,0 +1,354 @@
+# 【channel/runtime】chat 软超时与 deferred 结果投递可观测、可送达
+
+- Issue: #168
+- 状态: Approved (petri code-dev run-002)
+- 最后更新: 2026-07-21
+
+## 1. 背景
+
+Chat turn 默认 **600s 软超时**（`CHAT_POLICY.timeout_seconds`）。超时后 `_timeout_wrapper` 会拉起后台 **deferred-drain**（默认再约 **300s**，`drain_extra_seconds`），期望任务完成后通过 `_deliver_deferred_result` **双路投递**：写入原会话 history + `events.emit(source_type=deferred_result)` 实时推送。
+
+现状与痛点（对齐 issue 案例 run `7cb2fb03-…`）：
+
+1. **语义不清**：超时气泡易被理解为硬失败，用户不确定「是否仍在跑 / 是否还会推送」。
+2. **投递不可靠可感**：路径已存在，但 Web 侧 idle gate 未放行 `deferred_result`，且缺稳定 e2e/集成验收，难保证 drain 窗口内终稿一定到达原会话。
+3. **统计不一致**：timeout 的 `turn_end.tool_call_count` 曾为 `0`，与 Telegram「N commands executed」、milkie `tool.responded` 不一致，妨碍排查。
+
+代码锚点（实现入口，非新模块）：
+
+| 层 | 路径 |
+|----|------|
+| 超时/drain | `src/everbot/core/runtime/turn_orchestrator.py`（`_timeout_wrapper` / `_drain_after_timeout`） |
+| 文案 + deferred 双路 | `src/everbot/core/channel/core_service.py`（timeout 文案、`_deliver_deferred_result`） |
+| Policy | `src/everbot/core/runtime/turn_policy.py`（`timeout_seconds=600`, `drain_extra_seconds=300`） |
+| TG 推送 | `src/everbot/channels/telegram_channel.py`（`deferred_result` 已 exempt 活跃闸） |
+| Web 推送 | `src/everbot/web/services/chat_service.py`（`_on_background_event`） |
+| History | `src/everbot/core/session/session_mailbox.py`（`inject_history_message` + run_id 去重） |
+
+## 2. 设计目标与非目标
+
+### 目标
+
+- **S1**：软超时用户文案明确「后台仍继续」+「稍后可能自动推送」，与硬失败文案可区分。
+- **S2**：drain 窗口内产生的最终文本稳定投递到**原 channel 会话**并进入 **history**；至少 1 条可重复的 e2e/集成路径验收。
+- **S3**：同一超时 turn 上，渠道 commands 数、timeline `turn_end.tool_call_count`、milkie `tool.responded` 对齐（或文档写明可解释差值）。
+
+### 非目标
+
+- 仅靠把默认 600s 调大作为唯一手段。
+- 长任务全面迁 job/workflow 的产品化重构。
+- 本 issue 不吞并 #164 / #165 / #167 / #166。
+- 不把默认 drain 窗口时长调整作为主交付（保持 300s 默认；配置项已存在，无需新配置面）。
+- 不引入二次「drain 仍失败」用户提示产品化（见边界：仅日志 + 可观测；可另开）。
+- 不改 Telegram/Web 以外的新渠道适配。
+
+## 3. 架构设计
+
+### 3.1 逻辑分层（现有路径加固，不新建子系统）
+
+```mermaid
+flowchart TB
+  subgraph Channel["Channel 入口"]
+    TG[TelegramChannel]
+    Web[Web ChatService]
+  end
+
+  subgraph Core["core_service.process_message"]
+    TO[TurnOrchestrator.run_turn]
+    TW["_timeout_wrapper(timeout=600s)"]
+    Drain["_drain_after_timeout(+300s)"]
+    Deliver["_deliver_deferred_result"]
+    TL[timeline turn_end]
+    Copy[软超时文案 OutboundMessage]
+  end
+
+  subgraph SideEffects["投递副作用"]
+    Hist["inject_history_message\n(source=deferred_result)"]
+    Bus["events.emit\nscope=session, source_type=deferred_result"]
+  end
+
+  TG --> Core
+  Web --> Core
+  TO --> TW
+  TW -->|TimeoutError 前台结束| Copy
+  TW -->|TimeoutError 前台结束| TL
+  TW -->|create_task deferred-drain| Drain
+  Drain -->|final text| Deliver
+  Deliver --> Hist
+  Deliver --> Bus
+  Bus --> TG
+  Bus --> Web
+```
+
+### 3.2 核心业务流程
+
+**前台（用户可见超时）**
+
+1. `TurnOrchestrator._run_attempt` 用 `_timeout_wrapper` 消费 agent 事件流。
+2. 到达 deadline → 启动 `deferred-drain` 后台 task → 抛出 `asyncio.TimeoutError`。
+3. **加固点 A**：在 `_run_attempt` 内捕获 TimeoutError，yield `TURN_ERROR`（或专用语义）时**带上已累计的** `tool_call_count` / `tool_names_executed` / `failed_tool_outputs`；`error` 字符串保留 `timeout` 关键字供 core_service 分支识别。
+4. `core_service`：
+   - 记录 `turn_end`，`status="timeout"`（与硬 `error` 区分），`tool_call_count` 取编排层与本地计数的可靠值（见 §5）。
+   - 发送软超时文案（S1）+ `end`；**不**把软超时当硬失败堆栈气泡。
+5. 释放 session 锁；drain 在锁外继续。
+
+**后台（deferred 终稿）**
+
+1. `_drain_after_timeout` 继续消费 aiter（至多 `drain_extra_seconds`），优先 LLM final text，否则 tool output 拼接。
+2. 非空结果调用 `on_deferred_result(result_text)` → `_deliver_deferred_result`：
+   - **(A)** `inject_history_message`（`metadata.source=deferred_result`, `run_id` 去重）。
+   - **(B)** `events.emit(..., scope=session, target_session_id, target_channel, source_type=deferred_result)`。
+3. **加固点 B（Web）**：`deferred_result` 加入 Web idle-gate bypass，避免超时后 20s 内被丢弃。
+4. Telegram 已对 `deferred_result` 免除「用户活跃时 defer」闸；保持只投递 originating chat。
+5. 空结果 / drain 异常：打英文 warning 日志，不伪造成功；不向用户发硬失败文案。
+
+```mermaid
+sequenceDiagram
+  participant U as User
+  participant C as core_service
+  participant O as TurnOrchestrator
+  participant D as deferred-drain
+  participant H as history
+  participant E as events bus
+  participant Ch as TG/Web
+
+  U->>C: chat message
+  C->>O: run_turn + on_deferred_result
+  O-->>C: TOOL_CALL x N (streamed)
+  O-->>C: TimeoutError + stats
+  C->>Ch: soft-timeout copy + end
+  C->>C: turn_end status=timeout tool_call_count=N
+  O->>D: create_task drain
+  D->>C: on_deferred_result(final_text)
+  C->>H: inject_history_message
+  C->>E: emit deferred_result
+  E->>Ch: push to original session
+```
+
+## 4. 组件与公共接口
+
+### 4.1 `TurnOrchestrator` / `_timeout_wrapper` / `_drain_after_timeout`
+
+| 职责 | 接口约定 |
+|------|----------|
+| 软超时 | 超时后 **不** `aclose` 前台 iterator（交给 drain）；无 drain 回调时才 aclose |
+| 超时事件 | `_run_attempt` 捕获 `TimeoutError`，yield `TurnEvent(TURN_ERROR, error=..., tool_call_count=..., tool_names_executed=..., failed_tool_outputs=...)`，**禁止**在 `run_turn` 外层 bare `TURN_ERROR` 丢掉统计 |
+| drain 回调 | `on_deferred_result: Callable[[str], Awaitable\|None]`，单参数最终文本（与现实现一致；修正过时测试里双参数假设） |
+| 空结果 | drain 结束无文本则 **不调用** 回调 |
+
+不新增对外配置项；继续读 `TurnPolicy.timeout_seconds` / `drain_extra_seconds`。
+
+### 4.2 `core_service.process_message`
+
+| 路径 | 行为 |
+|------|------|
+| 软超时分支 | 匹配 error 中 `timeout`（保持现有启发式，优先识别 orchestrator 超时消息）；文案见 §5 |
+| `turn_end` | `status="timeout"`；`tool_call_count` 优先 `te.tool_call_count`，若为 0 且本地已累加则用本地值；可选写入 `deferred_drain=true` 元数据便于排查 |
+| `_deliver_deferred_result` | 保持双路；失败只 log；history 前缀保留「超时后台任务完成后自动生成」语义 |
+| 硬失败 | 既有「未能完成处理」路径不变；**不得**与软超时共用文案 |
+
+### 4.3 Channel 投递
+
+| Channel | 变更 |
+|---------|------|
+| Telegram | 文案走 core_service `text` 事件；commands 摘要逻辑不变（计 `skill` processing）。deferred 路由已正确 → **基本无改**，补回归测试 |
+| Web | **`deferred_result` 加入 `bypass_idle_gate`**；session-scope 推到 `target_session_id`；无连接时允许仅 history 可达（实时推送 best-effort） |
+
+### 4.4 不新增模块
+
+不引入新 service / 新队列 / 新 DB。所有改动落在现有 turn 编排与 channel 投递边界内。
+
+## 5. 数据与文案约定
+
+### 5.1 超时文案（S1）
+
+统一语义模板（TG/Web 同源字符串，渠道不各自发明语义）：
+
+```
+本轮前台等待已超时，后台任务仍在继续执行。
+若在后续处理窗口内完成，我会自动把结果推送到本会话（并写入历史，可供后续引用）。
+你无需重复发送同一指令；若长时间未收到结果，可再追问或换更具体的指令。
+```
+
+判定标准（可测）：
+
+- 含「后台…继续」类语义；
+- 含「自动推送 / 推送到本会话」类语义；
+- **不含**硬失败句式「未能完成处理」「执行失败」作为主结论。
+
+实现上可抽常量（如 `SOFT_TIMEOUT_USER_MESSAGE`）避免散落魔法字符串。
+
+### 5.2 Deferred history 消息
+
+保持现有结构：
+
+```python
+{
+  "role": "assistant",
+  "content": "[此消息由超时后台任务完成后自动生成]\n\n" + result_text,
+  "metadata": {
+    "source": "deferred_result",
+    "run_id": run_id,  # 与 turn 的 chat_* run_id 一致，用于去重
+    "injected_at": "<iso8601>",
+  },
+}
+```
+
+### 5.3 Event envelope
+
+```python
+events.emit(
+  session_id,
+  {"detail": result_text, "source_type": "deferred_result", "run_id": run_id, "agent_name": ..., "deliver": True},
+  scope="session",
+  target_session_id=session_id,
+  target_channel=extract_channel_type(session_id),
+  source_type="deferred_result",
+  run_id=run_id,
+)
+```
+
+### 5.4 Timeline `turn_end`（S3）
+
+| 字段 | 软超时取值 |
+|------|------------|
+| `status` | `"timeout"`（新增区分；旧 `"error"+timeout 文案` 视为兼容，测试以新值为准） |
+| `tool_call_count` | 与本 turn 已 yield 的 `TOOL_CALL`（及 skill_fallback tool_call）次数一致 |
+| `tool_names_executed` | 非空时与执行序列一致 |
+| `error` | 可保留 timeout 描述字符串 |
+
+**计数对齐定义（本 issue 事实源）**：
+
+- **N** = 本 turn 编排层计入的工具调用次数（与 milkie `tool.responded` 同 turn 对齐的目标值；内部 resource tools `_load_resource_skill` / `_read_skill_asset` 已在渠道侧隐藏且不应计入用户可见 N）。
+- Telegram `commands executed` = 收到的 `skill` + processing 次数（已隐藏内部 tools）→ 应等于 N。
+- `turn_end.tool_call_count` = N。
+- 若 milkie 侧仍含框架内部 tool，文档一句说明：**用户可见 N 以 alfred 过滤后计数为准**；验收对比时对 milkie 做同名过滤或使用同 turn 的 alfred timeline `tool_call` 事件数作为中间真值。
+
+### 5.5 根因（S3）— 实现必须修
+
+`run_turn` 外层：
+
+```python
+except Exception as exc:
+    yield TurnEvent(type=TURN_ERROR, error=str(exc))  # 丢失 tool_call_count
+```
+
+当 `_timeout_wrapper` 在 `_run_attempt` 内抛 `TimeoutError` 时，**已累计统计留在 `_run_attempt` 栈帧**，外层无法恢复。若 core_service 本地计数因事件映射缺口未同步，则 `turn_end.tool_call_count` 可能为 0。
+
+**修复**：在 `_run_attempt` 对 timeout 特化捕获并带统计 yield；`run_turn` 仅作兜底。`core_service` 在 `TURN_ERROR` 时写回本地计数：`tool_call_count = te.tool_call_count or tool_call_count`（已有），并确保 timeline 使用更新后的值。
+
+## 6. 设计思路与折衷
+
+| 候选 | 决策 | 理由 |
+|------|------|------|
+| A. 仅加大 timeout | **不做**（非目标） | 不解决投递与统计；掩盖问题 |
+| B. 现有 soft-timeout + drain + 双路加固 | **采用** | 路径已存在；改动面最小；满足 S1–S3 |
+| C. 超时后转 job/workflow | **不做**（非目标） | 产品化面过大 |
+| 文案渠道差异化 | **同源语义，单字符串** | 降低测试矩阵；展示层可加前缀但不改语义 |
+| drain 失败二次提示 | **本期不做** | issue 未要求；避免新状态机 |
+| 超时后用户又发新 turn | **仍投递原 session** + history 占位规则（已有） | 结果归属 originating turn；不静默丢弃 |
+| Web idle gate | **bypass deferred_result** | 用户刚超时必然活跃；20s 闸会吞掉 +32s 案例中的终稿推送 |
+| 新 status=`timeout` | **采用** | 可观测；比从 error 字符串反推清晰 |
+
+## 7. 边界考虑
+
+| 场景 | 行为 |
+|------|------|
+| drain 窗口内完成 | 推送 + history；run_id 去重防双写 |
+| drain 超时仍无文本 | 不回调；仅日志；用户保留软超时文案，无伪造成功 |
+| drain 中途异常 | log warning；aclose aiter；不抛到事件环 |
+| 用户超时时已有部分 delta | 已展示内容保留；超时文案追加；deferred 终稿再推一条 |
+| 用户在 drain 完成前发新消息 | deferred 仍进原 session history/push；role 交替由 `inject_history_message` 占位处理 |
+| Web 无活跃 WS | history 仍写入；重连后可读 history（实时推送 best-effort） |
+| TG 投递失败 | 现有 warning；history 仍是 LLM 后续引用真源 |
+| 硬取消 `CancelledError` | 不走 deferred-drain 成功路径（保持现有 cancel 语义） |
+| 并发 process_message | session 锁保证 turn 串行；drain 用 `update_atomic` 注入 history |
+
+## 8. 测试计划
+
+### 8.1 TDD 优先顺序（喂 `unit_test` / 开发）
+
+1. **Unit — 超时统计（S3）**  
+   - 脚本化 agent：先 yield N 次 tool_call/output，再 hang。  
+   - `TurnOrchestrator` + 短 `timeout_seconds`。  
+   - **Pass**：收到 `TURN_ERROR` 且 `tool_call_count == N`，`error` 含 timeout。  
+   - **Pass**：`core_service`（mock session）`turn_end` 的 `tool_call_count == N` 且 `status == "timeout"`。
+
+2. **Unit — 软超时文案（S1）**  
+   - 触发 timeout 路径。  
+   - **Pass**：outbound `text` 匹配 §5.1 语义（关键字断言，非整句锁死若需 i18n 弹性）。  
+   - **Pass**：不出现硬失败主文案。
+
+3. **Unit — drain 回调与双路（S2）**  
+   - `_timeout_wrapper` / `_drain_after_timeout`：hang 后继续产出 LLM answer → 回调收到终稿。  
+   - `core_service._deliver_deferred_result`：`inject_history_message` 被调用 + `events.emit` 带 `scope/target_*/source_type=deferred_result`。  
+   - **Pass**：history content 含终稿与 deferred 前缀；emit 路由字段正确。
+
+4. **Unit — Web idle gate（S2）**  
+   - 模拟 `last_activity` 在 20s 内 + `source_type=deferred_result`。  
+   - **Pass**：WS 仍收到推送（bypass 生效）。
+
+5. **Unit — Telegram 回归**  
+   - `deferred_result` 只到 originating chat；不因 active turn 被 defer（现有测试保持绿）。
+
+### 8.2 Integration / E2E（S2 验收最低条）
+
+**至少 1 条**集成路径（推荐 mock channel + 真实 `process_message` + 短 timeout policy，不必真 Telegram）：
+
+| 步骤 | 期望 |
+|------|------|
+| 1. 配置 `timeout_seconds` 很小（如 0.3s）、`drain_extra_seconds` 足够（如 2s） | policy 生效 |
+| 2. agent 流：tool × N → sleep → 最终 LLM text | 模拟案例 +32s 缩短版 |
+| 3. 用户侧只发一条消息，等待 | 先收到软超时文案 |
+| 4. 再等待 drain | 收到 deferred 终稿（event 或 channel sink） |
+| 5. 读 session history | 存在 `metadata.source==deferred_result` 且 content 含终稿 |
+| 6. 读 timeline | `turn_end.tool_call_count == N`，`status==timeout` |
+
+**Pass 标准**：步骤 3–6 稳定可重复（CI 绿）。
+
+### 8.3 与 Stories 映射
+
+| ID | 测试层 |
+|----|--------|
+| S1 | Unit 文案断言 |
+| S2 | Unit drain+emit + Integration/E2E 一条路径 |
+| S3 | Unit orchestrator/core_service 统计 + Integration timeline 字段 |
+
+## 9. Acceptance checklist
+
+交付边界：仅 chat 软超时语义、deferred 投递加固、timeout turn 统计、最小 e2e/集成验证。  
+评审须在 `review.json` 中逐条报告下列 ID。
+
+| ID | 可观察通过条件 |
+|----|----------------|
+| **S1** | 软超时且 drain 仍进行时，用户可见文案明确表达「后台仍继续」与「可能自动推送到本会话」；不与硬失败主文案混淆。 |
+| **S2** | 至少 1 条 e2e/集成测试稳定复现：超时后 drain 窗口内终稿 → 原会话收到 deferred_result（或等价推送）→ history 可查且可供后续 turn 引用。 |
+| **S3** | 同一超时 turn，当编排层工具调用为 N 时，渠道 commands 展示与 timeline `turn_end.tool_call_count` 均为 N；若与 milkie 原始计数存在过滤差值，usage/注释中有可解释说明。 |
+| **NG1** | 未将「默认 600s 调大」作为唯一交付手段。 |
+| **NG2** | 未做长任务 job/workflow 产品化重构；未吞并 #164/#165/#167/#166。 |
+
+## 10. 实现顺序（给开发）
+
+1. **S3**：`_run_attempt` 捕获 timeout + 带统计 `TURN_ERROR`；`core_service` `turn_end status=timeout` 与计数回写。单测先红后绿。  
+2. **S1**：抽换软超时文案常量 + 单测。  
+3. **S2**：Web `bypass_idle_gate` 含 `deferred_result`；补 drain→deliver 单测；补 1 条 integration。  
+4. 回归：既有 `test_timeout_wrapper_*`、`test_deferred_result_*`、telegram deferred 测试。  
+5. （可选）`docs/runtime_design.md` Flow ④ 补一句 Web bypass 与 `status=timeout`，避免与代码漂移。
+
+## 11. 开放问题 / 已拍板
+
+| # | 问题 | 本设计拍板 |
+|---|------|------------|
+| 1 | 文案渠道差异化？ | **否**，同源语义字符串 |
+| 2 | drain 失败二次提示？ | **本期不做**，仅日志 |
+| 3 | 新消息竞态？ | **仍投递原会话**；history 占位已有 |
+| 4 | `tool_call_count=0` 边界？ | **优先修 timeout 路径**；不扩大到所有提前结束除非同根因 |
+| 5 | 真 Telegram e2e？ | **不强制**；mock channel + integration 满足 S2 |
+
+## 12. 关联
+
+- Issue: https://github.com/xforce-io/alfred/issues/168
+- 同批：#164 → #165 → **#168** → #167 → #166
+- 案例：milkie run `7cb2fb03-b3dc-4e09-be27-d5739abbc31a`，session `tg_session_demo_agent__8576399597`
+- 既有设计叙述：`docs/runtime_design.md` §7.5 Flow ④ deferred_result 双路投递
+- 既有测试：`tests/unit/test_turn_orchestrator.py`、`test_channel_core_service.py`、`test_telegram_channel.py`、`test_session_manager_core.py`

--- a/docs/runtime_design.md
+++ b/docs/runtime_design.md
@@ -1413,9 +1413,12 @@ Telegram/Web subscriber 的路由逻辑已统一：都先调用 `resolve_routing
                    target_session_id=session_id,
                    target_channel=extract_channel_type(session_id))
         → 实时推送（见 Flow ③ 的 deferred_result 分支）
-        → Telegram: 仅当 target_channel=telegram 时推送到对应 chat
-        → Web: 仅当 target_channel=web 时推到该 session 的 ws 连接
+        → Telegram: 仅当 target_channel=telegram 时推送到对应 chat（active-turn 闸已 exempt deferred_result）
+        → Web: 仅当 target_channel=web 时推到该 session 的 ws 连接；
+               **idle gate（20s）对 deferred_result bypass**，避免超时后用户仍活跃时吞掉终稿推送
 ```
+
+前台软超时路径：`turn_end.status="timeout"`，`tool_call_count` 取编排层累计值（`_run_attempt` 内捕获 TimeoutError 并带统计 yield，避免 skill 阶段计数丢失）；用户可见 N **排除**框架内部 resource tools（`_load_resource_skill` / `_read_skill_asset`，与 Telegram 隐藏列表一致）；`_timeout_wrapper` 超时**不** cancel 进行中的 `__anext__`，将 pending task 交给 deferred-drain；drain 在整个 `drain_extra_seconds` 窗口内对后续 `__anext__` 同样使用非取消等待（不以 60s 分段 cancel）。
 
 注：不使用 mailbox deposit——结果已在 history_messages 中，再通过 mailbox 以 "Background Updates" 前缀重复呈现给 LLM 是纯冗余。
 

--- a/src/everbot/core/channel/core_service.py
+++ b/src/everbot/core/channel/core_service.py
@@ -28,6 +28,7 @@ from ...core.runtime.context_strategy import PrimaryContextStrategy, RuntimeDeps
 from ...core.runtime.mailbox import compose_message_with_mailbox_updates
 from ...core.runtime.turn_orchestrator import (
     CHAT_POLICY,
+    USER_HIDDEN_INTERNAL_TOOLS,
     TurnEventType,
     TurnOrchestrator,
     build_chat_policy,
@@ -45,6 +46,20 @@ except Exception:  # pragma: no cover
     _slm_handle_skill_event = None  # type: ignore[assignment]
 
 logger = logging.getLogger(__name__)
+
+# Soft-timeout user-facing copy (S1 / issue #168). Shared by all channels so
+# Telegram and Web present the same semantics; do not invent per-channel variants.
+SOFT_TIMEOUT_USER_MESSAGE = (
+    "本轮前台等待已超时，后台任务仍在继续执行。\n"
+    "若在后续处理窗口内完成，我会自动把结果推送到本会话（并写入历史，可供后续引用）。\n"
+    "你无需重复发送同一指令；若长时间未收到结果，可再追问或换更具体的指令。"
+)
+
+# Deferred history inject retry budget (F-005 / S2). Each attempt blocks up to
+# DEFERRED_HISTORY_INJECT_TIMEOUT for the session lock; total wall time covers a
+# long follow-up turn holding the lock past a single inject timeout.
+DEFERRED_HISTORY_INJECT_MAX_ATTEMPTS = 12
+DEFERRED_HISTORY_INJECT_TIMEOUT = 5.0
 
 
 def _build_circuit_break_summary(exc: Exception, kind: str) -> str:
@@ -305,11 +320,13 @@ class ChannelCoreService:
             async def _deliver_deferred_result(result_text: str) -> None:
                 """Deliver deferred result from a timed-out turn via history + events.
 
-                History injection persists the result for LLM context;
-                events.emit pushes it to connected channels in real-time.
-                Mailbox deposit is intentionally omitted — the result is
-                already in history_messages so prepending it again as a
-                "Background Updates" prefix would be redundant.
+                History injection is a hard prerequisite for successful delivery
+                (S2): subsequent turns must be able to cite the final text. A
+                follow-up turn may hold the session lock longer than a single
+                inject timeout, so we retry with blocking waits. run_id dedup
+                keeps re-injects idempotent. Real-time emit only runs after
+                history is durable so we never promise a result that is not
+                in context.
                 """
                 try:
                     msg = {
@@ -324,10 +341,55 @@ class ChannelCoreService:
                             "injected_at": datetime.now(timezone.utc).isoformat(),
                         },
                     }
+                    injected = True
                     if hasattr(self.session_manager, "inject_history_message"):
-                        await self.session_manager.inject_history_message(
-                            session_id, msg, timeout=5.0, blocking=False,
-                        )
+                        injected = False
+                        # Each attempt blocks up to inject_timeout for the lock;
+                        # total budget covers a long follow-up turn holding it.
+                        max_attempts = DEFERRED_HISTORY_INJECT_MAX_ATTEMPTS
+                        inject_timeout = DEFERRED_HISTORY_INJECT_TIMEOUT
+                        for attempt in range(1, max_attempts + 1):
+                            try:
+                                ok = await self.session_manager.inject_history_message(
+                                    session_id,
+                                    msg,
+                                    timeout=inject_timeout,
+                                    blocking=True,
+                                )
+                            except Exception as inject_exc:
+                                logger.warning(
+                                    "Deferred history inject attempt %s/%s raised "
+                                    "(session=%s run_id=%s): %s",
+                                    attempt,
+                                    max_attempts,
+                                    session_id,
+                                    run_id,
+                                    inject_exc,
+                                )
+                                ok = False
+                            if ok:
+                                injected = True
+                                break
+                            logger.warning(
+                                "Deferred history inject attempt %s/%s failed "
+                                "(session=%s run_id=%s); will retry after lock release",
+                                attempt,
+                                max_attempts,
+                                session_id,
+                                run_id,
+                            )
+                            if attempt < max_attempts:
+                                await asyncio.sleep(min(1.0 * attempt, 5.0))
+                        if not injected:
+                            logger.error(
+                                "Failed to inject deferred result into history after "
+                                "%s attempts (session=%s run_id=%s); skipping "
+                                "real-time emit so history remains the source of truth",
+                                max_attempts,
+                                session_id,
+                                run_id,
+                            )
+                            return
                     await events.emit(
                         session_id,
                         {
@@ -404,9 +466,13 @@ class ChannelCoreService:
                     }))
 
                 elif te.type == TurnEventType.TOOL_CALL:
-                    tool_call_count += 1
-                    tool_execution_count += 1
-                    tool_names_executed.append(te.tool_name)
+                    # Align with orchestrator / Telegram user-visible N: hide
+                    # framework-internal resource loaders from command counts.
+                    _visible = (te.tool_name or "") not in USER_HIDDEN_INTERNAL_TOOLS
+                    if _visible:
+                        tool_call_count += 1
+                        tool_execution_count += 1
+                        tool_names_executed.append(te.tool_name)
                     self._record_timeline_event(
                         session_id, "tool_call", tool_name=te.tool_name,
                         args_preview=te.tool_args, args_truncated=te.args_truncated,
@@ -443,11 +509,23 @@ class ChannelCoreService:
                     await on_event(OutboundMessage(session_id, te.content, msg_type="status"))
 
                 elif te.type == TurnEventType.TURN_ERROR:
-                    # Preserve structured stats from the orchestrator
+                    # Write orchestrator stats back to locals before raising so
+                    # turn_end (and channel summaries) see skill-stage tool
+                    # counts that never flowed through TOOL_CALL events.
+                    if te.tool_call_count:
+                        tool_call_count = te.tool_call_count
+                    if te.tool_execution_count:
+                        tool_execution_count = te.tool_execution_count
+                    if te.tool_names_executed:
+                        tool_names_executed = list(te.tool_names_executed)
+                    if te.failed_tool_outputs:
+                        failed_tool_outputs = te.failed_tool_outputs
                     err = RuntimeError(te.error)
-                    err.turn_tool_call_count = te.tool_call_count or tool_call_count
-                    err.turn_tool_names = list(te.tool_names_executed or tool_names_executed)
-                    err.turn_failed_count = te.failed_tool_outputs or failed_tool_outputs
+                    err.turn_tool_call_count = tool_call_count
+                    err.turn_tool_names = list(tool_names_executed)
+                    err.turn_failed_count = failed_tool_outputs
+                    # Only wrapper soft-timeout sets status="timeout" (drain started).
+                    err.is_soft_timeout = (te.status == "timeout")
                     raise err
 
                 elif te.type == TurnEventType.TURN_COMPLETE:
@@ -540,20 +618,31 @@ class ChannelCoreService:
             logger.error("Agent execution error:\n%s", traceback.format_exc())
             should_send_end = True
             try:
+                # Prefer stats attached on the exception (orchestrator TURN_ERROR)
+                # over locals, which may be 0 for skill-stage tool calls.
+                end_tool_call_count = getattr(e, "turn_tool_call_count", None) or tool_call_count
+                end_tool_names = getattr(e, "turn_tool_names", None) or tool_names_executed
+                end_failed = getattr(e, "turn_failed_count", None)
+                if end_failed is None:
+                    end_failed = failed_tool_outputs
+                err_msg = str(e)
+                # Soft-timeout UX only when orchestrator marked status="timeout"
+                # (foreground SoftTimeoutError from _timeout_wrapper). Generic
+                # agent/tool/provider timeouts must not promise deferred delivery.
+                is_soft_timeout = bool(getattr(e, "is_soft_timeout", False))
                 self._record_timeline_event(
                     session_id,
                     "turn_end",
-                    tool_call_count=tool_call_count,
+                    tool_call_count=end_tool_call_count,
                     tool_execution_count=tool_execution_count,
-                    tool_names_executed=tool_names_executed,
-                    failed_tool_outputs=failed_tool_outputs,
+                    tool_names_executed=end_tool_names,
+                    failed_tool_outputs=end_failed,
                     response_length=len(response or ""),
-                    status="error",
-                    error=str(e),
+                    status="timeout" if is_soft_timeout else "error",
+                    error=err_msg,
                     source_type="chat_user",
                     run_id=run_id,
                 )
-                err_msg = str(e)
                 if err_msg.startswith("REPEATED_TOOL_INTENT"):
                     summary = _build_circuit_break_summary(e, "intent")
                     await on_event(OutboundMessage(session_id, summary, msg_type="text"))
@@ -570,10 +659,10 @@ class ChannelCoreService:
                 elif err_msg.startswith("REPEATED_TOOL_FAILURES"):
                     summary = _build_circuit_break_summary(e, "failure")
                     await on_event(OutboundMessage(session_id, summary, msg_type="text"))
-                elif "timeout" in err_msg.lower():
-                    await on_event(OutboundMessage(session_id, (
-                        "本轮执行超时，但后台任务仍在继续。如果任务完成，我会自动推送结果给你。"
-                    ), msg_type="text"))
+                elif is_soft_timeout:
+                    await on_event(OutboundMessage(
+                        session_id, SOFT_TIMEOUT_USER_MESSAGE, msg_type="text",
+                    ))
                 else:
                     await on_event(OutboundMessage(session_id, (
                         "本轮执行遇到错误，未能完成处理。"

--- a/src/everbot/core/runtime/turn_orchestrator.py
+++ b/src/everbot/core/runtime/turn_orchestrator.py
@@ -35,6 +35,14 @@ from .turn_policy import (  # noqa: F401 — re-exported
 logger = logging.getLogger(__name__)
 
 
+class SoftTimeoutError(asyncio.TimeoutError):
+    """Foreground soft-timeout raised only by :func:`_timeout_wrapper`.
+
+    Distinct from agent/tool/provider ``TimeoutError`` so channel UX can promise
+    deferred-drain delivery only when drain was actually started (issue #168).
+    """
+
+
 def _progress_fingerprint(progress: Dict[str, Any]) -> str:
     """Build a stable fingerprint for one progress item.
 
@@ -87,6 +95,25 @@ def _progress_fingerprint(progress: Dict[str, Any]) -> str:
 # ---------------------------------------------------------------------------
 # Helpers (stateless, extracted from ChatService)
 # ---------------------------------------------------------------------------
+
+# Framework-internal tools hidden from user-visible channels (Telegram hides
+# these in skill progress UI). They must not count toward tool_call_count so
+# timeline turn_end.N matches "N commands executed" (issue #168 / S3).
+USER_HIDDEN_INTERNAL_TOOLS = frozenset({
+    "_load_resource_skill",
+    "_read_skill_asset",
+})
+
+
+def _counts_toward_tool_call_budget(tool_name: str, policy: TurnPolicy) -> bool:
+    """Return True if *tool_name* should increment user-visible tool_call_count."""
+    name = tool_name or ""
+    if name in USER_HIDDEN_INTERNAL_TOOLS:
+        return False
+    if name in policy.budget_exempt_tools:
+        return False
+    return True
+
 
 def _is_retryable(exc: Exception, markers: List[str]) -> bool:
     # Turn-level timeouts are NOT transient network errors — retrying would
@@ -640,109 +667,321 @@ class TurnOrchestrator:
             window = _recent_fps[-_LOOP_WINDOW:]
             return len(set(window)) <= 3
 
-        async for event in event_stream:
-            # External cancellation — emit partial results instead of
-            # discarding all work done so far.
-            if cancel_event is not None and cancel_event.is_set():
-                estimated_tokens = max(1, output_chars // 4) if output_chars > 0 else 0
-                yield TurnEvent(
-                    type=TurnEventType.TURN_COMPLETE,
-                    answer=_last_round_response or response or last_successful_tool_output,
-                    tool_call_count=tool_call_count,
-                    tool_execution_count=tool_execution_count,
-                    tool_names_executed=list(tool_names_executed),
-                    failed_tool_outputs=failed_tool_outputs,
-                    output_tokens=estimated_tokens,
-                    status="cancelled",
-                )
-                return
+        def _timeout_error_event(exc: BaseException, *, soft: bool) -> TurnEvent:
+            """Build TURN_ERROR for timeout with stats accumulated so far.
 
-            if not isinstance(event, dict) or "_progress" not in event:
-                non_progress_count += 1
-                if non_progress_count >= policy.max_non_progress_events:
+            Soft-timeout (from ``_timeout_wrapper``) sets ``status="timeout"`` so
+            channels can show deferred-drain UX. Other TimeoutError sources must
+            not set that marker (issue #168 / F-006).
+            """
+            err_msg = str(exc).strip() or "Turn timeout"
+            if "timeout" not in err_msg.lower():
+                err_msg = f"Turn timeout: {err_msg}"
+            return TurnEvent(
+                type=TurnEventType.TURN_ERROR,
+                error=err_msg,
+                status="timeout" if soft else "error",
+                answer=_last_round_response or response,
+                tool_call_count=tool_call_count,
+                tool_execution_count=tool_execution_count,
+                tool_names_executed=list(tool_names_executed),
+                failed_tool_outputs=failed_tool_outputs,
+            )
+
+        try:
+            async for event in event_stream:
+                # External cancellation — emit partial results instead of
+                # discarding all work done so far.
+                if cancel_event is not None and cancel_event.is_set():
+                    estimated_tokens = max(1, output_chars // 4) if output_chars > 0 else 0
                     yield TurnEvent(
-                        type=TurnEventType.TURN_ERROR,
-                        error="TOO_MANY_NON_PROGRESS_EVENTS",
+                        type=TurnEventType.TURN_COMPLETE,
+                        answer=_last_round_response or response or last_successful_tool_output,
+                        tool_call_count=tool_call_count,
+                        tool_execution_count=tool_execution_count,
+                        tool_names_executed=list(tool_names_executed),
+                        failed_tool_outputs=failed_tool_outputs,
+                        output_tokens=estimated_tokens,
+                        status="cancelled",
                     )
                     return
-                continue
 
-            non_progress_count = 0
-            for progress in event.get("_progress", []):
-                stage = progress.get("stage")
-                # LLM deltas are token-level increments: the provider streams each
-                # token exactly once, and identical token text (spaces, digits, URL
-                # fragments, emoji, repeated words) recurs constantly. Content-based
-                # dedup — meant for legacy providers that resent the full accumulated
-                # _progress list on every event — would silently drop those repeats
-                # and corrupt the streamed text (regression: "共6篇"→"共篇",
-                # ".../abs/2606.04923"→"abs93", papers merged). Never dedup llm deltas;
-                # round boundaries are handled by LLM_ROUND_RESET, not by fingerprints.
-                if stage != "llm":
-                    progress_fp = _progress_fingerprint(progress)
-                    if progress_fp in seen_progress_fingerprints:
-                        continue
-                    seen_progress_fingerprints.add(progress_fp)
-                pid = progress.get("id") or ""
-                status = progress.get("status") or ""
+                if not isinstance(event, dict) or "_progress" not in event:
+                    non_progress_count += 1
+                    if non_progress_count >= policy.max_non_progress_events:
+                        yield TurnEvent(
+                            type=TurnEventType.TURN_ERROR,
+                            error="TOO_MANY_NON_PROGRESS_EVENTS",
+                        )
+                        return
+                    continue
 
-                if stage == "llm":
-                    delta = progress.get("delta", "")
-                    answer = progress.get("answer", "")
-                    think = progress.get("think", "")
-                    output_chars += len(delta) + len(think)
-                    if delta:
-                        if not llm_started:
-                            llm_started = True
-                        llm_had_output_this_round = True
-                        consecutive_empty_llm_rounds = 0
-                        consecutive_think_only_rounds = 0
-                        response += delta
-                        _last_round_response += delta
-                        _round_text += delta
-                        yield TurnEvent(type=TurnEventType.LLM_DELTA, content=delta)
-                    if answer and not response:
-                        response = answer
-                        if not llm_started:
-                            llm_started = True
-                        llm_had_output_this_round = True
-                        consecutive_empty_llm_rounds = 0
-                        consecutive_think_only_rounds = 0
-                    # Reasoning output (think) means the model is actively
-                    # working, but it is NOT user-visible text.  We track it
-                    # separately: a few think-only rounds are normal (model
-                    # reasons before calling a tool), but sustained think-only
-                    # rounds with no visible delta indicate a loop.
-                    if think and not llm_had_output_this_round:
-                        llm_had_think_this_round = True
-
-                elif stage == "skill":
-                    if pid and sent_progress.get(pid) == status:
-                        continue
-                    skill_info = progress.get("skill_info") or {}
-                    s_name = skill_info.get("name") or progress.get("tool_name") or ""
-                    s_args = skill_info.get("args") or progress.get("args") or ""
-                    s_output = progress.get("answer") or progress.get("block_answer") or progress.get("output") or ""
-
-                    fail_sig = None  # set in completed/failed branch below
-
-                    if status in ("running", "processing"):
-                        # Identical repeat of an idempotent meta-tool → drop as a
-                        # no-op: no budget, no intent counting, no emit.
-                        if _is_idempotent_noop(s_name, s_args):
+                non_progress_count = 0
+                for progress in event.get("_progress", []):
+                    stage = progress.get("stage")
+                    # LLM deltas are token-level increments: the provider streams each
+                    # token exactly once, and identical token text (spaces, digits, URL
+                    # fragments, emoji, repeated words) recurs constantly. Content-based
+                    # dedup — meant for legacy providers that resent the full accumulated
+                    # _progress list on every event — would silently drop those repeats
+                    # and corrupt the streamed text (regression: "共6篇"→"共篇",
+                    # ".../abs/2606.04923"→"abs93", papers merged). Never dedup llm deltas;
+                    # round boundaries are handled by LLM_ROUND_RESET, not by fingerprints.
+                    if stage != "llm":
+                        progress_fp = _progress_fingerprint(progress)
+                        if progress_fp in seen_progress_fingerprints:
                             continue
-                        # A *novel* tool call means the round made progress: tool-use
-                        # native models legitimately call tools without any narration
-                        # text, so "tool call + no text" is NOT a degradation signal on
-                        # its own. Only a text-less round that ALSO makes no progress
-                        # (a repeated tool intent — going in circles) counts toward the
-                        # empty/think-only loop guards. Repeated intents are additionally
-                        # bounded by the intent-dedup guard below, and distinct runaway
-                        # calls by the tool-call budget. (Fixes EMPTY_OUTPUT_LOOP false
-                        # positives on legitimate multi-step skill workflows; a genuine
-                        # empty LLM response under the streaming model ends the turn
-                        # rather than looping back here.)
-                        intent_sig = _extract_tool_intent_signature(s_name, s_args)
+                        seen_progress_fingerprints.add(progress_fp)
+                    pid = progress.get("id") or ""
+                    status = progress.get("status") or ""
+
+                    if stage == "llm":
+                        delta = progress.get("delta", "")
+                        answer = progress.get("answer", "")
+                        think = progress.get("think", "")
+                        output_chars += len(delta) + len(think)
+                        if delta:
+                            if not llm_started:
+                                llm_started = True
+                            llm_had_output_this_round = True
+                            consecutive_empty_llm_rounds = 0
+                            consecutive_think_only_rounds = 0
+                            response += delta
+                            _last_round_response += delta
+                            _round_text += delta
+                            yield TurnEvent(type=TurnEventType.LLM_DELTA, content=delta)
+                        if answer and not response:
+                            response = answer
+                            if not llm_started:
+                                llm_started = True
+                            llm_had_output_this_round = True
+                            consecutive_empty_llm_rounds = 0
+                            consecutive_think_only_rounds = 0
+                        # Reasoning output (think) means the model is actively
+                        # working, but it is NOT user-visible text.  We track it
+                        # separately: a few think-only rounds are normal (model
+                        # reasons before calling a tool), but sustained think-only
+                        # rounds with no visible delta indicate a loop.
+                        if think and not llm_had_output_this_round:
+                            llm_had_think_this_round = True
+
+                    elif stage == "skill":
+                        if pid and sent_progress.get(pid) == status:
+                            continue
+                        skill_info = progress.get("skill_info") or {}
+                        s_name = skill_info.get("name") or progress.get("tool_name") or ""
+                        s_args = skill_info.get("args") or progress.get("args") or ""
+                        s_output = progress.get("answer") or progress.get("block_answer") or progress.get("output") or ""
+
+                        fail_sig = None  # set in completed/failed branch below
+
+                        if status in ("running", "processing"):
+                            # Identical repeat of an idempotent meta-tool → drop as a
+                            # no-op: no budget, no intent counting, no emit.
+                            if _is_idempotent_noop(s_name, s_args):
+                                continue
+                            # A *novel* tool call means the round made progress: tool-use
+                            # native models legitimately call tools without any narration
+                            # text, so "tool call + no text" is NOT a degradation signal on
+                            # its own. Only a text-less round that ALSO makes no progress
+                            # (a repeated tool intent — going in circles) counts toward the
+                            # empty/think-only loop guards. Repeated intents are additionally
+                            # bounded by the intent-dedup guard below, and distinct runaway
+                            # calls by the tool-call budget. (Fixes EMPTY_OUTPUT_LOOP false
+                            # positives on legitimate multi-step skill workflows; a genuine
+                            # empty LLM response under the streaming model ends the turn
+                            # rather than looping back here.)
+                            intent_sig = _extract_tool_intent_signature(s_name, s_args)
+                            made_progress = bool(intent_sig) and tool_intent_signatures.get(intent_sig, 0) == 0
+                            if made_progress:
+                                consecutive_empty_llm_rounds = 0
+                                consecutive_think_only_rounds = 0
+                            else:
+                                # Empty-output loop detection (only when not progressing)
+                                err = self._check_empty_output_loop(
+                                    llm_had_output_this_round, llm_had_think_this_round,
+                                    tool_execution_count,
+                                    consecutive_empty_llm_rounds, consecutive_think_only_rounds,
+                                    response,
+                                    tool_call_count, tool_names_executed, failed_tool_outputs,
+                                )
+                                if err:
+                                    _flush_trajectory()
+                                    yield err
+                                    return
+                            # Repeated-text loop detection
+                            if tool_execution_count > 0 and _check_round_text_loop():
+                                _flush_trajectory()
+                                yield TurnEvent(
+                                    type=TurnEventType.TURN_ERROR,
+                                    error=f"REPEATED_TEXT_LOOP: {len(_recent_fps)} rounds with {len(set(_recent_fps[-_LOOP_WINDOW:]))} distinct outputs in last {_LOOP_WINDOW}",
+                                    answer=response, tool_call_count=tool_call_count,
+                                    tool_execution_count=tool_execution_count,
+                                    tool_names_executed=list(tool_names_executed),
+                                    failed_tool_outputs=failed_tool_outputs,
+                                )
+                                return
+                            if not made_progress and not llm_had_output_this_round and tool_execution_count > 0:
+                                if llm_had_think_this_round:
+                                    consecutive_think_only_rounds += 1
+                                else:
+                                    consecutive_empty_llm_rounds += 1
+                            # Emit round reset when a new tool call follows LLM output,
+                            # so channel consumers can discard intermediate text.
+                            if llm_had_output_this_round and _last_round_response:
+                                yield TurnEvent(type=TurnEventType.LLM_ROUND_RESET)
+                                _last_round_response = ""
+                            llm_had_output_this_round = False
+                            llm_had_think_this_round = False
+
+                            # Skill invocation → count as tool call (unless exempt /
+                            # user-hidden internal resource loaders).
+                            if _counts_toward_tool_call_budget(s_name, policy):
+                                tool_call_count += 1
+                            if tool_call_count > policy.max_tool_calls:
+                                yield TurnEvent(
+                                    type=TurnEventType.TURN_ERROR,
+                                    error=f"TOOL_CALL_BUDGET_EXCEEDED: tool_calls={tool_call_count}, limit={policy.max_tool_calls}",
+                                    answer=response,
+                                    tool_call_count=tool_call_count,
+                                    tool_execution_count=tool_execution_count,
+                                    tool_names_executed=list(tool_names_executed),
+                                    failed_tool_outputs=failed_tool_outputs,
+                                )
+                                return
+
+                            # Intent dedup check (intent_sig computed above)
+                            err = self._check_intent_dedup(
+                                intent_sig, tool_intent_signatures, warned_intents,
+                                response, tool_call_count, tool_execution_count,
+                                tool_names_executed, failed_tool_outputs,
+                            )
+                            if err:
+                                yield err
+                                return
+                            if pid and intent_sig:
+                                pid_to_intent[pid] = intent_sig
+
+                            tool_execution_count += 1
+                            # Keep tool_names_executed aligned with user-visible
+                            # command counts (exclude framework-internal loaders).
+                            if s_name not in USER_HIDDEN_INTERNAL_TOOLS:
+                                tool_names_executed.append(s_name)
+
+                        elif status in ("completed", "failed"):
+                            # Skill result → track failures
+                            fail_sig = _extract_failure_signature(s_output)
+                            if fail_sig:
+                                failed_tool_outputs += 1
+                                failure_signatures[fail_sig] = failure_signatures.get(fail_sig, 0) + 1
+                                self.accumulated_failures[fail_sig] = failure_signatures[fail_sig]
+                                if (
+                                    failed_tool_outputs >= policy.max_failed_tool_outputs
+                                    or failure_signatures[fail_sig] >= effective_same_failure_limit
+                                ):
+                                    yield TurnEvent(
+                                        type=TurnEventType.TURN_ERROR,
+                                        error=(
+                                            f"REPEATED_TOOL_FAILURES: failed={failed_tool_outputs}, "
+                                            f"signature={fail_sig}, count={failure_signatures[fail_sig]}"
+                                        ),
+                                        answer=response,
+                                        tool_call_count=tool_call_count,
+                                        tool_execution_count=tool_execution_count,
+                                        tool_names_executed=list(tool_names_executed),
+                                        failed_tool_outputs=failed_tool_outputs,
+                                    )
+                                    return
+
+                        # Track last successful skill output for fallback
+                        # Check both: no failure signature AND status is not explicitly "failed"
+                        if not fail_sig and s_output and status != "failed":
+                            last_successful_tool_output = s_output[:policy.max_tool_output_preview_chars]
+
+                        # Inject failure count warning for skill outputs
+                        warn_output = s_output
+                        if fail_sig and failed_tool_outputs >= 1:
+                            sig_count = failure_signatures.get(fail_sig, 0)
+                            sig_max = effective_same_failure_limit
+                            total_max = policy.max_failed_tool_outputs
+                            warn_output = s_output + (
+                                f"\n[⚠ tool_failure {failed_tool_outputs}/{total_max}"
+                                f" (sig {sig_count}/{sig_max}): {fail_sig}."
+                                f" Switch strategy to avoid circuit break.]"
+                            )
+                        # Inject repeated-intent warning so LLM can self-correct
+                        _pid_intent = pid_to_intent.get(pid)
+                        if _pid_intent and not fail_sig:
+                            _out_hash = hashlib.sha256(s_output[:256].encode()).hexdigest()[:12]
+                            _prev_hash = tool_intent_last_output.get(_pid_intent)
+                            if _prev_hash == _out_hash:
+                                warned_intents.add(_pid_intent)
+                                warn_output += (
+                                    f"\n[⚠ repeated_intent: This command returned the same result as"
+                                    f" last time. You already have this output."
+                                    f" Do NOT call it again — include it in your reply now.]"
+                                )
+                            elif _pid_intent in warned_intents:
+                                warn_output += (
+                                    f"\n[⚠ repeated_intent: You have already run this"
+                                    f" same command {tool_intent_signatures.get(_pid_intent, 0)} times."
+                                    f" Do NOT call it again. Respond to the user based"
+                                    f" on information you already have.]"
+                                )
+                            tool_intent_last_output[_pid_intent] = _out_hash
+                        elif _pid_intent and _pid_intent in warned_intents:
+                            warn_output += (
+                                f"\n[⚠ repeated_intent: You have already run this"
+                                f" same command {tool_intent_signatures.get(_pid_intent, 0)} times."
+                                f" Do NOT call it again. Respond to the user based"
+                                f" on information you already have.]"
+                            )
+
+                        yield TurnEvent(
+                            type=TurnEventType.SKILL,
+                            pid=pid, status=status,
+                            skill_name=s_name, skill_args=s_args, skill_output=warn_output,
+                        )
+                        if pid:
+                            sent_progress[pid] = status
+
+                    elif stage == "tool_call":
+                        t_name = progress.get("tool_name", "")
+
+                        # Phantom tool guard: detect calls to unregistered tools
+                        if self._get_registered_tools is not None:
+                            registered = self._get_registered_tools()
+                            if t_name and t_name not in registered:
+                                phantom_tool_counts[t_name] = phantom_tool_counts.get(t_name, 0) + 1
+                                if phantom_tool_counts[t_name] > policy.max_phantom_tool_calls:
+                                    _flush_trajectory()
+                                    yield TurnEvent(
+                                        type=TurnEventType.TURN_ERROR,
+                                        error=(
+                                            f"PHANTOM_TOOL: tool `{t_name}` is not registered, "
+                                            f"called {phantom_tool_counts[t_name]} times, "
+                                            f"limit={policy.max_phantom_tool_calls}"
+                                        ),
+                                        answer=response,
+                                        tool_call_count=tool_call_count,
+                                        tool_execution_count=tool_execution_count,
+                                        tool_names_executed=list(tool_names_executed),
+                                        failed_tool_outputs=failed_tool_outputs,
+                                    )
+                                    return
+                                if pid:
+                                    phantom_pids[pid] = t_name
+
+                        # A novel tool call means progress (see the skill branch above):
+                        # tool-use without narration is not a degradation signal; only a
+                        # text-less round that repeats a tool intent counts toward the
+                        # empty/think-only loop guards.
+                        t_args_raw = progress.get("args", "")
+                        # Identical repeat of an idempotent meta-tool → drop as a no-op
+                        # (parity with the skill branch above).
+                        if status in ("running", "processing") and _is_idempotent_noop(t_name, t_args_raw):
+                            continue
+                        intent_sig = _extract_tool_intent_signature(t_name, t_args_raw)
                         made_progress = bool(intent_sig) and tool_intent_signatures.get(intent_sig, 0) == 0
                         if made_progress:
                             consecutive_empty_llm_rounds = 0
@@ -777,16 +1016,13 @@ class TurnOrchestrator:
                                 consecutive_think_only_rounds += 1
                             else:
                                 consecutive_empty_llm_rounds += 1
-                        # Emit round reset when a new tool call follows LLM output,
-                        # so channel consumers can discard intermediate text.
                         if llm_had_output_this_round and _last_round_response:
                             yield TurnEvent(type=TurnEventType.LLM_ROUND_RESET)
                             _last_round_response = ""
                         llm_had_output_this_round = False
                         llm_had_think_this_round = False
 
-                        # Skill invocation → count as tool call (unless exempt)
-                        if s_name not in policy.budget_exempt_tools:
+                        if _counts_toward_tool_call_budget(t_name, policy):
                             tool_call_count += 1
                         if tool_call_count > policy.max_tool_calls:
                             yield TurnEvent(
@@ -799,6 +1035,8 @@ class TurnOrchestrator:
                                 failed_tool_outputs=failed_tool_outputs,
                             )
                             return
+                        if pid and sent_progress.get(pid) == status:
+                            continue
 
                         # Intent dedup check (intent_sig computed above)
                         err = self._check_intent_dedup(
@@ -812,12 +1050,24 @@ class TurnOrchestrator:
                         if pid and intent_sig:
                             pid_to_intent[pid] = intent_sig
 
+                        args_preview, args_trunc, args_total = _truncate_preview(t_args_raw, policy.max_tool_args_preview_chars)
                         tool_execution_count += 1
-                        tool_names_executed.append(s_name)
+                        if t_name not in USER_HIDDEN_INTERNAL_TOOLS:
+                            tool_names_executed.append(t_name)
+                        yield TurnEvent(
+                            type=TurnEventType.TOOL_CALL,
+                            pid=pid, status=status,
+                            tool_name=t_name, tool_args=args_preview,
+                            args_truncated=args_trunc, args_total_chars=args_total,
+                        )
+                        if pid:
+                            sent_progress[pid] = status
 
-                    elif status in ("completed", "failed"):
-                        # Skill result → track failures
-                        fail_sig = _extract_failure_signature(s_output)
+                    elif stage == "tool_output":
+                        if pid and sent_progress.get(pid) == status:
+                            continue
+                        t_output_raw = progress.get("output", "")
+                        fail_sig = _extract_failure_signature(t_output_raw)
                         if fail_sig:
                             failed_tool_outputs += 1
                             failure_signatures[fail_sig] = failure_signatures.get(fail_sig, 0) + 1
@@ -840,265 +1090,78 @@ class TurnOrchestrator:
                                 )
                                 return
 
-                    # Track last successful skill output for fallback
-                    # Check both: no failure signature AND status is not explicitly "failed"
-                    if not fail_sig and s_output and status != "failed":
-                        last_successful_tool_output = s_output[:policy.max_tool_output_preview_chars]
+                        out_preview, out_trunc, out_total = _truncate_preview(t_output_raw, policy.max_tool_output_preview_chars)
 
-                    # Inject failure count warning for skill outputs
-                    warn_output = s_output
-                    if fail_sig and failed_tool_outputs >= 1:
-                        sig_count = failure_signatures.get(fail_sig, 0)
-                        sig_max = effective_same_failure_limit
-                        total_max = policy.max_failed_tool_outputs
-                        warn_output = s_output + (
-                            f"\n[⚠ tool_failure {failed_tool_outputs}/{total_max}"
-                            f" (sig {sig_count}/{sig_max}): {fail_sig}."
-                            f" Switch strategy to avoid circuit break.]"
-                        )
-                    # Inject repeated-intent warning so LLM can self-correct
-                    _pid_intent = pid_to_intent.get(pid)
-                    if _pid_intent and not fail_sig:
-                        _out_hash = hashlib.sha256(s_output[:256].encode()).hexdigest()[:12]
-                        _prev_hash = tool_intent_last_output.get(_pid_intent)
-                        if _prev_hash == _out_hash:
-                            warned_intents.add(_pid_intent)
-                            warn_output += (
-                                f"\n[⚠ repeated_intent: This command returned the same result as"
-                                f" last time. You already have this output."
-                                f" Do NOT call it again — include it in your reply now.]"
+                        # Inject failure count warning so LLM can see how close
+                        # it is to the circuit breaker and switch strategy.
+                        if fail_sig and failed_tool_outputs >= 1:
+                            sig_count = failure_signatures.get(fail_sig, 0)
+                            sig_max = effective_same_failure_limit
+                            total_max = policy.max_failed_tool_outputs
+                            out_preview += (
+                                f"\n[⚠ tool_failure {failed_tool_outputs}/{total_max}"
+                                f" (sig {sig_count}/{sig_max}): {fail_sig}."
+                                f" Switch strategy to avoid circuit break.]"
                             )
-                        elif _pid_intent in warned_intents:
-                            warn_output += (
-                                f"\n[⚠ repeated_intent: You have already run this"
-                                f" same command {tool_intent_signatures.get(_pid_intent, 0)} times."
-                                f" Do NOT call it again. Respond to the user based"
-                                f" on information you already have.]"
-                            )
-                        tool_intent_last_output[_pid_intent] = _out_hash
-                    elif _pid_intent and _pid_intent in warned_intents:
-                        warn_output += (
-                            f"\n[⚠ repeated_intent: You have already run this"
-                            f" same command {tool_intent_signatures.get(_pid_intent, 0)} times."
-                            f" Do NOT call it again. Respond to the user based"
-                            f" on information you already have.]"
-                        )
-
-                    yield TurnEvent(
-                        type=TurnEventType.SKILL,
-                        pid=pid, status=status,
-                        skill_name=s_name, skill_args=s_args, skill_output=warn_output,
-                    )
-                    if pid:
-                        sent_progress[pid] = status
-
-                elif stage == "tool_call":
-                    t_name = progress.get("tool_name", "")
-
-                    # Phantom tool guard: detect calls to unregistered tools
-                    if self._get_registered_tools is not None:
-                        registered = self._get_registered_tools()
-                        if t_name and t_name not in registered:
-                            phantom_tool_counts[t_name] = phantom_tool_counts.get(t_name, 0) + 1
-                            if phantom_tool_counts[t_name] > policy.max_phantom_tool_calls:
-                                _flush_trajectory()
-                                yield TurnEvent(
-                                    type=TurnEventType.TURN_ERROR,
-                                    error=(
-                                        f"PHANTOM_TOOL: tool `{t_name}` is not registered, "
-                                        f"called {phantom_tool_counts[t_name]} times, "
-                                        f"limit={policy.max_phantom_tool_calls}"
-                                    ),
-                                    answer=response,
-                                    tool_call_count=tool_call_count,
-                                    tool_execution_count=tool_execution_count,
-                                    tool_names_executed=list(tool_names_executed),
-                                    failed_tool_outputs=failed_tool_outputs,
+                        # Inject repeated-intent warning so LLM can self-correct
+                        _pid_intent = pid_to_intent.get(pid)
+                        if _pid_intent and not fail_sig:
+                            _out_hash = hashlib.sha256(t_output_raw[:256].encode()).hexdigest()[:12]
+                            _prev_hash = tool_intent_last_output.get(_pid_intent)
+                            if _prev_hash == _out_hash:
+                                # Same successful output as last time — agent is stuck
+                                warned_intents.add(_pid_intent)
+                                out_preview += (
+                                    f"\n[⚠ repeated_intent: This command returned the same result as"
+                                    f" last time. You already have this output."
+                                    f" Do NOT call it again — include it in your reply now.]"
                                 )
-                                return
-                            if pid:
-                                phantom_pids[pid] = t_name
-
-                    # A novel tool call means progress (see the skill branch above):
-                    # tool-use without narration is not a degradation signal; only a
-                    # text-less round that repeats a tool intent counts toward the
-                    # empty/think-only loop guards.
-                    t_args_raw = progress.get("args", "")
-                    # Identical repeat of an idempotent meta-tool → drop as a no-op
-                    # (parity with the skill branch above).
-                    if status in ("running", "processing") and _is_idempotent_noop(t_name, t_args_raw):
-                        continue
-                    intent_sig = _extract_tool_intent_signature(t_name, t_args_raw)
-                    made_progress = bool(intent_sig) and tool_intent_signatures.get(intent_sig, 0) == 0
-                    if made_progress:
-                        consecutive_empty_llm_rounds = 0
-                        consecutive_think_only_rounds = 0
-                    else:
-                        # Empty-output loop detection (only when not progressing)
-                        err = self._check_empty_output_loop(
-                            llm_had_output_this_round, llm_had_think_this_round,
-                            tool_execution_count,
-                            consecutive_empty_llm_rounds, consecutive_think_only_rounds,
-                            response,
-                            tool_call_count, tool_names_executed, failed_tool_outputs,
-                        )
-                        if err:
-                            _flush_trajectory()
-                            yield err
-                            return
-                    # Repeated-text loop detection
-                    if tool_execution_count > 0 and _check_round_text_loop():
-                        _flush_trajectory()
-                        yield TurnEvent(
-                            type=TurnEventType.TURN_ERROR,
-                            error=f"REPEATED_TEXT_LOOP: {len(_recent_fps)} rounds with {len(set(_recent_fps[-_LOOP_WINDOW:]))} distinct outputs in last {_LOOP_WINDOW}",
-                            answer=response, tool_call_count=tool_call_count,
-                            tool_execution_count=tool_execution_count,
-                            tool_names_executed=list(tool_names_executed),
-                            failed_tool_outputs=failed_tool_outputs,
-                        )
-                        return
-                    if not made_progress and not llm_had_output_this_round and tool_execution_count > 0:
-                        if llm_had_think_this_round:
-                            consecutive_think_only_rounds += 1
-                        else:
-                            consecutive_empty_llm_rounds += 1
-                    if llm_had_output_this_round and _last_round_response:
-                        yield TurnEvent(type=TurnEventType.LLM_ROUND_RESET)
-                        _last_round_response = ""
-                    llm_had_output_this_round = False
-                    llm_had_think_this_round = False
-
-                    if t_name not in policy.budget_exempt_tools:
-                        tool_call_count += 1
-                    if tool_call_count > policy.max_tool_calls:
-                        yield TurnEvent(
-                            type=TurnEventType.TURN_ERROR,
-                            error=f"TOOL_CALL_BUDGET_EXCEEDED: tool_calls={tool_call_count}, limit={policy.max_tool_calls}",
-                            answer=response,
-                            tool_call_count=tool_call_count,
-                            tool_execution_count=tool_execution_count,
-                            tool_names_executed=list(tool_names_executed),
-                            failed_tool_outputs=failed_tool_outputs,
-                        )
-                        return
-                    if pid and sent_progress.get(pid) == status:
-                        continue
-
-                    # Intent dedup check (intent_sig computed above)
-                    err = self._check_intent_dedup(
-                        intent_sig, tool_intent_signatures, warned_intents,
-                        response, tool_call_count, tool_execution_count,
-                        tool_names_executed, failed_tool_outputs,
-                    )
-                    if err:
-                        yield err
-                        return
-                    if pid and intent_sig:
-                        pid_to_intent[pid] = intent_sig
-
-                    args_preview, args_trunc, args_total = _truncate_preview(t_args_raw, policy.max_tool_args_preview_chars)
-                    tool_execution_count += 1
-                    tool_names_executed.append(t_name)
-                    yield TurnEvent(
-                        type=TurnEventType.TOOL_CALL,
-                        pid=pid, status=status,
-                        tool_name=t_name, tool_args=args_preview,
-                        args_truncated=args_trunc, args_total_chars=args_total,
-                    )
-                    if pid:
-                        sent_progress[pid] = status
-
-                elif stage == "tool_output":
-                    if pid and sent_progress.get(pid) == status:
-                        continue
-                    t_output_raw = progress.get("output", "")
-                    fail_sig = _extract_failure_signature(t_output_raw)
-                    if fail_sig:
-                        failed_tool_outputs += 1
-                        failure_signatures[fail_sig] = failure_signatures.get(fail_sig, 0) + 1
-                        self.accumulated_failures[fail_sig] = failure_signatures[fail_sig]
-                        if (
-                            failed_tool_outputs >= policy.max_failed_tool_outputs
-                            or failure_signatures[fail_sig] >= effective_same_failure_limit
-                        ):
-                            yield TurnEvent(
-                                type=TurnEventType.TURN_ERROR,
-                                error=(
-                                    f"REPEATED_TOOL_FAILURES: failed={failed_tool_outputs}, "
-                                    f"signature={fail_sig}, count={failure_signatures[fail_sig]}"
-                                ),
-                                answer=response,
-                                tool_call_count=tool_call_count,
-                                tool_execution_count=tool_execution_count,
-                                tool_names_executed=list(tool_names_executed),
-                                failed_tool_outputs=failed_tool_outputs,
-                            )
-                            return
-
-                    out_preview, out_trunc, out_total = _truncate_preview(t_output_raw, policy.max_tool_output_preview_chars)
-
-                    # Inject failure count warning so LLM can see how close
-                    # it is to the circuit breaker and switch strategy.
-                    if fail_sig and failed_tool_outputs >= 1:
-                        sig_count = failure_signatures.get(fail_sig, 0)
-                        sig_max = effective_same_failure_limit
-                        total_max = policy.max_failed_tool_outputs
-                        out_preview += (
-                            f"\n[⚠ tool_failure {failed_tool_outputs}/{total_max}"
-                            f" (sig {sig_count}/{sig_max}): {fail_sig}."
-                            f" Switch strategy to avoid circuit break.]"
-                        )
-                    # Inject repeated-intent warning so LLM can self-correct
-                    _pid_intent = pid_to_intent.get(pid)
-                    if _pid_intent and not fail_sig:
-                        _out_hash = hashlib.sha256(t_output_raw[:256].encode()).hexdigest()[:12]
-                        _prev_hash = tool_intent_last_output.get(_pid_intent)
-                        if _prev_hash == _out_hash:
-                            # Same successful output as last time — agent is stuck
-                            warned_intents.add(_pid_intent)
-                            out_preview += (
-                                f"\n[⚠ repeated_intent: This command returned the same result as"
-                                f" last time. You already have this output."
-                                f" Do NOT call it again — include it in your reply now.]"
-                            )
-                        elif _pid_intent in warned_intents:
+                            elif _pid_intent in warned_intents:
+                                out_preview += (
+                                    f"\n[⚠ repeated_intent: You have already run this"
+                                    f" same command {tool_intent_signatures.get(_pid_intent, 0)} times."
+                                    f" Do NOT call it again. Respond to the user based"
+                                    f" on information you already have.]"
+                                )
+                            tool_intent_last_output[_pid_intent] = _out_hash
+                        elif _pid_intent and _pid_intent in warned_intents:
                             out_preview += (
                                 f"\n[⚠ repeated_intent: You have already run this"
                                 f" same command {tool_intent_signatures.get(_pid_intent, 0)} times."
                                 f" Do NOT call it again. Respond to the user based"
                                 f" on information you already have.]"
                             )
-                        tool_intent_last_output[_pid_intent] = _out_hash
-                    elif _pid_intent and _pid_intent in warned_intents:
-                        out_preview += (
-                            f"\n[⚠ repeated_intent: You have already run this"
-                            f" same command {tool_intent_signatures.get(_pid_intent, 0)} times."
-                            f" Do NOT call it again. Respond to the user based"
-                            f" on information you already have.]"
-                        )
 
-                    # Phantom tool correction: tell LLM this tool doesn't exist
-                    _phantom_name = phantom_pids.pop(pid, None) if pid else None
-                    if _phantom_name:
-                        out_preview += (
-                            f"\n[⚠ PHANTOM_TOOL: `{_phantom_name}` is not a registered tool"
-                            f" and cannot be called. Use registered tools"
-                            f" (_bash, _python, _grep, etc.) to complete the task.]"
-                        )
+                        # Phantom tool correction: tell LLM this tool doesn't exist
+                        _phantom_name = phantom_pids.pop(pid, None) if pid else None
+                        if _phantom_name:
+                            out_preview += (
+                                f"\n[⚠ PHANTOM_TOOL: `{_phantom_name}` is not a registered tool"
+                                f" and cannot be called. Use registered tools"
+                                f" (_bash, _python, _grep, etc.) to complete the task.]"
+                            )
 
-                    yield TurnEvent(
-                        type=TurnEventType.TOOL_OUTPUT,
-                        pid=pid, status="failed" if fail_sig else "success",
-                        tool_name=progress.get("tool_name", ""),
-                        tool_output=out_preview,
-                        output_truncated=out_trunc, output_total_chars=out_total,
-                        reference_id=progress.get("reference_id", ""),
-                    )
-                    if not fail_sig and t_output_raw:
-                        last_successful_tool_output = t_output_raw[:policy.max_tool_output_preview_chars]
-                    if pid:
-                        sent_progress[pid] = status
+                        yield TurnEvent(
+                            type=TurnEventType.TOOL_OUTPUT,
+                            pid=pid, status="failed" if fail_sig else "success",
+                            tool_name=progress.get("tool_name", ""),
+                            tool_output=out_preview,
+                            output_truncated=out_trunc, output_total_chars=out_total,
+                            reference_id=progress.get("reference_id", ""),
+                        )
+                        if not fail_sig and t_output_raw:
+                            last_successful_tool_output = t_output_raw[:policy.max_tool_output_preview_chars]
+                        if pid:
+                            sent_progress[pid] = status
+
+        except SoftTimeoutError as exc:
+            # Foreground soft-timeout from _timeout_wrapper (drain started).
+            yield _timeout_error_event(exc, soft=True)
+            return
+        except (asyncio.TimeoutError, TimeoutError) as exc:
+            # Agent/tool/provider timeout — not deferred-drain soft-timeout.
+            yield _timeout_error_event(exc, soft=False)
+            return
 
         # Fallback: if LLM produced no text but the last tool returned
         # substantial output, use that output as the response so the user
@@ -1150,97 +1213,160 @@ async def _timeout_wrapper(
     Uses manual ``__anext__()`` instead of ``async for`` so that when a
     timeout occurs the underlying iterator is **not** closed via
     ``athrow()``—it can be handed off to a background drain task.
+
+    Critical: do **not** use ``asyncio.wait_for`` on ``__anext__`` when a
+    drain callback is registered. ``wait_for`` cancels the in-flight
+    ``__anext__`` on timeout, which injects ``CancelledError`` into the
+    agent async generator and aborts work that deferred-drain is supposed
+    to finish. Instead we race a non-cancelling wait and hand the pending
+    task to drain.
     """
     loop = asyncio.get_event_loop()
     deadline = loop.time() + timeout
     aiter = stream.__aiter__()
-    while True:
-        remaining = deadline - loop.time()
-        if remaining <= 0:
-            # Already past deadline
-            if on_timeout_drain is not None:
-                asyncio.create_task(
-                    _drain_after_timeout(aiter, on_timeout_drain, drain_extra_seconds),
-                    name="deferred-drain",
-                )
-            else:
-                try:
-                    await aiter.aclose()
-                except Exception:
-                    pass
-            raise asyncio.TimeoutError(f"Turn exceeded {timeout}s timeout")
-        try:
-            item = await asyncio.wait_for(aiter.__anext__(), timeout=remaining)
-        except StopAsyncIteration:
-            return
-        except asyncio.TimeoutError:
-            if on_timeout_drain is not None:
-                asyncio.create_task(
-                    _drain_after_timeout(aiter, on_timeout_drain, drain_extra_seconds),
-                    name="deferred-drain",
-                )
-            else:
-                try:
-                    await aiter.aclose()
-                except Exception:
-                    pass
-            raise asyncio.TimeoutError(f"Turn exceeded {timeout}s timeout")
-        yield item
+    pending_anext: Optional[asyncio.Task] = None
+
+    def _start_drain(pending: Optional[asyncio.Task]) -> None:
+        if on_timeout_drain is not None:
+            asyncio.create_task(
+                _drain_after_timeout(
+                    aiter,
+                    on_timeout_drain,
+                    drain_extra_seconds,
+                    pending_anext=pending,
+                ),
+                name="deferred-drain",
+            )
+        else:
+            if pending is not None and not pending.done():
+                pending.cancel()
+            try:
+                # Best-effort close when no drain path will continue the stream.
+                close = getattr(aiter, "aclose", None)
+                if close is not None:
+                    asyncio.create_task(close())
+            except Exception:
+                pass
+
+    try:
+        while True:
+            remaining = deadline - loop.time()
+            if remaining <= 0:
+                _start_drain(pending_anext)
+                pending_anext = None
+                raise SoftTimeoutError(f"Turn exceeded {timeout}s timeout")
+
+            if pending_anext is None:
+                pending_anext = asyncio.ensure_future(aiter.__anext__())
+
+            done, _ = await asyncio.wait({pending_anext}, timeout=remaining)
+            if not done:
+                # Soft timeout: leave pending_anext running for drain.
+                _start_drain(pending_anext)
+                pending_anext = None
+                raise SoftTimeoutError(f"Turn exceeded {timeout}s timeout")
+
+            task = pending_anext
+            pending_anext = None
+            try:
+                item = task.result()
+            except StopAsyncIteration:
+                return
+            yield item
+    except GeneratorExit:
+        if pending_anext is not None and not pending_anext.done():
+            pending_anext.cancel()
+        raise
 
 
 async def _drain_after_timeout(
     aiter: AsyncIterator,
     on_result: Callable,
     extra_timeout: float,
+    *,
+    pending_anext: Optional[asyncio.Task] = None,
 ) -> None:
-    """Continue consuming an event stream after timeout and deliver collected results."""
+    """Continue consuming an event stream after timeout and deliver collected results.
+
+    ``pending_anext`` is an in-flight ``__anext__`` task that must not be
+    cancelled on soft timeout (see ``_timeout_wrapper``). Drain awaits it
+    first, then continues with further ``__anext__`` calls.
+    """
     deadline = asyncio.get_event_loop().time() + extra_timeout
     collected_outputs: list[str] = []
     final_response = ""
     seen_progress_fingerprints: set[str] = set()
+
+    def _ingest(item: Any) -> None:
+        nonlocal final_response
+        if not isinstance(item, dict) or "_progress" not in item:
+            return
+        for progress in item.get("_progress", []):
+            progress_fp = _progress_fingerprint(progress)
+            if progress_fp in seen_progress_fingerprints:
+                continue
+            seen_progress_fingerprints.add(progress_fp)
+            stage = progress.get("stage")
+            status = progress.get("status", "")
+            if stage == "skill" and status in ("completed", "failed"):
+                # Skip internal resource-loading tools — their output
+                # is framework-internal (contains [PIN] markers, full
+                # SKILL.md content) and must not be forwarded to the user.
+                skill_info = progress.get("skill_info") or {}
+                skill_name = skill_info.get("name") or progress.get("tool_name") or ""
+                if skill_name in ("_load_resource_skill", "_read_skill_asset"):
+                    continue
+                output = (
+                    progress.get("answer")
+                    or progress.get("block_answer")
+                    or progress.get("output")
+                    or ""
+                )
+                if output:
+                    collected_outputs.append(output)
+            elif stage == "llm":
+                delta = progress.get("delta", "")
+                answer = progress.get("answer", "")
+                if delta:
+                    final_response += delta
+                elif answer:
+                    final_response = answer
+
+    in_flight: Optional[asyncio.Task] = pending_anext
     try:
+        # Drain must never cancel an in-flight __anext__ until the whole drain
+        # window expires. asyncio.wait_for without shield would cancel the
+        # generator mid-tool, aborting work that still has remaining budget
+        # (e.g. progress then >60s silence before final text within 300s).
         while asyncio.get_event_loop().time() < deadline:
+            remaining = deadline - asyncio.get_event_loop().time()
+            if remaining <= 0:
+                break
+            if in_flight is None:
+                in_flight = asyncio.ensure_future(aiter.__anext__())
+            done, _ = await asyncio.wait({in_flight}, timeout=remaining)
+            if not done:
+                # Drain window exhausted while __anext__ still running.
+                break
+            task = in_flight
+            in_flight = None
             try:
-                item = await asyncio.wait_for(aiter.__anext__(), timeout=60)
+                item = task.result()
             except StopAsyncIteration:
                 break
-            except asyncio.TimeoutError:
-                continue
-            if not isinstance(item, dict) or "_progress" not in item:
-                continue
-            for progress in item.get("_progress", []):
-                progress_fp = _progress_fingerprint(progress)
-                if progress_fp in seen_progress_fingerprints:
-                    continue
-                seen_progress_fingerprints.add(progress_fp)
-                stage = progress.get("stage")
-                status = progress.get("status", "")
-                if stage == "skill" and status in ("completed", "failed"):
-                    # Skip internal resource-loading tools — their output
-                    # is framework-internal (contains [PIN] markers, full
-                    # SKILL.md content) and must not be forwarded to the user.
-                    skill_info = progress.get("skill_info") or {}
-                    skill_name = skill_info.get("name") or progress.get("tool_name") or ""
-                    if skill_name in ("_load_resource_skill", "_read_skill_asset"):
-                        continue
-                    output = (
-                        progress.get("answer")
-                        or progress.get("block_answer")
-                        or progress.get("output")
-                        or ""
-                    )
-                    if output:
-                        collected_outputs.append(output)
-                elif stage == "llm":
-                    delta = progress.get("delta", "")
-                    answer = progress.get("answer", "")
-                    if delta:
-                        final_response += delta
-                    elif answer:
-                        final_response = answer
+            except Exception as e:
+                logger.warning("Deferred drain anext error: %s", e)
+                break
+            _ingest(item)
     except Exception as e:
         logger.warning("Deferred drain error: %s", e)
     finally:
+        if in_flight is not None and not in_flight.done():
+            in_flight.cancel()
+            try:
+                await in_flight
+            except (asyncio.CancelledError, Exception):
+                pass
         try:
             await aiter.aclose()
         except Exception:

--- a/src/everbot/web/services/chat_service.py
+++ b/src/everbot/web/services/chat_service.py
@@ -142,7 +142,13 @@ class ChatService:
             # Heartbeat body content must be visible only via primary-session mailbox drain.
             if event_type in {"message", "delta", "skill"} or "_progress" in data:
                 return
-        bypass_idle_gate = source_type in {"time_reminder", "heartbeat", "heartbeat_delivery"}
+        # deferred_result must bypass the idle gate: soft-timeout users are
+        # still "active" within 20s, and the final answer often arrives ~+30s
+        # after timeout (issue #168). Dropping it here makes deferred delivery
+        # appear broken even when history inject succeeded.
+        bypass_idle_gate = source_type in {
+            "time_reminder", "heartbeat", "heartbeat_delivery", "deferred_result",
+        }
 
         if routing.scope == "agent" and agent_name:
             # Agent-scope idle gate: throttle by last broadcast time (not user activity)

--- a/tests/unit/test_channel_core_service.py
+++ b/tests/unit/test_channel_core_service.py
@@ -527,3 +527,732 @@ class TestWorkspaceInstructionsHelpersMilkieSafe:
             agent = SimpleNamespace(executor=SimpleNamespace(context=ctx))
             core._cache_runtime_workspace_instructions(agent, "test_agent")
             assert core._runtime_workspace_instructions_by_agent.get("test_agent") == "DOLPHIN WS"
+
+
+# ---------------------------------------------------------------------------
+# Issue #168: soft-timeout copy, turn_end stats, deferred delivery
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_soft_timeout_user_message_semantics(monkeypatch):
+    """S1: Soft-timeout copy must say background continues + auto-push; not hard-fail."""
+    agent = _TurnErrorAgent()
+
+    class _FakeTurnOrchestrator:
+        def __init__(self, _policy, **_kw):
+            self.accumulated_failures = {}
+
+        async def run_turn(self, *_args, **_kwargs):
+            from src.everbot.core.runtime.turn_policy import TurnEvent, TurnEventType
+            yield TurnEvent(
+                type=TurnEventType.TURN_ERROR,
+                error="Turn exceeded 0.3s timeout",
+                status="timeout",
+                tool_call_count=5,
+                tool_names_executed=["_bash", "search"],
+                failed_tool_outputs=0,
+            )
+
+    monkeypatch.setattr(
+        "src.everbot.core.channel.core_service.TurnOrchestrator",
+        _FakeTurnOrchestrator,
+    )
+
+    with tempfile.TemporaryDirectory() as tmp:
+        core = _make_core_service(Path(tmp))
+        collector = _EventCollector()
+        await core.process_message(
+            agent, "demo_agent", "web_session_demo_agent", "hi", collector,
+        )
+
+    texts = [t.content for t in collector.payloads_by_type("text")]
+    assert texts, "expected a soft-timeout text outbound"
+    joined = "\n".join(texts)
+    assert "后台" in joined and "继续" in joined
+    assert any(k in joined for k in ("自动推送", "推送到本会话", "推送结果"))
+    assert "未能完成处理" not in joined
+    assert "执行失败" not in joined
+
+    # Hard-fail stack bubble must not be the primary conclusion for soft timeout
+    errors = collector.payloads_by_type("error")
+    assert not errors, f"soft timeout must not emit error payload: {errors}"
+
+
+@pytest.mark.asyncio
+async def test_soft_timeout_turn_end_status_and_tool_count(monkeypatch):
+    """S3: turn_end on soft timeout has status=timeout and tool_call_count from orchestrator."""
+    agent = _TurnErrorAgent()
+
+    class _FakeTurnOrchestrator:
+        def __init__(self, _policy, **_kw):
+            self.accumulated_failures = {}
+
+        async def run_turn(self, *_args, **_kwargs):
+            from src.everbot.core.runtime.turn_policy import TurnEvent, TurnEventType
+            # Skill-stage tools never increment core_service local counters;
+            # stats only arrive on TURN_ERROR from the orchestrator.
+            yield TurnEvent(
+                type=TurnEventType.TURN_ERROR,
+                error="Turn exceeded 600s timeout",
+                status="timeout",
+                tool_call_count=8,
+                tool_execution_count=8,
+                tool_names_executed=["a", "b", "c", "d", "e", "f", "g", "h"],
+                failed_tool_outputs=0,
+            )
+
+    monkeypatch.setattr(
+        "src.everbot.core.channel.core_service.TurnOrchestrator",
+        _FakeTurnOrchestrator,
+    )
+
+    with tempfile.TemporaryDirectory() as tmp:
+        core = _make_core_service(Path(tmp))
+        collector = _EventCollector()
+        await core.process_message(
+            agent, "demo_agent", "web_session_demo_agent", "long task", collector,
+        )
+
+    timeline = core.session_manager._timeline_events
+    turn_ends = [e for e in timeline if e.get("type") == "turn_end" or e.get("event_type") == "turn_end"]
+    # append_timeline_event stores the event dict as passed
+    if not turn_ends:
+        # Event may store type under different keys depending on _record_timeline_event
+        turn_ends = [e for e in timeline if "turn_end" in str(e.get("type", e.get("event", "")))]
+    assert turn_ends, f"expected turn_end in timeline, got: {timeline}"
+    te = turn_ends[-1]
+    assert te.get("tool_call_count") == 8, te
+    assert te.get("status") == "timeout", te
+
+
+@pytest.mark.asyncio
+async def test_soft_timeout_end_to_end_drain_history_and_timeline(monkeypatch):
+    """S2 integration path: short timeout → soft copy → deferred final → history + emit.
+
+    Uses a real TurnOrchestrator with a scripted agent (mock channel sink).
+    """
+    import asyncio
+    from src.everbot.core.runtime.turn_policy import TurnPolicy
+
+    final_text = "DEFERRED_FINAL_ANSWER_168"
+    emitted = []
+
+    class _SlowFinishAgent:
+        name = "dummy_agent"
+
+        def __init__(self):
+            self.executor = SimpleNamespace(context=_DummyContext())
+            self.state = AgentState.INITIALIZED
+
+        async def continue_chat(self, **_kwargs):
+            # Two skill tools (count as N=2 in orchestrator, not local core_service)
+            for i in range(2):
+                yield {
+                    "_progress": [{
+                        "id": f"sk{i}",
+                        "stage": "skill",
+                        "status": "processing",
+                        "skill_info": {"name": f"tool_{i}", "args": f"a{i}"},
+                    }],
+                }
+                yield {
+                    "_progress": [{
+                        "id": f"sk{i}",
+                        "stage": "skill",
+                        "status": "completed",
+                        "skill_info": {"name": f"tool_{i}"},
+                        "output": f"out{i}",
+                    }],
+                }
+            await asyncio.sleep(0.35)
+            yield {
+                "_progress": [{
+                    "id": "llm1",
+                    "stage": "llm",
+                    "status": "running",
+                    "delta": final_text,
+                }],
+            }
+
+    def _short_policy(*_a, **_k):
+        return TurnPolicy(
+            max_attempts=1,
+            timeout_seconds=0.15,
+            drain_extra_seconds=2.0,
+            max_tool_calls=50,
+            max_same_tool_intent=50,
+        )
+
+    async def _fake_emit(source_session_id, data, **kwargs):
+        emitted.append((source_session_id, data, kwargs))
+
+    monkeypatch.setattr(
+        "src.everbot.core.channel.core_service.build_chat_policy",
+        _short_policy,
+    )
+    monkeypatch.setattr(
+        "src.everbot.core.channel.core_service.events.emit",
+        _fake_emit,
+    )
+
+    agent = _SlowFinishAgent()
+    with tempfile.TemporaryDirectory() as tmp:
+        core = _make_core_service(Path(tmp))
+        collector = _EventCollector()
+        await core.process_message(
+            agent, "demo_agent", "web_session_demo_agent", "run long", collector,
+        )
+
+        # Soft-timeout copy first
+        texts = [t.content for t in collector.payloads_by_type("text")]
+        assert texts, "expected soft-timeout text"
+        assert any("后台" in t and "继续" in t for t in texts)
+
+        # turn_end stats
+        timeline = core.session_manager._timeline_events
+        turn_ends = [
+            e for e in timeline
+            if e.get("type") == "turn_end" or e.get("event_type") == "turn_end"
+        ]
+        assert turn_ends, timeline
+        te = turn_ends[-1]
+        assert te.get("status") == "timeout", te
+        assert te.get("tool_call_count") == 2, te
+
+        # Wait for deferred drain
+        for _ in range(40):
+            if emitted:
+                break
+            await asyncio.sleep(0.1)
+
+        assert emitted, "deferred_result must be emitted after drain"
+        _sid, data, kwargs = emitted[0]
+        assert data.get("source_type") == "deferred_result"
+        assert final_text in data.get("detail", "")
+        assert kwargs.get("source_type") == "deferred_result"
+        assert kwargs.get("scope") == "session"
+        assert kwargs.get("target_session_id") == "web_session_demo_agent"
+
+        core.session_manager.inject_history_message.assert_awaited()
+        inj_args = core.session_manager.inject_history_message.await_args
+        msg = inj_args.args[1] if inj_args.args and len(inj_args.args) > 1 else inj_args.kwargs.get("message")
+        assert msg is not None
+        assert msg.get("metadata", {}).get("source") == "deferred_result"
+        assert final_text in msg.get("content", "")
+        assert "超时后台任务完成后自动生成" in msg.get("content", "")
+
+
+@pytest.mark.asyncio
+async def test_soft_timeout_deferred_persists_to_real_session_history(monkeypatch):
+    """S2 E2E: real SessionManager history is readable after deferred delivery.
+
+    Uses a real SessionManager (disk-backed) + mock channel sink. After soft
+    timeout and drain, the deferred final must be loadable from history and
+    available as context for a subsequent turn.
+    """
+    import asyncio
+    from unittest.mock import MagicMock
+
+    from src.everbot.core.runtime.turn_policy import TurnPolicy
+    from src.everbot.core.session.session import SessionManager
+    from src.everbot.infra.dolphin_compat import KEY_HISTORY
+
+    final_text = "PERSISTED_DEFERRED_FINAL_168"
+    session_id = "web_session_demo_agent"
+    emitted = []
+
+    class _StubProvider:
+        """In-memory provider so process_message does not need milkie serve."""
+
+        def __init__(self):
+            self._vars: dict = {KEY_HISTORY: []}
+
+        def is_paused(self, _agent):
+            return False
+
+        def is_error(self, _agent):
+            return False
+
+        def set_variable(self, _agent, key, value):
+            self._vars[key] = value
+
+        def get_variable(self, _agent, key):
+            return self._vars.get(key)
+
+        def set_session_id(self, agent, session_id_):
+            agent.context_id = session_id_
+
+        def init_trajectory(self, *_a, **_k):
+            return None
+
+        def needs_history_restore(self):
+            return True
+
+        def export_session(self, _agent):
+            return {
+                "history_messages": list(self._vars.get(KEY_HISTORY) or []),
+                "variables": dict(self._vars),
+            }
+
+        def restore_history(self, _agent, history):
+            self._vars[KEY_HISTORY] = list(history or [])
+
+    stub = _StubProvider()
+
+    class _SlowFinishAgent:
+        name = "demo_agent"
+
+        def __init__(self):
+            self.executor = SimpleNamespace(context=_DummyContext())
+            self.state = AgentState.INITIALIZED
+            self.context_id = "unset"
+            self.base_url = "http://stub"
+
+        async def continue_chat(self, **_kwargs):
+            # One internal resource tool + two visible tools → user-visible N=2
+            yield {
+                "_progress": [{
+                    "id": "sk_int",
+                    "stage": "skill",
+                    "status": "processing",
+                    "skill_info": {"name": "_load_resource_skill", "args": "x"},
+                }],
+            }
+            yield {
+                "_progress": [{
+                    "id": "sk_int",
+                    "stage": "skill",
+                    "status": "completed",
+                    "skill_info": {"name": "_load_resource_skill"},
+                    "output": "skill md",
+                }],
+            }
+            for i in range(2):
+                yield {
+                    "_progress": [{
+                        "id": f"sk{i}",
+                        "stage": "skill",
+                        "status": "processing",
+                        "skill_info": {"name": f"tool_{i}", "args": f"a{i}"},
+                    }],
+                }
+                yield {
+                    "_progress": [{
+                        "id": f"sk{i}",
+                        "stage": "skill",
+                        "status": "completed",
+                        "skill_info": {"name": f"tool_{i}"},
+                        "output": f"out{i}",
+                    }],
+                }
+            await asyncio.sleep(0.35)
+            yield {
+                "_progress": [{
+                    "id": "llm1",
+                    "stage": "llm",
+                    "status": "running",
+                    "delta": final_text,
+                }],
+            }
+
+    def _short_policy(*_a, **_k):
+        return TurnPolicy(
+            max_attempts=1,
+            timeout_seconds=0.15,
+            drain_extra_seconds=2.0,
+            max_tool_calls=50,
+            max_same_tool_intent=50,
+        )
+
+    async def _fake_emit(source_session_id, data, **kwargs):
+        emitted.append((source_session_id, data, kwargs))
+
+    monkeypatch.setattr(
+        "src.everbot.core.channel.core_service.build_chat_policy",
+        _short_policy,
+    )
+    monkeypatch.setattr(
+        "src.everbot.core.channel.core_service.events.emit",
+        _fake_emit,
+    )
+    monkeypatch.setattr(
+        "src.everbot.core.channel.core_service.provider_for",
+        lambda _agent: stub,
+    )
+    # save_session may still talk to provider; keep it lightweight via real SM
+    # but stub export used on error path.
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        sm = SessionManager(tmp_path)
+        ud = _make_user_data_mock(tmp_path)
+        core = ChannelCoreService.__new__(ChannelCoreService)
+        core.session_manager = sm
+        core.user_data = ud
+        core.agent_service = None
+        core._session_failure_memory = {}
+        # Avoid full WorkspaceLoader / strategy init paths that need config
+        core._primary_context_strategy = MagicMock()
+        core._primary_context_strategy.build_system_prompt = MagicMock(return_value=None)
+        core._runtime_deps = MagicMock()
+
+        collector = _EventCollector()
+        agent = _SlowFinishAgent()
+        await core.process_message(
+            agent, "demo_agent", session_id, "run long real history", collector,
+        )
+
+        texts = [t.content for t in collector.payloads_by_type("text")]
+        assert texts and any("后台" in t and "继续" in t for t in texts)
+
+        # Wait for deferred drain + real inject_history_message
+        for _ in range(40):
+            if emitted:
+                break
+            await asyncio.sleep(0.1)
+        assert emitted, "deferred_result must be emitted"
+
+        # --- Read back real persisted history ---
+        history = await core.load_history(session_id)
+        deferred_msgs = [
+            m for m in history
+            if isinstance(m, dict)
+            and (m.get("metadata") or {}).get("source") == "deferred_result"
+        ]
+        assert deferred_msgs, f"expected deferred_result in history, got: {history}"
+        assert final_text in deferred_msgs[-1].get("content", "")
+        assert "超时后台任务完成后自动生成" in deferred_msgs[-1].get("content", "")
+
+        # turn_end tool_call_count is user-visible N=2 (internal loader excluded)
+        # Timeline lives on SessionManager; collect from disk session if present
+        session_data = await sm.load_session(session_id)
+        assert session_data is not None
+        # Timeline may be in-memory and/or persisted depending on save path
+        timeline = []
+        if hasattr(sm, "_timeline_events"):
+            tl = sm._timeline_events
+            if isinstance(tl, dict):
+                timeline = list(tl.get(session_id) or [])
+            elif isinstance(tl, list):
+                timeline = list(tl)
+        if not timeline and session_data.timeline:
+            timeline = list(session_data.timeline)
+        turn_ends = [
+            e for e in timeline
+            if isinstance(e, dict) and (
+                e.get("type") == "turn_end" or e.get("event_type") == "turn_end"
+            )
+        ]
+        assert turn_ends, f"expected turn_end, timeline={timeline}"
+        te = turn_ends[-1]
+        assert te.get("status") == "timeout", te
+        assert te.get("tool_call_count") == 2, te
+
+        # Subsequent turn context: history still carries deferred final
+        history2 = await core.load_history(session_id)
+        assert any(final_text in (m.get("content") or "") for m in history2 if isinstance(m, dict))
+        # Provider-facing restore path would see the same messages
+        stub.restore_history(agent, history2)
+        restored = stub.get_variable(agent, KEY_HISTORY)
+        assert any(
+            final_text in (m.get("content") or "")
+            for m in (restored or [])
+            if isinstance(m, dict)
+        )
+
+
+@pytest.mark.asyncio
+async def test_non_soft_timeout_error_not_promised_as_deferred(monkeypatch):
+    """F-006: plain TimeoutError / 'timeout' text must not send soft-timeout copy.
+
+    Agent/tool/provider timeouts do not start deferred-drain; users must not
+    be told background work continues or that a result will auto-push.
+    """
+    agent = _TurnErrorAgent()
+
+    class _FakeTurnOrchestrator:
+        def __init__(self, _policy, **_kw):
+            self.accumulated_failures = {}
+
+        async def run_turn(self, *_args, **_kwargs):
+            from src.everbot.core.runtime.turn_policy import TurnEvent, TurnEventType
+            # status intentionally not "timeout" — not a wrapper soft-timeout
+            yield TurnEvent(
+                type=TurnEventType.TURN_ERROR,
+                error="TimeoutError: provider request timed out after 30s",
+                status="error",
+                tool_call_count=2,
+                tool_names_executed=["search", "fetch"],
+                failed_tool_outputs=0,
+            )
+
+    monkeypatch.setattr(
+        "src.everbot.core.channel.core_service.TurnOrchestrator",
+        _FakeTurnOrchestrator,
+    )
+
+    with tempfile.TemporaryDirectory() as tmp:
+        core = _make_core_service(Path(tmp))
+        collector = _EventCollector()
+        await core.process_message(
+            agent, "demo_agent", "web_session_demo_agent", "search stuff", collector,
+        )
+
+    texts = [t.content for t in collector.payloads_by_type("text")]
+    joined = "\n".join(texts)
+    assert "后台" not in joined or "继续" not in joined, (
+        f"must not promise background continuation for non-soft timeout: {joined!r}"
+    )
+    assert "自动推送" not in joined
+    assert "推送到本会话" not in joined
+    # Hard-failure path should be used
+    assert any("未能完成处理" in t for t in texts) or collector.payloads_by_type("error")
+
+    timeline = core.session_manager._timeline_events
+    turn_ends = [
+        e for e in timeline
+        if e.get("type") == "turn_end" or e.get("event_type") == "turn_end"
+    ]
+    assert turn_ends, timeline
+    assert turn_ends[-1].get("status") == "error", turn_ends[-1]
+    assert turn_ends[-1].get("status") != "timeout"
+
+
+@pytest.mark.asyncio
+async def test_deferred_history_retries_while_session_lock_held(monkeypatch):
+    """F-005 / S2: follow-up turn holding lock longer than inject timeout still lands history.
+
+    inject_history_message may return False while another turn holds the session
+    lock past a single 5s attempt. Delivery must retry and only emit after
+    history is written.
+    """
+    import asyncio
+    from unittest.mock import MagicMock
+
+    import src.everbot.core.channel.core_service as core_mod
+    from src.everbot.core.runtime.turn_policy import TurnPolicy
+    from src.everbot.core.session.session import SessionManager
+
+    final_text = "DEFERRED_AFTER_LOCK_CONTENTION_168"
+    session_id = "web_session_demo_agent"
+    emitted: list = []
+    inject_attempts = {"n": 0}
+
+    # Shorten only retry backoffs (s >= 1.0); leave agent hang sleep intact.
+    _real_sleep = core_mod.asyncio.sleep
+
+    async def _selective_sleep(s):
+        if s >= 1.0:
+            return None
+        return await _real_sleep(s)
+
+    monkeypatch.setattr(core_mod.asyncio, "sleep", _selective_sleep)
+
+    class _StubProvider:
+        def __init__(self):
+            self._vars: dict = {KEY_HISTORY: []}
+
+        def is_paused(self, _agent):
+            return False
+
+        def is_error(self, _agent):
+            return False
+
+        def set_variable(self, _agent, key, value):
+            self._vars[key] = value
+
+        def get_variable(self, _agent, key):
+            return self._vars.get(key)
+
+        def set_session_id(self, agent, session_id_):
+            agent.context_id = session_id_
+
+        def init_trajectory(self, *_a, **_k):
+            return None
+
+        def needs_history_restore(self):
+            return True
+
+        def export_session(self, _agent):
+            return {
+                "history_messages": list(self._vars.get(KEY_HISTORY) or []),
+                "variables": dict(self._vars),
+            }
+
+        def restore_history(self, _agent, history):
+            self._vars[KEY_HISTORY] = list(history or [])
+
+    stub = _StubProvider()
+
+    class _SlowFinishAgent:
+        name = "demo_agent"
+
+        def __init__(self):
+            self.executor = SimpleNamespace(context=_DummyContext())
+            self.state = AgentState.INITIALIZED
+            self.context_id = "unset"
+            self.base_url = "http://stub"
+
+        async def continue_chat(self, **_kwargs):
+            yield {
+                "_progress": [{
+                    "id": "sk0",
+                    "stage": "skill",
+                    "status": "processing",
+                    "skill_info": {"name": "tool_0", "args": "a0"},
+                }],
+            }
+            yield {
+                "_progress": [{
+                    "id": "sk0",
+                    "stage": "skill",
+                    "status": "completed",
+                    "skill_info": {"name": "tool_0"},
+                    "output": "out0",
+                }],
+            }
+            await asyncio.sleep(0.35)
+            yield {
+                "_progress": [{
+                    "id": "llm1",
+                    "stage": "llm",
+                    "status": "running",
+                    "delta": final_text,
+                }],
+            }
+
+    def _short_policy(*_a, **_k):
+        return TurnPolicy(
+            max_attempts=1,
+            timeout_seconds=0.15,
+            drain_extra_seconds=3.0,
+            max_tool_calls=50,
+            max_same_tool_intent=50,
+        )
+
+    async def _fake_emit(source_session_id, data, **kwargs):
+        emitted.append((source_session_id, data, kwargs))
+
+    monkeypatch.setattr(
+        "src.everbot.core.channel.core_service.build_chat_policy",
+        _short_policy,
+    )
+    monkeypatch.setattr(
+        "src.everbot.core.channel.core_service.events.emit",
+        _fake_emit,
+    )
+    monkeypatch.setattr(
+        "src.everbot.core.channel.core_service.provider_for",
+        lambda _agent: stub,
+    )
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        sm = SessionManager(tmp_path)
+
+        real_inject = sm.inject_history_message
+
+        async def _contended_inject(sid, message, *, timeout=5.0, blocking=True):
+            inject_attempts["n"] += 1
+            # First two attempts fail as if lock held past inject timeout
+            # (follow-up turn longer than one inject_timeout).
+            if inject_attempts["n"] <= 2:
+                return False
+            return await real_inject(sid, message, timeout=timeout, blocking=blocking)
+
+        sm.inject_history_message = _contended_inject  # type: ignore[method-assign]
+
+        ud = _make_user_data_mock(tmp_path)
+        core = ChannelCoreService.__new__(ChannelCoreService)
+        core.session_manager = sm
+        core.user_data = ud
+        core.agent_service = None
+        core._session_failure_memory = {}
+        core._primary_context_strategy = MagicMock()
+        core._primary_context_strategy.build_system_prompt = MagicMock(return_value=None)
+        core._runtime_deps = MagicMock()
+
+        collector = _EventCollector()
+        agent = _SlowFinishAgent()
+        await core.process_message(
+            agent, "demo_agent", session_id, "run under contention", collector,
+        )
+
+        # Wait for deferred drain + retries
+        for _ in range(60):
+            if emitted:
+                break
+            await asyncio.sleep(0.1)
+
+        assert inject_attempts["n"] >= 3, (
+            f"expected retries under lock contention, got {inject_attempts['n']}"
+        )
+        assert emitted, "emit only after successful history inject; expected emit after retries"
+
+        history = await core.load_history(session_id)
+        deferred_msgs = [
+            m for m in history
+            if isinstance(m, dict)
+            and (m.get("metadata") or {}).get("source") == "deferred_result"
+        ]
+        assert deferred_msgs, f"expected deferred_result in history after contention, got: {history}"
+        assert final_text in deferred_msgs[-1].get("content", "")
+
+
+@pytest.mark.asyncio
+async def test_deferred_skips_emit_when_history_inject_never_succeeds(monkeypatch):
+    """F-005: if history inject exhausts retries, do not emit deferred_result."""
+    import src.everbot.core.channel.core_service as core_mod
+
+    agent = _TurnErrorAgent()
+    emitted: list = []
+    inject_calls = {"n": 0}
+    captured: dict = {}
+
+    class _FakeTurnOrchestrator:
+        def __init__(self, _policy, **_kw):
+            self.accumulated_failures = {}
+
+        async def run_turn(self, *_args, **kwargs):
+            from src.everbot.core.runtime.turn_policy import TurnEvent, TurnEventType
+            captured["on_deferred"] = kwargs.get("on_deferred_result")
+            yield TurnEvent(
+                type=TurnEventType.TURN_ERROR,
+                error="Turn exceeded 0.3s timeout",
+                status="timeout",
+                tool_call_count=1,
+            )
+
+    async def _fake_emit(*_a, **_k):
+        emitted.append((_a, _k))
+
+    async def _always_fail_inject(*_a, **_k):
+        inject_calls["n"] += 1
+        return False
+
+    async def _fast_sleep(_s):
+        return None
+
+    monkeypatch.setattr(
+        "src.everbot.core.channel.core_service.TurnOrchestrator",
+        _FakeTurnOrchestrator,
+    )
+    monkeypatch.setattr(
+        "src.everbot.core.channel.core_service.events.emit",
+        _fake_emit,
+    )
+    monkeypatch.setattr(core_mod, "DEFERRED_HISTORY_INJECT_MAX_ATTEMPTS", 3)
+    monkeypatch.setattr(core_mod.asyncio, "sleep", _fast_sleep)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        core = _make_core_service(Path(tmp))
+        core.session_manager.inject_history_message = _always_fail_inject
+        collector = _EventCollector()
+        await core.process_message(
+            agent, "demo_agent", "web_session_demo_agent", "hi", collector,
+        )
+        assert captured.get("on_deferred") is not None
+        # Invoke deliver path directly (same closure used by drain callback).
+        await captured["on_deferred"]("SHOULD_NOT_EMIT_WITHOUT_HISTORY")
+
+    assert inject_calls["n"] >= 3, f"expected exhausted retries, got {inject_calls['n']}"
+    assert not emitted, f"must not emit without durable history, got {emitted}"

--- a/tests/unit/test_chat_service_stream_filter.py
+++ b/tests/unit/test_chat_service_stream_filter.py
@@ -298,3 +298,76 @@ async def test_process_message_stops_on_repeated_tool_failures():
     )
     assert websocket.sent[-1]["type"] == "end"
     service.session_manager.save_session.assert_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Issue #168: Web idle gate must bypass deferred_result
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_deferred_result_bypasses_web_idle_gate():
+    """S2: deferred_result must be pushed even when last_activity is within 20s.
+
+    Soft-timeout users are necessarily "active"; the idle gate would otherwise
+    drop the +N-second deferred final that arrives after timeout.
+    """
+    import time
+    from unittest.mock import MagicMock
+
+    service = ChatService.__new__(ChatService)
+    service._active_connections = {}
+    service._connections_by_agent = {}
+    service._last_activity = {}
+    service._last_agent_broadcast = {}
+    service._bootstrap_locks = {}
+
+    sid = "web_session_demo_agent"
+    ws = _DummyWebSocket()
+    service._active_connections[sid] = {ws}
+    # Simulate recent user activity (within idle window)
+    service._last_activity[sid] = time.time()
+
+    payload = {
+        "detail": "FINAL after timeout",
+        "source_type": "deferred_result",
+        "deliver": True,
+        "scope": "session",
+        "target_session_id": sid,
+        "target_channel": "web",
+        "agent_name": "demo_agent",
+        "run_id": "chat_abc123",
+    }
+    await service._on_background_event(sid, payload)
+    assert ws.sent, "deferred_result must bypass idle gate and be pushed to WS"
+    assert ws.sent[0]["source_type"] == "deferred_result"
+    assert "FINAL after timeout" in ws.sent[0]["detail"]
+
+
+@pytest.mark.asyncio
+async def test_non_bypass_source_still_idle_gated():
+    """Control: ordinary session-scope events remain idle-gated within 20s."""
+    import time
+
+    service = ChatService.__new__(ChatService)
+    service._active_connections = {}
+    service._connections_by_agent = {}
+    service._last_activity = {}
+    service._last_agent_broadcast = {}
+    service._bootstrap_locks = {}
+
+    sid = "web_session_demo_agent"
+    ws = _DummyWebSocket()
+    service._active_connections[sid] = {ws}
+    service._last_activity[sid] = time.time()
+
+    payload = {
+        "detail": "should be gated",
+        "source_type": "inspector_push",
+        "deliver": True,
+        "scope": "session",
+        "target_session_id": sid,
+        "target_channel": "web",
+        "agent_name": "demo_agent",
+    }
+    await service._on_background_event(sid, payload)
+    assert not ws.sent, "non-bypass source_type must still be idle-gated"

--- a/tests/unit/test_turn_orchestrator.py
+++ b/tests/unit/test_turn_orchestrator.py
@@ -11,11 +11,14 @@ from src.everbot.core.runtime.turn_orchestrator import (
     CHAT_POLICY,
     HEARTBEAT_POLICY,
     JOB_POLICY,
+    SoftTimeoutError,
+    USER_HIDDEN_INTERNAL_TOOLS,
     WORKFLOW_POLICY,
     TurnEvent,
     TurnEventType,
     TurnOrchestrator,
     TurnPolicy,
+    _counts_toward_tool_call_budget,
     _drain_after_timeout,
     _extract_failure_signature,
     _extract_tool_intent_signature,
@@ -2833,3 +2836,291 @@ async def test_issue136_real_run_no_longer_trips_budget():
     complete = next(e for e in events if e.type == TurnEventType.TURN_COMPLETE)
     # 7 run_command + 5 个不同 update_step = 12;cite/create_plan 豁免,重复 step 丢弃
     assert complete.tool_call_count == 12, complete.tool_call_count
+
+
+# ---------------------------------------------------------------------------
+# Issue #168: soft-timeout stats + deferred drain end-to-end
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_timeout_turn_error_preserves_tool_call_count():
+    """S3: Timeout after N tool calls must yield TURN_ERROR with tool_call_count=N.
+
+    Root cause: TimeoutError bubbled out of _run_attempt and the outer
+    run_turn handler emitted a bare TURN_ERROR without stats, so skill-stage
+    tool counts (only held inside _run_attempt) were lost.
+    """
+    n = 3
+    script = []
+    for i in range(n):
+        script.append(_progress_event(_skill_call(f"tool_{i}", f"arg{i}", pid=f"sk{i}")))
+        script.append(_progress_event(_skill_output(f"tool_{i}", f"out{i}", pid=f"sk{i}")))
+
+    class _HangAfterTools:
+        async def continue_chat(self, **kwargs):
+            for item in script:
+                yield item
+            await asyncio.sleep(999999)
+            yield _progress_event(_llm_delta("never"))
+
+    orch = TurnOrchestrator(TurnPolicy(
+        max_attempts=1,
+        timeout_seconds=0.25,
+        max_tool_calls=50,
+        max_same_tool_intent=50,
+    ))
+    events: list[TurnEvent] = []
+    try:
+        async for te in orch.run_turn(_HangAfterTools(), "hi"):
+            events.append(te)
+    except asyncio.TimeoutError:
+        pytest.fail("TimeoutError must be converted to TURN_ERROR with stats, not re-raised")
+
+    errors = [e for e in events if e.type == TurnEventType.TURN_ERROR]
+    assert len(errors) == 1, f"Expected 1 TURN_ERROR, got {[e.type for e in events]}"
+    assert "timeout" in (errors[0].error or "").lower()
+    assert errors[0].status == "timeout", "wrapper soft-timeout must set status=timeout"
+    assert errors[0].tool_call_count == n, (
+        f"Expected tool_call_count={n}, got {errors[0].tool_call_count}"
+    )
+    assert len(errors[0].tool_names_executed) == n
+
+
+@pytest.mark.asyncio
+async def test_non_wrapper_timeout_error_is_not_soft_timeout():
+    """F-006: agent/tool TimeoutError must not be marked as soft-timeout.
+
+    Soft-timeout UX promises deferred drain delivery; only SoftTimeoutError
+    from _timeout_wrapper starts that drain. Generic TimeoutError must yield
+    TURN_ERROR without status=timeout.
+    """
+
+    class _AgentTimeout:
+        async def continue_chat(self, **kwargs):
+            yield _progress_event(_skill_call("search", "q", pid="sk0"))
+            yield _progress_event(_skill_output("search", "partial", pid="sk0"))
+            raise TimeoutError("provider request timed out after 30s")
+
+    orch = TurnOrchestrator(TurnPolicy(
+        max_attempts=1,
+        # No wrapper timeout — the agent itself raises TimeoutError.
+        timeout_seconds=None,
+        max_tool_calls=50,
+        max_same_tool_intent=50,
+    ))
+    events: list[TurnEvent] = []
+    async for te in orch.run_turn(_AgentTimeout(), "hi"):
+        events.append(te)
+
+    errors = [e for e in events if e.type == TurnEventType.TURN_ERROR]
+    assert len(errors) == 1, f"expected TURN_ERROR, got {[e.type for e in events]}"
+    assert "timeout" in (errors[0].error or "").lower()
+    assert errors[0].status != "timeout", (
+        f"non-wrapper TimeoutError must not set soft-timeout status, got {errors[0].status!r}"
+    )
+    # Stats still preserved for diagnostics
+    assert errors[0].tool_call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_timeout_wrapper_raises_soft_timeout_error():
+    """F-006: _timeout_wrapper raises SoftTimeoutError, not bare TimeoutError."""
+
+    async def _hang():
+        await asyncio.sleep(999)
+        yield _progress_event(_llm_delta("never"))
+
+    items = []
+    with pytest.raises(SoftTimeoutError) as ei:
+        async for item in _timeout_wrapper(_hang(), timeout=0.05):
+            items.append(item)
+    assert "timeout" in str(ei.value).lower()
+
+
+@pytest.mark.asyncio
+async def test_timeout_turn_error_preserves_tool_call_stage_count():
+    """S3: Same as above but with stage=tool_call/tool_output events."""
+    n = 2
+    script = []
+    for i in range(n):
+        script.append(_progress_event(_tool_call(f"_bash", f"echo {i}", pid=f"tc{i}")))
+        script.append(_progress_event(_tool_output(f"_bash", f"ok{i}", pid=f"to{i}")))
+
+    class _HangAfterTools:
+        async def continue_chat(self, **kwargs):
+            for item in script:
+                yield item
+            await asyncio.sleep(999999)
+
+    orch = TurnOrchestrator(TurnPolicy(
+        max_attempts=1,
+        timeout_seconds=0.25,
+        max_tool_calls=50,
+        max_same_tool_intent=50,
+    ))
+    events: list[TurnEvent] = []
+    async for te in orch.run_turn(_HangAfterTools(), "hi"):
+        events.append(te)
+
+    errors = [e for e in events if e.type == TurnEventType.TURN_ERROR]
+    assert len(errors) == 1
+    assert errors[0].tool_call_count == n
+    assert "timeout" in errors[0].error.lower()
+    assert errors[0].status == "timeout"
+
+
+@pytest.mark.asyncio
+async def test_timeout_drain_delivers_final_llm_text():
+    """S2: After soft timeout, drain continues the stream and delivers final text."""
+    deferred: list[str] = []
+
+    class _ToolsThenFinal:
+        async def continue_chat(self, **kwargs):
+            yield _progress_event(_skill_call("search", "q", pid="sk0"))
+            yield _progress_event(_skill_output("search", "partial", pid="sk0"))
+            # Hang past the foreground timeout, then finish with final text.
+            await asyncio.sleep(0.4)
+            yield _progress_event(_llm_delta("FINAL_DRAFT_FOR_USER"))
+
+    async def _on_deferred(text: str):
+        deferred.append(text)
+
+    orch = TurnOrchestrator(TurnPolicy(
+        max_attempts=1,
+        timeout_seconds=0.15,
+        drain_extra_seconds=2.0,
+        max_tool_calls=50,
+        max_same_tool_intent=50,
+    ))
+    events: list[TurnEvent] = []
+    async for te in orch.run_turn(
+        _ToolsThenFinal(), "hi", on_deferred_result=_on_deferred,
+    ):
+        events.append(te)
+
+    errors = [e for e in events if e.type == TurnEventType.TURN_ERROR]
+    assert len(errors) == 1
+    assert errors[0].tool_call_count == 1
+
+    # Wait for background drain task
+    for _ in range(30):
+        if deferred:
+            break
+        await asyncio.sleep(0.1)
+
+    assert deferred, "deferred drain must deliver final LLM text"
+    assert "FINAL_DRAFT_FOR_USER" in deferred[0]
+
+
+@pytest.mark.asyncio
+async def test_timeout_tool_call_count_excludes_internal_resource_tools():
+    """S3: user-visible N excludes _load_resource_skill / _read_skill_asset.
+
+    Telegram hides these; timeline turn_end.tool_call_count must match the
+    channel command count (filtered N), not raw milkie tool.responded.
+    """
+    script = [
+        _progress_event(_skill_call("_load_resource_skill", "paper-discovery", pid="sk0")),
+        _progress_event(_skill_output("_load_resource_skill", "SKILL.md", pid="sk0")),
+        _progress_event(_skill_call("_read_skill_asset", "refs.md", pid="sk1")),
+        _progress_event(_skill_output("_read_skill_asset", "asset", pid="sk1")),
+        _progress_event(_skill_call("web_search", "q", pid="sk2")),
+        _progress_event(_skill_output("web_search", "hits", pid="sk2")),
+        _progress_event(_skill_call("_bash", "echo 1", pid="sk3")),
+        _progress_event(_skill_output("_bash", "1", pid="sk3")),
+    ]
+
+    class _HangAfterMix:
+        async def continue_chat(self, **kwargs):
+            for item in script:
+                yield item
+            await asyncio.sleep(999999)
+
+    orch = TurnOrchestrator(TurnPolicy(
+        max_attempts=1,
+        timeout_seconds=0.25,
+        max_tool_calls=50,
+        max_same_tool_intent=50,
+    ))
+    events: list[TurnEvent] = []
+    async for te in orch.run_turn(_HangAfterMix(), "hi"):
+        events.append(te)
+
+    errors = [e for e in events if e.type == TurnEventType.TURN_ERROR]
+    assert len(errors) == 1
+    assert "timeout" in (errors[0].error or "").lower()
+    # Only web_search + _bash are user-visible → N=2
+    assert errors[0].tool_call_count == 2, errors[0].tool_call_count
+    assert "_load_resource_skill" not in (errors[0].tool_names_executed or [])
+    assert "_read_skill_asset" not in (errors[0].tool_names_executed or [])
+    # Sanity: filter helper matches Telegram hide list
+    assert USER_HIDDEN_INTERNAL_TOOLS == frozenset({
+        "_load_resource_skill", "_read_skill_asset",
+    })
+    policy = TurnPolicy()
+    assert not _counts_toward_tool_call_budget("_load_resource_skill", policy)
+    assert _counts_toward_tool_call_budget("web_search", policy)
+
+
+@pytest.mark.asyncio
+async def test_drain_long_gap_within_window_delivers_without_cancel():
+    """S2: progress then long silence still within drain window → final delivered.
+
+    Regression for cancelling wait_for(timeout=60) on subsequent __anext__:
+    the agent generator must not be cancelled while remaining drain budget
+    still allows completion.
+    """
+    cancelled = {"hit": False}
+    results: list[str] = []
+
+    async def _stream():
+        try:
+            yield _progress_event(_skill_call("search", "q", pid="sk0"))
+            yield _progress_event(_skill_output("search", "partial", pid="sk0"))
+            # Gap longer than the old hard-coded 60s intermediate would cancel
+            # in production; here we use a short drain window and a gap that
+            # still fits inside it to prove non-cancelling wait.
+            await asyncio.sleep(0.9)
+            yield _progress_event(_llm_delta("LATE_FINAL_WITHIN_WINDOW"))
+        except asyncio.CancelledError:
+            cancelled["hit"] = True
+            raise
+
+    async def _on_result(text: str):
+        results.append(text)
+
+    await _drain_after_timeout(_stream(), _on_result, extra_timeout=2.0)
+
+    assert not cancelled["hit"], "drain must not cancel in-flight __anext__ within window"
+    assert results, "final text must be delivered after long mid-window gap"
+    assert "LATE_FINAL_WITHIN_WINDOW" in results[0]
+
+
+@pytest.mark.asyncio
+async def test_drain_pending_anext_long_gap_delivers():
+    """S2: in-flight pending_anext that finishes late but in-window is delivered."""
+    cancelled = {"hit": False}
+    results: list[str] = []
+
+    async def _gen():
+        try:
+            await asyncio.sleep(0.8)
+            yield _progress_event(_llm_delta("FROM_PENDING_ANEXT"))
+        except asyncio.CancelledError:
+            cancelled["hit"] = True
+            raise
+
+    aiter = _gen().__aiter__()
+    pending = asyncio.ensure_future(aiter.__anext__())
+    # Let the anext start sleeping before drain attaches.
+    await asyncio.sleep(0.05)
+
+    async def _on_result(text: str):
+        results.append(text)
+
+    await _drain_after_timeout(
+        aiter, _on_result, extra_timeout=2.0, pending_anext=pending,
+    )
+
+    assert not cancelled["hit"]
+    assert results and "FROM_PENDING_ANEXT" in results[0]


### PR DESCRIPTION
## Summary

Closes #168.

- **S1 Soft-timeout UX**: only structured `SoftTimeoutError` from the turn timeout wrapper shows “background still running / may auto-push” copy; ordinary agent/tool/provider timeouts stay hard-error paths.
- **S2 Deferred delivery**: non-cancelling drain for the full `drain_extra_seconds` window; history inject checks return value + retries under session lock contention; emit `deferred_result` only after durable history write; Web chat idle gate **bypasses** `deferred_result`.
- **S3 Tool stats**: timeout `TURN_ERROR` / `turn_end` keep accumulated user-visible tool counts; exclude internal resource tools (`_load_resource_skill` / `_read_skill_asset`) consistently with Telegram hide list.
- Docs: `docs/design/168-chat-soft-timeout-deferred.md` + `docs/runtime_design.md` notes.
- Tests: unit coverage for soft-timeout marker, drain long-gap/pending `__anext__`, history retry, Web idle bypass, mixed-tool timeout counts.

Implemented via Petri code-dev (issue → design → TDD → unit_test → Codex review; approved after 3 develop-review iterations on run-002).

## Test plan

- [x] `python -m pytest tests/unit/test_channel_core_service.py tests/unit/test_turn_orchestrator.py tests/unit/test_chat_service_stream_filter.py -q` (159 passed locally)
- [x] Petri deterministic stage: `pytest tests/unit` green during code-dev
- [ ] Manual/smoke: soft-timeout chat turn → timeout copy is soft semantics → deferred final reaches same session + history within drain window
- [ ] Confirm Telegram “N commands executed” matches timeline `turn_end.tool_call_count` when only user-visible tools ran (internal resource tools excluded)