### PR TITLE
【session】长会话历史压缩，降低 chat turn 上下文底座

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,3 +375,4 @@ A: 参考 [docs/SKILLS_GUIDE.md](docs/SKILLS_GUIDE.md)，在 `skills/` 下创建
 - 多渠道设计: [docs/channel_design.md](docs/channel_design.md)
 - 技能生命周期: [docs/skill_lifecycle_design.md](docs/skill_lifecycle_design.md)
 - 技能开发: [docs/SKILLS_GUIDE.md](docs/SKILLS_GUIDE.md)
+- 长会话历史压缩: [docs/usage/guides/history_compaction.md](docs/usage/guides/history_compaction.md)

--- a/config/everbot.example.yaml
+++ b/config/everbot.example.yaml
@@ -26,6 +26,15 @@ everbot:
     job_cleanup_interval_seconds: 600  # 清理轮询间隔（秒）
     scheduler_cron_jobs: true       # true=inline/isolated 分流；false=回退 heartbeat 统一执行
 
+  # 长会话历史压缩（#166）：chat turn 首轮 LLM 前按 token 预算摘要+安全窗口。
+  # 关闭风险：长会话每轮 input 底座回到全量，易超时/触顶。详见 docs/usage/guides/history_compaction.md
+  # session:
+  #   history_compaction:
+  #     enabled: true
+  #     trigger_tokens: 40000
+  #     target_recent_tokens: 20000
+  #     max_summary_tokens: 2000
+
   # Channel 配置
   channels:
     telegram:

--- a/docs/design/166-long-session-history-compaction.md
+++ b/docs/design/166-long-session-history-compaction.md
@@ -1,0 +1,470 @@
+# 【session】长会话历史压缩，降低 chat turn 上下文底座
+
+- Issue: #166
+- 状态: Approved (petri code-dev run-002)
+- 最后更新: 2026-07-21
+- 来源: issue brief + design proposal（issue comment 3）；评审通过后 promote 为 `docs/design/166-long-session-history-compaction.md`
+
+## 1. 背景
+
+同一超时案例（session `tg_session_demo_agent__8576399597`，milkie run `7cb2fb03-…`）中，chat turn **第一轮** LLM 请求已约 **94074 inputTokens**（messages≈168，system + 历史主导）。本 turn 新增 tool 输出只是增量；巨大历史底座使每一轮 tool 决策更慢，更容易顶穿 600s 前台预算。仅做 tool 输出精简（#167）无法显著降低开场 tokens。
+
+现状盘点（必须复用，禁止第二套处理器）：
+
+| 能力 | 位置 | 现状缺口 |
+|------|------|----------|
+| Token 估算 `chars//3` | `history_utils._estimate_tokens` | 可用；常量 `COMPACT_TOKEN_BUDGET=40_000`、`COMPACT_WINDOW_TOKENS=20_000` |
+| 摘要 + 滑动窗口 | `SessionCompressor.maybe_compress` / `compress_history` | 摘要失败直接 skip；窗口切点**不保证** tool 链边界安全 |
+| 触发路径 | `session.py` / `persistence.py` save | **仅** `provider.needs_history_restore()==True`（Dolphin）时压缩；**Milkie 保存路径整段跳过** |
+| Restore | `persistence.restore_to_agent` | Milkie `needs_history_restore()==False`，不灌回；serve 内历史原样进 `/chat` |
+| 孤儿 tool 愈合 | `persistence._heal_orphan_tool_messages` | 仅 Dolphin restore；压缩器本身不产出合法序列保证 |
+| 观测 / 配置 | 无 `history_compaction` 事件；阈值硬编码 | 不可配置、不可关、不可审计前后规模 |
+
+与 #164 / #165 / #167 / #168 正交：本设计只降低「每轮固定历史底座」。
+
+## 2. 名词解释
+
+| 术语 | 含义 |
+|------|------|
+| **history 底座** | 进入本 turn 首个 LLM 请求时，除 system 与当轮新 input 外，由既有对话历史贡献的 input tokens |
+| **trigger_tokens** | 对话历史（排除 heartbeat/placeholder）估算 token 超过该值时触发压缩 |
+| **target_recent_tokens** | 压缩后保留的最近原文窗口 token 上限（摘要另计） |
+| **summary pair** | 注入在历史头部的 `user`(含 `SUMMARY_TAG`) + `assistant`(摘要正文) 消息对 |
+| **安全窗口裁剪** | 摘要失败时，在**不破坏 tool 配对**的前提下，丢弃旧消息、仅保留合法最近窗口（无摘要） |
+| **orphan tool** | `role=tool` 消息在窗口内找不到对应 assistant `tool_calls[].id`；或反向悬空 `tool_call` 无 result（未完成链除外） |
+
+## 3. 设计目标与非目标
+
+### 目标
+
+1. **S1 降本**：超阈值会话在可复现 fixture 上，首轮 LLM 请求 history/input tokens 较未压缩基线下降 **≥ 30%**；近期对话与未决任务仍可用。
+2. **S2 可观测可配置**：触发时写结构化事件；`session.history_compaction` 可配置并有文档；可关闭应急回退。
+3. **S3 结构与事实安全**：压缩后无 orphan tool；继续多轮 tool 不因非法序列报 provider 错；关键用户约束仍出现在上下文。
+4. **S4 路径统一**：Dolphin 与 Milkie 共享同一 history-policy 入口；在**交给模型前**生效，不只在 save 后改磁盘镜像。
+5. **S5 失败不阻断**：未达阈值零额外请求；摘要失败不导致 chat 失败，不把失败文本当摘要写入 history。
+
+### 非目标
+
+- 单次 tool result 的 resultStrategy / 大输出投影（#167）
+- web search schema / objectId（#165）、软超时 deferred（#168）、thrash 防护（#164）
+- 整会话迁移为长期记忆 / 向量检索
+- 未达阈值时每轮强制摘要 LLM
+- 依赖 provider repair 修复断配 tool 链
+- 改 system prompt 或心跳策略本体（心跳隔离沿用现有 `compress_history` 逻辑）
+
+## 4. 能力与功能设计
+
+### 4.1 运行时行为（用户不可见；runtime 可见）
+
+1. 用户发起新 chat turn。
+2. 系统在 `run_turn` / provider 真正组 LLM 请求**之前**调用统一入口 `HistoryCompactionPolicy.ensure_within_budget(...)`。
+3. 若未超阈值或 `enabled=false`：原样返回，无副作用。
+4. 若超阈值：摘要旧段 + 保留安全 recent 窗口 → 回写 provider 运行态 history + 原子持久化 alfred session 镜像 → 写 `history_compaction` 事件。
+5. 后续本 turn 的多轮 tool LLM 请求在**已压缩**历史底座上继续（本 turn 内不再重复摘要，除非另有配置；默认一次 turn 入口最多尝试一次）。
+
+### 4.2 UI / UX
+
+N/A — 无用户可见 UI。开发者通过 timeline/log 与配置观测。
+
+## 5. 设计思路与折衷
+
+### 5.1 候选方案
+
+| 方案 | 做法 | 优点 | 缺点 | 结论 |
+|------|------|------|------|------|
+| A. 仅加强 save 路径压缩 | 去掉 milkie skip，save 时压缩 alfred JSONL | 改动小 | **不降低** milkie serve 内实际进模型的历史 | 否 |
+| B. 仅滑动窗口丢弃旧消息 | 无摘要 | 无 LLM 成本 | 丢失用户约束/结论；难满足「关键事实仍可用」 | 否（仅作失败回退） |
+| C. **恢复/首轮前预压缩 + 摘要 + 安全窗口**（选用） | 统一 policy；复用 `SessionCompressor`；成功后回写运行态 | 直接打底座；复用现有摘要；失败可降级 | 超阈值时多一次 fast LLM；需 milkie import | **是** |
+| D. 全量摘要 / 向量记忆 | 历史全进 memory store | 长期可检索 | 超 scope、交付面过大 | 否 |
+
+### 5.2 关键折衷
+
+1. **摘要 + 有界原文窗口**：摘要保留约束/结论/未决事项；窗口保证近期 tool 可逐字引用。比纯丢弃更安全，比全量摘要更便宜可控。
+2. **默认 40k trigger / 20k target**：与现网 `COMPACT_TOKEN_BUDGET` / `COMPACT_WINDOW_TOKENS` 一致，避免无依据换档；`max_summary_tokens` 默认 **2000**（覆盖现 prompt「不超过 500 字」并给配置留余量）。
+3. **摘要失败 → 安全窗口裁剪 → 仍失败则保留原 history**：接受 issue 开放问题 #2 的「可安全裁剪」立场；**禁止静默删除**无法安全裁的消息。
+4. **一次 turn 入口压缩一次**：避免 turn 内每 tool round 重复摘要；本 turn 新增消息仍可在**下次** turn 入口再压。
+5. **不新建第二套 compressor**：扩展 `SessionCompressor` + 抽纯函数窗口/校验；入口命名为 policy 层，实现仍落在 `core/session/`。
+
+## 6. 架构设计
+
+### 6.1 逻辑分层
+
+```mermaid
+flowchart TB
+  subgraph Entry["Chat 入口"]
+    CS[core_service.process_message]
+    TO[TurnOrchestrator.run_turn]
+  end
+
+  subgraph Policy["session history policy（本 issue 核心）"]
+    CFG[resolve HistoryCompactionConfig\nagent > global > default]
+    EST["_estimate_tokens\n(exclude heartbeat)"]
+    GATE{enabled && tokens > trigger?}
+    SC[SessionCompressor\n摘要 + 安全窗口]
+    SAFE[safe_window_trim\n无摘要回退]
+    VAL[validate_tool_pairs]
+    EVT[timeline/log\nhistory_compaction]
+  end
+
+  subgraph Adapter["Provider adapter 边界"]
+    DOL[Dolphin: 进程内 history 替换\n+ import_portable_session 语义]
+    MIL[Milkie: export_session\n→ compact → import_session\n/session/import]
+  end
+
+  subgraph Persist["持久化"]
+    AS[atomic_save SessionData\nhistory + compaction metadata]
+  end
+
+  CS --> CFG
+  CFG --> EST --> GATE
+  GATE -->|no| TO
+  GATE -->|yes| SC
+  SC -->|summary ok| VAL
+  SC -->|summary fail| SAFE --> VAL
+  VAL -->|ok| Adapter
+  VAL -->|unsafe| EVT
+  Adapter --> AS
+  Adapter --> EVT
+  AS --> TO
+  DOL --> TO
+  MIL --> TO
+```
+
+### 6.2 核心业务流程
+
+```mermaid
+sequenceDiagram
+  participant U as User
+  participant C as core_service
+  participant P as HistoryCompactionPolicy
+  participant SC as SessionCompressor
+  participant Prov as AgentProvider
+  participant LLM as Provider LLM path
+
+  U->>C: chat message
+  C->>Prov: export live history (if needed)
+  C->>P: ensure_within_budget(history, cfg, context)
+  alt under trigger or disabled
+    P-->>C: unchanged, outcome=skipped
+  else over trigger
+    P->>SC: compress (summary + safe window)
+    alt summary ok and valid
+      SC-->>P: compacted history
+      P->>Prov: apply compacted history
+      P->>C: persist + history_compaction(outcome=summarized)
+    else summary fail, safe trim ok
+      P->>Prov: apply trimmed history
+      P->>C: persist + history_compaction(outcome=window_trimmed)
+    else cannot safely reduce
+      P-->>C: keep original + history_compaction(outcome=kept_original)
+    end
+  end
+  C->>LLM: run_turn (first request uses reduced base)
+```
+
+**调用时机（硬要求）**
+
+| 时机 | Dolphin | Milkie | 说明 |
+|------|---------|--------|------|
+| **Chat turn 首轮前**（主路径） | 是 | 是 | 满足 S1/S4；在 `core_service` 进入 `TurnOrchestrator.run_turn` 前，或 orchestrator 的 pre-turn hook |
+| Save 后写盘 | 是（已有，改为走同一 policy） | 是（写 alfred JSONL 镜像；**不替代** serve 内压缩） | 磁盘与运行态一致 |
+| Restore 灌回 | 是（灌回前 ensure） | N/A（不灌回） | 避免 restore 后立刻再撑爆 |
+
+**Milkie 专属适配（S4 关键）**
+
+1. `export_session` → alfred history dict 列表（已有 `POST /session/history`）。
+2. Policy 压缩/裁剪纯函数结果。
+3. **必须**把压缩后 history 写回 serve，否则首轮 LLM 仍用全量 sqlite 历史。对接 milkie 已交付的 **`POST /session/import`**（#124）：在 `MilkieProvider` 新增 `import_session(agent, portable)`（或等价 `replace_history`），将 summary pair + recent 窗口导入同一 `contextId`。
+4. 同步 `atomic_save` alfred session JSONL（审计/记忆/导出用）。
+5. 若 import 失败：记 `outcome=apply_failed`，**不**阻断 chat（S5）；运行态可能仍大，但行为可观测。实现上应优先保证 import 成功路径有 integration 覆盖。
+
+**Dolphin 适配**
+
+- 进程内替换 history（与现 `compress_history` 写回 list 一致），必要时经现有 portable import 路径保证 executor context 一致。
+- Save 路径去掉「仅 needs_history_restore 才 compress」的误判：policy 对 primary/channel 会话统一可用；provider 差异只在 **apply** 层。
+
+## 7. 模块设计
+
+### 7.1 `HistoryCompactionConfig`（新，纯数据）
+
+建议位置：`src/everbot/core/session/history_compaction.py`（或并入 `history_utils.py` 若文件仍短）。
+
+```python
+@dataclass(frozen=True)
+class HistoryCompactionConfig:
+    enabled: bool = True
+    trigger_tokens: int = 40_000
+    target_recent_tokens: int = 20_000
+    max_summary_tokens: int = 2_000
+```
+
+解析优先级（对齐 `turn_policy._resolve_timeout` 风格）：
+
+1. `everbot.agents.<agent_name>.session.history_compaction.*`
+2. `everbot.session.history_compaction.*`（global）
+3. 上表默认值
+
+合法范围（配置非法时 log warning 并回退默认，不抛）：
+
+- `trigger_tokens >= 1000`
+- `target_recent_tokens >= 500` 且 `target_recent_tokens <= trigger_tokens`
+- `max_summary_tokens` 在 `[200, 8000]`
+
+### 7.2 `HistoryCompactionPolicy`（新，编排）
+
+**职责**：阈值判断、调用 compressor/safe trim、校验、产出 `CompactionResult`、不直接打 HTTP。
+
+```python
+@dataclass
+class CompactionResult:
+    history: list[dict]
+    changed: bool
+    outcome: str  # skipped | summarized | window_trimmed | over_budget_unavoidable | kept_original | apply_failed
+    reason: str
+    before_tokens: int
+    after_tokens: int
+    summary_tokens: int
+    retained_messages: int
+
+class HistoryCompactionPolicy:
+    async def ensure_within_budget(
+        self,
+        history: list[dict],
+        config: HistoryCompactionConfig,
+        *,
+        summarize: Callable[..., Awaitable[str]] | SessionCompressor,
+    ) -> CompactionResult: ...
+```
+
+心跳隔离：复用 `compress_history` 逻辑——只对非 heartbeat/placeholder 估算与压缩，再拼回 tail。
+
+### 7.3 `SessionCompressor`（扩展，非替换）
+
+| 改动 | 说明 |
+|------|------|
+| 配置注入 | `token_budget` / trigger 从 config 传入，不再仅依赖模块常量（常量保留为默认） |
+| **安全切点** | 见 §7.4；替代当前纯 token 累加 `window_start` |
+| 摘要长度 | 生成后按 `max_summary_tokens` 截断摘要正文（字符预算 `max_summary_tokens * 3`），避免摘要本身膨胀 |
+| 失败语义 | `_generate_summary` 异常或空串 → 返回未压缩，由 policy 决定 safe trim（**不要**把 error 字符串当摘要；现 `raise_on_error=False` 若返回错误文案，应用启发式拒绝：过短/含 traceback/以 `Error` 开头等，或改为 `raise_on_error=True` 在 compressor 内捕获） |
+| 既有摘要 | `extract_existing_summary` 合并后只保留**一对**最新 summary marker |
+
+公开纯函数（便于单测）：
+
+- `find_safe_window_start(messages, token_budget) -> int`
+- `validate_tool_pairing(messages) -> list[str]`（错误码列表，空=合法）
+- `safe_window_trim(messages, token_budget) -> tuple[list, bool]`
+
+### 7.4 结构安全窗口算法
+
+目标：切点只能落在**合法对话边界**。
+
+1. 从尾部按 `_estimate_tokens` 累加，得到候选 `window_start`（与现逻辑相同，至少保留最后一条）。
+2. **若 `messages[window_start]` 是 `role=tool`**：向前扩展到包含对应 `tool_call_id` 的 assistant（若找不到，继续向前直到找到或到 0）。
+3. **若 `window_start` 落在 assistant 且其后 tool results 未齐**：向前或向后扩展使该 tool_call 集合在窗口内**完整闭合**（优先向后纳入已有 result；若 result 在更旧侧则向前纳入 assistant）。
+4. **未完成 tool chain 在尾部**：整条链必须保留在 `to_keep`，不得只留 half。
+5. `to_compress = messages[:window_start]` 可含完整旧 tool 链的语义进摘要 prompt；**压缩后 history 不得保留**孤立 `tool_call_id` / orphan tool result。
+6. `inject_summary` 之后对全序列 `validate_tool_pairing`；失败则**丢弃本次结果**，走 safe trim 或 kept_original。
+
+单条超大消息：
+
+- 至少保留最新用户消息 + 关联完整 tool chain。
+- 若单条已超过 `target_recent_tokens`：`outcome=over_budget_unavoidable`，**不截断** JSON/tool 参数（防非法请求）。
+
+### 7.5 Provider apply 边界
+
+| 组件 | 接口 | 行为 |
+|------|------|------|
+| `AgentProvider` | 扩展 `import_session(agent, state: dict) -> None`（或 document 为可选 capability） | Dolphin：进程内/portable 导入；Milkie：HTTP `/session/import` |
+| `SessionManager` / `core_service` | `async def maybe_compact_session_history(...)` | resolve config → export if needed → policy → apply → atomic_save → timeline |
+
+**并发**：在现有 session 锁内执行 apply+save；基于最新 revision/export 重算，避免旧快照覆盖新消息（沿用现有 atomic_save / revision 模式）。
+
+### 7.6 观测
+
+每次 **attempt**（含 skipped 可选：默认仅在 `changed` 或失败 outcome 时写，避免噪声；**至少**对 summarized / window_trimmed / kept_original / over_budget_unavoidable / apply_failed 写事件）：
+
+```json
+{
+  "type": "history_compaction",
+  "provider": "milkie|dolphin|...",
+  "reason": "over_trigger|manual|...",
+  "before_tokens": 94000,
+  "after_tokens": 22000,
+  "summary_tokens": 400,
+  "retained_messages": 42,
+  "outcome": "summarized",
+  "session_id": "..."
+}
+```
+
+- 写入：`SessionManager.append_timeline_event` + 英文 `logger.info`。
+- **禁止**写入历史正文或摘要全文。
+
+## 8. API / CLI 设计
+
+### 8.1 配置
+
+```yaml
+everbot:
+  session:
+    history_compaction:
+      enabled: true                 # false = 应急关闭，不触发压缩
+      trigger_tokens: 40000
+      target_recent_tokens: 20000
+      max_summary_tokens: 2000
+  agents:
+    demo_agent:
+      session:
+        history_compaction:
+          trigger_tokens: 30000     # 可选覆盖
+```
+
+文档：在 usage 配置参考（若尚无独立 configuration 页，可落在 `docs/usage/guides/` 或现有 config 说明）增加小节：
+
+- 默认值与合法范围
+- 关闭后风险：长会话每轮 input 底座回到全量，易超时/触顶
+- agent 覆盖优先级
+
+### 8.2 Provider
+
+- `export_session`：已有
+- **新增** `import_session(agent, portable_state)`：成功无返回；失败抛错由 policy 上层捕获为 `apply_failed`
+- CLI：无新子命令
+
+### 8.3 兼容
+
+- 默认 `enabled=true`，行为对短会话无感
+- 旧 session 文件无 compaction metadata 仍可读
+- 不改对外 HTTP chat API 形状
+
+## 9. 边界考虑
+
+| 场景 | 行为 |
+|------|------|
+| 短历史 / 未达阈值 | 不变；不调摘要 LLM |
+| `enabled=false` | 完全跳过；可观测为无事件或显式 skipped（实现选一，文档写明） |
+| 摘要 LLM 失败 / 空 / 疑似错误串 | 不写 history；尝试 safe window；再失败 `kept_original` |
+| 单条消息超 target | `over_budget_unavoidable`；保留消息完整 |
+| 已有 summary pair | 合并进新摘要输入；输出仅一对 marker |
+| 并发 turn | session 锁 + revision；基于最新 history |
+| Provider 差异 | 纯 policy 共享；apply 在 adapter |
+| 压缩中 chat 失败 | 不得因 policy 异常中断 chat（外层 try/except → kept_original + log） |
+
+## 10. 迁移 / 兼容 / 回滚
+
+- **迁移**：无强制数据迁移。首次超阈值 turn 原地压缩并持久化。
+- **兼容**：默认开启；可用 `enabled=false` 即时回退。
+- **回滚**：配置关闭或 revert PR；已压缩 session 不会自动解压（摘要不可逆）——可接受，与现 compressor 一致。
+
+## 11. 测试计划
+
+### 11.1 TDD 优先顺序（喂给 `unit_test` 阶段）
+
+| 序 | 用例 | 断言（通过标准） |
+|----|------|------------------|
+| U1 | token 估算与阈值门闸 | `< trigger` → unchanged；`> trigger` → 进入压缩路径 |
+| U2 | 安全窗口切点在 tool 中部 | `window_start` 扩展到 assistant tool_call；结果无 orphan |
+| U3 | 尾部未完成 tool chain | 整链保留在 recent |
+| U4 | 既有摘要合并 | 仅一对 `SUMMARY_TAG`；旧摘要文本进入新摘要输入 mock |
+| U5 | 摘要失败 → safe trim | mock LLM raise；history 变短且 `validate_tool_pairing` 空；outcome=`window_trimmed` |
+| U6 | 无法安全裁剪 | fixture 构造无法合法缩小；history 引用相等；outcome=`kept_original` |
+| U7 | 单条超大 | outcome=`over_budget_unavoidable`；tool JSON 未被截断 |
+| U8 | 配置优先级 | agent 覆盖 global 覆盖 default；`enabled=false` 不调用 summarize |
+| U9 | 事件字段 | mock timeline；字段齐全且无正文 |
+| U10 | **含 tool 历史的压缩**（S3 硬性） | assistant tool_calls + tool results 跨切点；压缩后配对合法 |
+
+### 11.2 Integration
+
+- SessionManager：compact → atomic_save → load，history 与 metadata 一致。
+- Dolphin 路径（或 fake provider `needs_history_restore=True`）：pre-turn ensure 后 agent history 已缩。
+- Milkie adapter：mock HTTP export/import；断言 import 被调用且 body 为压缩后消息。
+- 摘要失败回退与 apply 失败不抛到 chat 层。
+
+### 11.3 E2E（S1 / S2 / S3）
+
+可复现大 history fixture（目标：估算 tokens 量级接近案例 ~94k 等价，含早期关键约束、近期多轮、完整 tool 链）：
+
+1. restore / 导入 session → 发一条 chat → recording/mock provider 捕获**首个** LLM request。
+2. **S1**：history 或 input tokens 相对「关闭 compaction」基线下降 **≥ 30%**；近期消息与早期约束仍出现在请求 messages 或摘要中。
+3. **S2**：timeline 存在 `history_compaction`；`enabled=false` 时不触发 changed。
+4. **S3**：历史无 orphan tool；可继续一轮 mock tool call 无 provider 序列错误。
+
+### 11.4 与验收映射
+
+| ID | 测试层 |
+|----|--------|
+| S1 | E2E fixture 定量 + Unit 门闸 |
+| S2 | Unit 事件/配置 + E2E timeline + 文档检查 |
+| S3 | U2/U3/U10 + Integration tool 链 + E2E |
+| S4 | Integration Dolphin + Milkie apply 路径 |
+| S5 | U5/U6 + Integration 失败不阻断 |
+
+## 12. 开放问题 / 决策记录
+
+| # | 问题 | 决策 | 理由 |
+|---|------|------|------|
+| D1 | 默认 trigger/target？ | **40_000 / 20_000** | 与现网常量一致，降低换档风险；可用配置调 |
+| D2 | 摘要失败是否安全窗口裁剪？ | **是**（仅结构安全时）；否则保留原 history | 满足 S1 尽力降本且 S3/S5 |
+| D3 | 第二套历史处理器？ | **否**；扩展 `SessionCompressor` + policy 编排 | issue 明确避免重复建设 |
+| D4 | Milkie 如何让压缩进模型？ | **export → policy → import**（#124） | 仅压 alfred JSONL 不够 |
+| D5 | 每 tool round 压缩？ | **否**；每 chat turn 入口至多一次 | 控制摘要成本 |
+
+无未决开放问题阻塞实现；配置调参可在上线后按观测迭代。
+
+## 13. 关联
+
+- Issue: https://github.com/xforce-io/alfred/issues/166
+- 相关：`src/everbot/core/session/compressor.py`、`history_utils.py`、`session.py`、`persistence.py`、`core/channel/core_service.py`、`core/agent/provider/milkie/provider.py`
+- 既有：`docs/history_policy_design.md`（心跳隔离 + token compact；本设计补「首轮前 + Milkie apply」）
+- 正交：#164 #165 #167 #168
+- Promote 目标：`docs/design/166-long-session-history-compaction.md`
+
+---
+
+## Key Decisions
+
+1. **统一 pre-turn history policy，复用 SessionCompressor** — 解决「只在 Dolphin save 压盘、Milkie 运行态仍全量」的根因。
+2. **默认 40k/20k/2k summary** — 对齐现网，可配置。
+3. **结构安全窗口 + 摘要；失败安全裁剪或保留** — 平衡降本与 tool 合法性。
+4. **Milkie 必须 import 回 serve** — 否则无法达成 S1。
+5. **观测 `history_compaction` + 配置可关** — 满足 S2，应急回退。
+
+## Acceptance checklist
+
+Delivery boundary: pre-turn history compaction for long sessions (policy + provider apply + config + observability + tests). Non-goals: tool resultStrategy, thrash guard, soft-timeout copy, vector memory.
+
+| ID | Observable pass condition |
+|----|---------------------------|
+| **S1** | Over-threshold fixture: first LLM request history/input tokens **≥ 30%** lower than compaction-disabled baseline; recent dialogue / open tasks still present in context (verbatim window or summary). |
+| **S2** | On compaction attempt that changes or fails-closed: timeline/log event `history_compaction` with `before_tokens`, `after_tokens`, `outcome` (no history body). Config `session.history_compaction` (`enabled`, `trigger_tokens`, `target_recent_tokens`, `max_summary_tokens`) resolves agent > global > default; `enabled=false` skips compaction; docs describe defaults and disable risk. |
+| **S3** | Compacted history has no orphan tool messages; continued tool rounds do not fail for illegal message sequences; at least one unit/integration case with tool history; critical pre-compaction user constraints remain in context (window or summary). |
+| **S4** | Dolphin and Milkie (or equivalent) share the same policy entry; compaction is applied to the **live** history used for the next LLM call, not only the on-disk alfred mirror after save. |
+| **S5** | Summary failure does not fail the chat; safe window trim only when structure-preserving; otherwise original history kept (no silent unsafe delete); failure outcomes carry explicit `outcome`/`reason`. |
+
+## PR Plan
+
+### PR1 — Pure policy + safe window + unit tests
+
+- **Files**: `history_utils.py` / new `history_compaction.py`, `compressor.py`（安全切点、摘要拒绝错误串、config 默认）
+- **Deps**: none
+- **Desc**: 无 I/O 的阈值、安全窗口、校验、摘要注入；U1–U10 全绿
+
+### PR2 — Config resolve + observability + docs
+
+- **Files**: config resolve helper、timeline 事件、`docs/usage` 配置说明、常量与 config 对齐
+- **Deps**: PR1
+- **Desc**: S2 文档与事件字段稳定
+
+### PR3 — Pre-turn hook + Dolphin apply + SessionManager persist
+
+- **Files**: `core_service` 或 `TurnOrchestrator` pre-turn、`session.py`/`persistence.py` 收敛 save 路径到同一 policy
+- **Deps**: PR1, PR2
+- **Desc**: Dolphin/primary 路径首轮前压缩并原子保存
+
+### PR4 — Milkie `import_session` + integration/e2e fixture
+
+- **Files**: `MilkieProvider.import_session`、provider base 可选接口、integration/e2e 大 history fixture（≥30% 断言）
+- **Deps**: PR3
+- **Desc**: S1/S4 在 milkie 真实/半真实路径关闭；回归含 tool 历史
+
+建议合并顺序：PR1 → PR2 → PR3 → PR4；每 PR 独立可测、可回滚（PR4 前 milkie 仍可能达不到 S1，故 S1 验收以 PR4 为准）。

--- a/docs/usage/guides/history_compaction.md
+++ b/docs/usage/guides/history_compaction.md
@@ -1,0 +1,95 @@
+# Session History Compaction
+
+Long-lived channel/primary sessions can accumulate a large chat history base.
+Before each chat turn's first LLM request, EverBot may compact that history so
+input tokens stay within budget without dropping recent tool chains or critical
+user constraints.
+
+## When it runs
+
+- **Trigger**: estimated chat history tokens (heartbeat/placeholder excluded)
+  exceed `trigger_tokens`.
+- **Path**: chat turn entry (`core_service` pre-turn) and session save mirrors.
+- **Short sessions**: no-op; no extra LLM call when under threshold.
+
+## Defaults
+
+| Key | Default | Notes |
+|-----|---------|--------|
+| `enabled` | `true` | Set `false` for emergency rollback |
+| `trigger_tokens` | `40000` | Start compaction above this estimate |
+| `target_recent_tokens` | `20000` | Keep recent verbatim window under this |
+| `max_summary_tokens` | `2000` | Cap on injected summary body |
+
+Token estimate uses the existing `chars // 3` heuristic (same as save-path compact).
+
+## Configuration
+
+Priority: **agent > global > default**.
+
+```yaml
+everbot:
+  session:
+    history_compaction:
+      enabled: true
+      trigger_tokens: 40000
+      target_recent_tokens: 20000
+      max_summary_tokens: 2000
+  agents:
+    demo_agent:
+      session:
+        history_compaction:
+          trigger_tokens: 30000   # optional per-agent override
+```
+
+### Valid ranges
+
+- `trigger_tokens` ≥ 1000  
+- `target_recent_tokens` ≥ 500 and ≤ `trigger_tokens`  
+- `max_summary_tokens` in `[200, 8000]`  
+
+Invalid values log a warning and fall back to defaults (never crash the chat).
+
+## What happens on trigger
+
+1. Older messages (outside the safe recent window) are summarized with a fast LLM.
+2. A single summary marker pair is injected; previous summary text is merged in.
+3. The recent window cut is **tool-chain safe** (no orphan `tool` messages).
+4. Compacted history is applied to the live provider (Milkie: export → rewrite →
+   `/session/import`) and mirrored into the alfred session file.
+5. A timeline event `history_compaction` is recorded (sizes + outcome only;
+   **no** history body).
+
+### Outcomes
+
+| `outcome` | Meaning |
+|-----------|---------|
+| `skipped` | Disabled or under trigger |
+| `summarized` | Summary + recent window applied |
+| `window_trimmed` | Summary failed; structure-safe trim only |
+| `over_budget_unavoidable` | Minimal safe keep still over target (e.g. huge single message) |
+| `kept_original` | Could not safely reduce; original kept |
+| `apply_failed` | Provider import failed; chat continues with original live history |
+
+## Disable risk
+
+Setting `enabled: false` restores the full history base on every turn. Long
+sessions can again approach ~90k+ first-round input tokens and are more likely
+to hit foreground turn timeouts. Use only for emergency diagnosis.
+
+## Observability
+
+Timeline / logs (English log lines):
+
+```text
+history_compaction session=... outcome=summarized before_tokens=... after_tokens=...
+```
+
+Event fields: `type`, `provider`, `reason`, `before_tokens`, `after_tokens`,
+`summary_tokens`, `retained_messages`, `outcome`, optional `session_id`.
+
+## Related
+
+- Issue #166 — long session history compaction  
+- Design: `design.md` / `docs/design/166-long-session-history-compaction.md` (when promoted)  
+- Orthogonal: tool result projection (#167), soft timeout (#168)

--- a/src/everbot/core/agent/provider/base.py
+++ b/src/everbot/core/agent/provider/base.py
@@ -89,6 +89,15 @@ class AgentProvider(Protocol):
         """
         ...
 
+    def import_session(self, agent: Any, portable_state: dict) -> None:
+        """Apply portable session / compacted history into the live provider.
+
+        Optional capability (#166). Implementations may accept alfred-style
+        ``{history_messages, variables}`` and/or provider-native portable
+        payloads. Missing method is tolerated by callers.
+        """
+        ...
+
     def needs_history_restore(self) -> bool:
         """是否需要 alfred 把存档历史灌回 agent。
 

--- a/src/everbot/core/agent/provider/milkie/provider.py
+++ b/src/everbot/core/agent/provider/milkie/provider.py
@@ -28,6 +28,15 @@ from .....infra.user_data import get_user_data_manager
 
 logger = logging.getLogger(__name__)
 
+# Keep the synchronous provider request below the SessionManager's 15 s outer
+# deadline. The server-side expectedLatestRunId check is still authoritative:
+# a client disconnect cannot prove the server did not finish the import.
+_SESSION_IMPORT_HTTP_TIMEOUT_SECONDS = 14.0
+
+
+class MilkieSessionImportConflict(RuntimeError):
+    """The sidecar rejected an import because the session advanced."""
+
 
 def _milkie_data_dir(agent_name: str) -> Path:
     """该 agent 的 milkie sidecar 数据目录(= 传给 ``serve --data-dir`` 的目录,
@@ -674,12 +683,29 @@ class MilkieProvider:
         try:
             if "manifest" in portable_state:
                 session = portable_state
+                expected_latest_run_id = None
             else:
-                session = self._portable_from_compacted_history(
+                session, expected_latest_run_id = self._portable_from_compacted_history(
                     client, base, agent, portable_state
                 )
-            resp = client.post(f"{base}/session/import", json={"session": session})
+            payload = {"session": session}
+            if expected_latest_run_id:
+                payload["expectedLatestRunId"] = expected_latest_run_id
+            resp = client.post(
+                f"{base}/session/import",
+                json=payload,
+                timeout=_SESSION_IMPORT_HTTP_TIMEOUT_SECONDS,
+            )
+            if resp.status_code == 409:
+                raise MilkieSessionImportConflict(
+                    "milkie /session/import rejected stale session snapshot"
+                )
             resp.raise_for_status()
+            if expected_latest_run_id and resp.json().get("conditionApplied") is not True:
+                raise RuntimeError(
+                    "milkie /session/import lacks conditional-import support; "
+                    "refusing an unsafe history rewrite"
+                )
         finally:
             if owns:
                 client.close()
@@ -690,7 +716,7 @@ class MilkieProvider:
         base: str,
         agent: Any,
         portable_state: dict,
-    ) -> dict:
+    ) -> tuple[dict, Optional[str]]:
         """Export live portable session and rewrite history regions."""
         import copy
         import uuid
@@ -698,7 +724,11 @@ class MilkieProvider:
         context_id = getattr(agent, "context_id", None) or portable_state.get(
             "session_id"
         )
-        exp = client.post(f"{base}/session/export", json={"contextId": context_id})
+        exp = client.post(
+            f"{base}/session/export",
+            json={"contextId": context_id},
+            timeout=_SESSION_IMPORT_HTTP_TIMEOUT_SECONDS,
+        )
         if exp.status_code == 404:
             raise RuntimeError(
                 f"milkie /session/export: no session for contextId={context_id!r}"
@@ -757,7 +787,7 @@ class MilkieProvider:
             merged = dict(session.get("variables") or {})
             merged.update(variables)
             session["variables"] = merged
-        return session
+        return session, old_run_id
 
     def needs_history_restore(self) -> bool:
         return False  # serve 用 sqlite/jsonl 自持久化(#130),同 contextId 重启自动恢复

--- a/src/everbot/core/agent/provider/milkie/provider.py
+++ b/src/everbot/core/agent/provider/milkie/provider.py
@@ -656,6 +656,109 @@ class MilkieProvider:
             "variables": {},
         }
 
+    def import_session(self, agent: Any, portable_state: dict) -> None:
+        """Apply compacted / portable session into milkie serve (#166 / milkie#124).
+
+        Accepts:
+        - milkie PortableSession (has ``manifest``) → POST /session/import as-is
+        - alfred ``{history_messages, ...}`` → export current portable, rewrite
+          checkpoint history regions from compacted messages, re-import under
+          the same contextId so the next LLM call uses the reduced base.
+        """
+        if not isinstance(portable_state, dict):
+            raise TypeError("portable_state must be a dict")
+
+        client = self._sync_client or self._new_sync_client()
+        owns = self._sync_client is None
+        base = self._agent_base_url(agent)
+        try:
+            if "manifest" in portable_state:
+                session = portable_state
+            else:
+                session = self._portable_from_compacted_history(
+                    client, base, agent, portable_state
+                )
+            resp = client.post(f"{base}/session/import", json={"session": session})
+            resp.raise_for_status()
+        finally:
+            if owns:
+                client.close()
+
+    def _portable_from_compacted_history(
+        self,
+        client: Any,
+        base: str,
+        agent: Any,
+        portable_state: dict,
+    ) -> dict:
+        """Export live portable session and rewrite history regions."""
+        import copy
+        import uuid
+
+        context_id = getattr(agent, "context_id", None) or portable_state.get(
+            "session_id"
+        )
+        exp = client.post(f"{base}/session/export", json={"contextId": context_id})
+        if exp.status_code == 404:
+            raise RuntimeError(
+                f"milkie /session/export: no session for contextId={context_id!r}"
+            )
+        exp.raise_for_status()
+        session = exp.json()
+        if not isinstance(session, dict) or "manifest" not in session:
+            raise RuntimeError("milkie /session/export returned unexpected payload")
+
+        history = portable_state.get("history_messages") or []
+        session = copy.deepcopy(session)
+        new_run_id = f"compact-{uuid.uuid4().hex[:16]}"
+        old_run_id = session.get("manifest", {}).get("latestRunId")
+
+        for event in session.get("events") or []:
+            if not isinstance(event, dict):
+                continue
+            # New identities so append-on-import does not collide.
+            event["id"] = str(uuid.uuid4())
+            if event.get("runId") == old_run_id:
+                event["runId"] = new_run_id
+            if event.get("type") == "agent.checkpoint":
+                payload = event.get("payload") or {}
+                checkpoint = payload.get("checkpoint") if isinstance(payload, dict) else None
+                if isinstance(checkpoint, dict):
+                    ctx = checkpoint.get("context") or {}
+                    regions_snap = ctx.get("regions") if isinstance(ctx, dict) else None
+                    rewritten = _rewrite_history_regions(regions_snap, history)
+                    if rewritten is not None and isinstance(ctx, dict):
+                        ctx = dict(ctx)
+                        ctx["regions"] = rewritten
+                        checkpoint = dict(checkpoint)
+                        checkpoint["context"] = ctx
+                        checkpoint["checkpointId"] = str(uuid.uuid4())
+                        event["payload"] = {**payload, "checkpoint": checkpoint}
+            if event.get("type") == "agent.run.started":
+                # Break previousRunId chain so getSessionHistory does not walk
+                # the pre-compaction runs (graceful degradation on import).
+                p = event.get("payload")
+                if isinstance(p, dict) and "previousRunId" in p:
+                    p = dict(p)
+                    p.pop("previousRunId", None)
+                    event["payload"] = p
+
+        manifest = dict(session.get("manifest") or {})
+        manifest["contextId"] = context_id
+        manifest["latestRunId"] = new_run_id
+        manifest["exportedAt"] = int(__import__("time").time() * 1000)
+        if "schemaVersion" not in manifest:
+            manifest["schemaVersion"] = 1
+        session["manifest"] = manifest
+
+        # Merge alfred variables if provided
+        variables = portable_state.get("variables")
+        if isinstance(variables, dict) and variables:
+            merged = dict(session.get("variables") or {})
+            merged.update(variables)
+            session["variables"] = merged
+        return session
+
     def needs_history_restore(self) -> bool:
         return False  # serve 用 sqlite/jsonl 自持久化(#130),同 contextId 重启自动恢复
 
@@ -787,3 +890,97 @@ def _milkie_messages_to_history(messages: list) -> list:
     out = SessionPersistence._filter_empty_assistant_messages(out)
     out = SessionPersistence._heal_orphan_tool_messages(out)
     return out
+
+
+def _rewrite_history_regions(regions_snap: Any, history_messages: list) -> Any:
+    """Replace ``history:turn-*`` regions in a checkpoint region snapshot.
+
+    Keeps non-history regions (header, skills, tools, wm, …). Converts alfred
+    OpenAI-style history into milkie history-pair region content
+    ``{userInput, assistantText}``. Tool messages are folded into the preceding
+    assistant text so tool-chain semantics survive as prose (milkie inter-turn
+    regions only store user/assistant pairs).
+    """
+    if regions_snap is None:
+        return None
+
+    # Snapshot shape: {epoch, regions: [Region, ...]} or bare list
+    if isinstance(regions_snap, dict):
+        regions_list = list(regions_snap.get("regions") or [])
+        epoch = regions_snap.get("epoch", 0)
+        as_dict = True
+    elif isinstance(regions_snap, list):
+        regions_list = list(regions_snap)
+        epoch = 0
+        as_dict = False
+    else:
+        return regions_snap
+
+    kept = [
+        r
+        for r in regions_list
+        if isinstance(r, dict) and not str(r.get("id") or "").startswith("history:turn-")
+    ]
+
+    pairs = _history_messages_to_pairs(history_messages)
+    import time as _time
+
+    now = int(_time.time() * 1000)
+    for i, (user_input, asst_text) in enumerate(pairs):
+        rid = f"history:turn-compact-{i}"
+        kept.append(
+            {
+                "id": rid,
+                "target": "message",
+                "section": "history",
+                "intraTurn": "turn-persistent",
+                "interTurn": "session-persistent",
+                "stability": "session-stable",
+                "createdAt": now + i,
+                "content": {"userInput": user_input, "assistantText": asst_text},
+            }
+        )
+
+    if as_dict:
+        return {"epoch": epoch + 1, "regions": kept}
+    return kept
+
+
+def _history_messages_to_pairs(history_messages: list) -> list:
+    """Fold alfred history into (user, assistant_text) pairs for milkie regions."""
+    pairs: list = []
+    i = 0
+    msgs = [m for m in history_messages if isinstance(m, dict)]
+    while i < len(msgs):
+        m = msgs[i]
+        role = m.get("role")
+        if role == "user":
+            user_text = m.get("content") if isinstance(m.get("content"), str) else ""
+            asst_parts: list = []
+            i += 1
+            while i < len(msgs) and msgs[i].get("role") != "user":
+                cur = msgs[i]
+                if cur.get("role") == "assistant":
+                    content = cur.get("content")
+                    if isinstance(content, str) and content:
+                        asst_parts.append(content)
+                    for tc in cur.get("tool_calls") or []:
+                        fn = (tc or {}).get("function") or {}
+                        name = fn.get("name") or ""
+                        args = fn.get("arguments") or ""
+                        asst_parts.append(f"[tool_call {name}({args})]")
+                elif cur.get("role") == "tool":
+                    body = cur.get("content") if isinstance(cur.get("content"), str) else ""
+                    tcid = cur.get("tool_call_id") or ""
+                    # Bound tool body so a single region cannot re-inflate the base
+                    if len(body) > 2000:
+                        body = body[:2000] + "…"
+                    asst_parts.append(f"[tool_result {tcid}] {body}")
+                i += 1
+            pairs.append((user_text or "", "\n".join(asst_parts)))
+        else:
+            # Leading assistant/tool without user — wrap as system-ish pair
+            content = m.get("content") if isinstance(m.get("content"), str) else ""
+            pairs.append(("", content or json.dumps(m, ensure_ascii=False)[:500]))
+            i += 1
+    return pairs

--- a/src/everbot/core/channel/core_service.py
+++ b/src/everbot/core/channel/core_service.py
@@ -415,6 +415,24 @@ class ChannelCoreService:
             _prior_failures = self._session_failure_memory.get(session_id, {})
             _turn_orchestrator = TurnOrchestrator(_turn_policy, prior_failures=_prior_failures)
 
+            # #166: pre-turn history compaction — reduce fixed history base before
+            # the first LLM request. Failures never block chat (S5).
+            # lock_already_held: this turn already owns in-process + flock locks.
+            try:
+                await self.session_manager.maybe_compact_session_history(
+                    agent,
+                    session_id,
+                    agent_name,
+                    config=get_config(),
+                    lock_already_held=True,
+                )
+            except Exception:
+                logger.warning(
+                    "Pre-turn history compaction failed (session=%s); continuing chat",
+                    session_id,
+                    exc_info=True,
+                )
+
             async for te in _turn_orchestrator.run_turn(
                 agent,
                 effective_message,

--- a/src/everbot/core/session/__init__.py
+++ b/src/everbot/core/session/__init__.py
@@ -1,6 +1,12 @@
 """Session persistence and lifecycle management."""
 
 from .compressor import SessionCompressor
+from .history_compaction import (
+    CompactionResult,
+    HistoryCompactionConfig,
+    HistoryCompactionPolicy,
+    resolve_history_compaction_config,
+)
 from .session_data import SessionData
 from .persistence import SessionPersistence
 from .session import SessionManager
@@ -16,6 +22,10 @@ from .session_ids import (
 
 __all__ = [
     "SessionCompressor",
+    "CompactionResult",
+    "HistoryCompactionConfig",
+    "HistoryCompactionPolicy",
+    "resolve_history_compaction_config",
     "SessionData",
     "SessionManager",
     "SessionPersistence",

--- a/src/everbot/core/session/compressor.py
+++ b/src/everbot/core/session/compressor.py
@@ -6,6 +6,7 @@ Implements a sliding-window + LLM summary strategy:
   summarized via a fast LLM and injected as a compact summary pair at the
   head of the history, while the most recent WINDOW_SIZE messages are kept
   verbatim.
+- Token-budget path uses a tool-chain-safe window cut (issue #166).
 """
 
 from __future__ import annotations
@@ -16,6 +17,15 @@ from typing import Any, Dict, List, Optional, Tuple
 logger = logging.getLogger(__name__)
 
 from ..models.constants import SUMMARY_TAG  # noqa: F401 — re-exported
+
+# Re-export pure helpers used by policy/tests (single implementation source).
+from .history_compaction import (  # noqa: F401
+    find_safe_window_start,
+    looks_like_summary_error,
+    safe_window_trim,
+    truncate_summary,
+    validate_tool_pairing,
+)
 
 # ── Tunables ──────────────────────────────────────────────────────────
 COMPRESS_THRESHOLD = 80  # trigger compression when history exceeds this
@@ -38,13 +48,15 @@ _SUMMARY_PROMPT_TEMPLATE = """\
 class SessionCompressor:
     """Compress old history messages into an LLM-generated summary."""
 
-    def __init__(self, context: Any):
+    def __init__(self, context: Any = None, *, max_summary_tokens: int = 2000):
         """
         Args:
-            context: A Dolphin ``Context`` object (``agent.executor.context``).
-                     Used to obtain cloud/model config and create an LLMClient.
+            context: Optional opaque context for oneshot LLM (unused by
+                     OneshotLLMProvider but kept for call-site compatibility).
+            max_summary_tokens: Cap on generated summary body (tokens ≈ chars/3).
         """
         self._context = context
+        self._max_summary_tokens = max_summary_tokens
 
     # ── Public API ────────────────────────────────────────────────────
 
@@ -56,11 +68,9 @@ class SessionCompressor:
         """Compress *history_messages* if they exceed the threshold.
 
         When *token_budget* is provided, the window is computed by token
-        count (accumulating from the tail until *token_budget* tokens are
-        reached) instead of the fixed ``WINDOW_SIZE`` message count.
-        The threshold check also switches to token-based: compression is
-        always attempted when *token_budget* is given (the caller already
-        checked that total tokens exceed COMPACT_TOKEN_BUDGET).
+        count with a **tool-chain-safe** cut point instead of the fixed
+        ``WINDOW_SIZE`` message count. Compression is always attempted when
+        *token_budget* is given (the caller already checked the trigger).
 
         Returns ``(compressed, new_history)`` where *compressed* indicates
         whether compression was actually performed.  The caller should use
@@ -74,34 +84,19 @@ class SessionCompressor:
         old_summary, remaining = extract_existing_summary(history_messages)
 
         if token_budget is not None:
-            # Token-based window: accumulate from tail, always keeping at
-            # least the last message verbatim so the newest context is never
-            # entirely summarized away.
-            from .history_utils import _estimate_tokens
-
-            window_start = len(remaining)
-            accumulated = 0
-            for j in range(len(remaining) - 1, -1, -1):
-                msg_tokens = _estimate_tokens([remaining[j]])
-                if accumulated + msg_tokens > token_budget:
-                    break
-                accumulated += msg_tokens
-                window_start = j
-
-            # Guarantee at least the last message is kept verbatim.
-            # This prevents a single oversized message from pushing
-            # window_start to len(remaining) and yielding to_keep=[].
+            window_start = find_safe_window_start(remaining, token_budget)
             if window_start >= len(remaining) and remaining:
                 window_start = len(remaining) - 1
-
             to_compress = remaining[:window_start]
             to_keep = remaining[window_start:]
         else:
-            # Legacy path: fixed message-count window
+            # Legacy path: fixed message-count window (still expand for tools)
             if len(remaining) <= WINDOW_SIZE:
                 return False, history_messages
-            to_compress = remaining[:-WINDOW_SIZE]
-            to_keep = remaining[-WINDOW_SIZE:]
+            window_start = len(remaining) - WINDOW_SIZE
+            window_start = _expand_legacy_window_start(remaining, window_start)
+            to_compress = remaining[:window_start]
+            to_keep = remaining[window_start:]
 
         if not to_compress:
             return False, history_messages
@@ -112,7 +107,15 @@ class SessionCompressor:
             logger.exception("Failed to generate session summary; skipping compression")
             return False, history_messages
 
-        if not new_summary:
+        if not new_summary or looks_like_summary_error(new_summary):
+            return False, history_messages
+
+        new_summary = truncate_summary(new_summary, self._max_summary_tokens)
+        result = inject_summary(new_summary, to_keep)
+        if validate_tool_pairing(result):
+            logger.warning(
+                "Compressed history failed tool pairing validation; skipping compression"
+            )
             return False, history_messages
 
         logger.info(
@@ -121,7 +124,7 @@ class SessionCompressor:
             len(new_summary),
             len(to_keep),
         )
-        return True, inject_summary(new_summary, to_keep)
+        return True, result
 
     # ── High-level entry point ───────────────────────────────────────
 
@@ -136,6 +139,7 @@ class SessionCompressor:
 
         This is the single entry point used by both save paths
         (session.py and persistence.py) to avoid logic duplication.
+        Prefer :class:`HistoryCompactionPolicy` for pre-turn orchestration.
         """
         from .history_utils import (
             _is_heartbeat,
@@ -168,6 +172,90 @@ class SessionCompressor:
     async def _generate_summary(
         self, old_summary: str, messages: List[Dict[str, Any]]
     ) -> str:
+        """Summarize *messages*, covering the full compress region.
+
+        Large regions are map-reduced in chunks so late constraints and tool
+        conclusions are not dropped by a prefix-only char cap or a hard map
+        chunk limit (issue #166 F-004). Every chunk is mapped; partials are
+        merged with a hierarchical reduce so reduce prompts stay bounded.
+        """
+        chunks = chunk_messages_for_summary(
+            messages, max_chars_per_chunk=_SUMMARY_CHUNK_CHARS
+        )
+        if len(chunks) == 1:
+            return await self._call_summary_llm(old_summary, chunks[0])
+
+        # Map: one bounded summary per chunk — full head→tail coverage.
+        # Fail-closed (issue #166 F-005): any empty/error map result aborts the
+        # entire summary so callers fall back to safe window / kept_original
+        # instead of committing a partial summary that silently drops facts.
+        partials: List[str] = []
+        for idx, chunk in enumerate(chunks):
+            # Feed prior summary only into the first map call; later chunks stand alone.
+            seed = old_summary if idx == 0 else ""
+            partial = await self._call_summary_llm(seed, chunk)
+            if not partial or looks_like_summary_error(partial):
+                raise RuntimeError(
+                    f"Map summary failed for chunk {idx + 1}/{len(chunks)} "
+                    "(empty or error-like output); aborting partial summary"
+                )
+            partials.append(partial.strip())
+
+        # Hierarchical reduce: merge partials in bounded fan-in batches until one.
+        return await self._reduce_partial_summaries(old_summary, partials)
+
+    async def _reduce_partial_summaries(
+        self, old_summary: str, partials: List[str]
+    ) -> str:
+        """Merge map partials with hierarchical reduce (bounded fan-in).
+
+        Fail-closed (issue #166 F-005): any empty/error reduce output aborts
+        the entire summary so callers keep original history or safe-window trim
+        rather than submitting an incomplete merged summary.
+        """
+        level = list(partials)
+        if not level:
+            raise RuntimeError("No usable partial summaries for reduce")
+        if len(level) == 1:
+            return level[0]
+
+        seed = old_summary
+        while len(level) > 1:
+            next_level: List[str] = []
+            for batch_start in range(0, len(level), _SUMMARY_REDUCE_FAN_IN):
+                batch = level[batch_start : batch_start + _SUMMARY_REDUCE_FAN_IN]
+                if len(batch) == 1:
+                    next_level.append(batch[0])
+                    continue
+                reduce_msgs: List[Dict[str, Any]] = [
+                    {
+                        "role": "assistant",
+                        "content": (
+                            f"[分段摘要{batch_start + i + 1}/"
+                            f"{len(level)}] {text}"
+                        ),
+                    }
+                    for i, text in enumerate(batch)
+                ]
+                # Only the first reduce batch absorbs the prior session summary.
+                batch_seed = seed if batch_start == 0 else ""
+                merged = await self._call_summary_llm(batch_seed, reduce_msgs)
+                if not merged or looks_like_summary_error(merged):
+                    raise RuntimeError(
+                        f"Reduce summary failed for batch starting at "
+                        f"{batch_start} (empty or error-like output); "
+                        "aborting partial summary"
+                    )
+                next_level.append(merged.strip())
+            # After the first level, old_summary is already folded in.
+            seed = ""
+            level = next_level
+
+        return level[0]
+
+    async def _call_summary_llm(
+        self, old_summary: str, messages: List[Dict[str, Any]]
+    ) -> str:
         messages_text = _format_messages_for_prompt(messages)
         if old_summary:
             old_summary_block = f"之前的摘要：\n{old_summary}\n"
@@ -181,12 +269,20 @@ class SessionCompressor:
 
         from ..agent.provider import oneshot_llm_provider
 
-        # raise_on_error=False preserves the original compressor behavior:
-        # when the LLM surfaces an error string it is used verbatim as the
-        # summary rather than raising (callers degrade gracefully).
+        # raise_on_error=True so error strings are not silently stored as
+        # summary text; callers catch and degrade to safe window / keep original.
         return await oneshot_llm_provider().call_llm(
-            self._context, prompt, temperature=0.3, fast=True, raise_on_error=False
+            self._context, prompt, temperature=0.3, fast=True, raise_on_error=True
         )
+
+
+def _expand_legacy_window_start(
+    messages: List[Dict[str, Any]], start: int
+) -> int:
+    """Expand a count-based window start so tool pairs stay intact."""
+    from .history_compaction import _expand_to_safe_boundary
+
+    return _expand_to_safe_boundary(messages, start)
 
 
 # ── Pure helpers (no LLM, no I/O) ────────────────────────────────────
@@ -237,25 +333,185 @@ def is_summary_message(msg: Dict[str, Any]) -> bool:
     )
 
 
+# Per-chunk budget for map-reduce summary; keeps each oneshot prompt bounded
+# while still covering the full compressed region via multiple map calls.
+# Map stage processes *all* chunks (no hard map cap — issue #166 F-004).
+# Hierarchical reduce merges at most _SUMMARY_REDUCE_FAN_IN partials per call.
+_SUMMARY_CHUNK_CHARS = 10_000
+_SUMMARY_REDUCE_FAN_IN = 8
+_TOOL_BODY_MAX = 800
+_TOOL_ARGS_MAX = 400
+
+
+def _message_to_summary_line(msg: Dict[str, Any]) -> Optional[str]:
+    """One human-readable line for the summary prompt (includes tool facts)."""
+    role = msg.get("role", "unknown")
+    content = msg.get("content")
+
+    if role == "tool":
+        tcid = msg.get("tool_call_id") or ""
+        body = content if isinstance(content, str) else ""
+        if len(body) > _TOOL_BODY_MAX:
+            body = body[:_TOOL_BODY_MAX] + "…"
+        return f"工具结果({tcid}): {body}"
+
+    if role == "assistant":
+        parts: list[str] = []
+        if isinstance(content, str) and content:
+            parts.append(content)
+        for tc in msg.get("tool_calls") or []:
+            if not isinstance(tc, dict):
+                continue
+            fn = tc.get("function") or {}
+            if not isinstance(fn, dict):
+                fn = {}
+            name = fn.get("name") or ""
+            args = fn.get("arguments") or ""
+            if not isinstance(args, str):
+                args = str(args)
+            if len(args) > _TOOL_ARGS_MAX:
+                args = args[:_TOOL_ARGS_MAX] + "…"
+            parts.append(f"[调用工具 {name}({args})]")
+        if not parts:
+            return None
+        return f"助手: {' '.join(parts)}"
+
+    if role == "user":
+        if not isinstance(content, str) or not content:
+            return None
+        return f"用户: {content}"
+
+    if isinstance(content, str) and content:
+        return f"{role}: {content}"
+    return None
+
+
+def _pack_lines_with_coverage(lines: List[str], max_chars: int) -> str:
+    """Fill *max_chars* using head + mid samples + tail (never prefix-only).
+
+    Late messages (constraints / tool conclusions near the compress cut) get a
+    larger share of the budget than early bulk noise.
+    """
+    n = len(lines)
+    if n == 0 or max_chars <= 0:
+        return ""
+
+    # Budget split: head 25%, mid 30%, tail 40% (+ markers).
+    head_budget = max(200, max_chars // 4)
+    tail_budget = max(400, (max_chars * 2) // 5)
+    mid_budget = max(200, max_chars - head_budget - tail_budget - 100)
+
+    selected: List[Tuple[int, str]] = []
+    used: set[int] = set()
+
+    total = 0
+    for i, line in enumerate(lines):
+        cost = len(line) + 1
+        if total + cost > head_budget:
+            break
+        selected.append((i, line))
+        used.add(i)
+        total += cost
+
+    total = 0
+    for i in range(n - 1, -1, -1):
+        if i in used:
+            continue
+        line = lines[i]
+        cost = len(line) + 1
+        if total + cost > tail_budget:
+            break
+        selected.append((i, line))
+        used.add(i)
+        total += cost
+
+    remaining = [i for i in range(n) if i not in used]
+    if remaining and mid_budget > 0:
+        # Evenly sample remaining indices so mid-region facts still appear.
+        approx_lines = max(1, mid_budget // 120)
+        step = max(1, len(remaining) // approx_lines)
+        mid_total = 0
+        for k in range(0, len(remaining), step):
+            i = remaining[k]
+            line = lines[i]
+            cost = len(line) + 1
+            if mid_total + cost > mid_budget:
+                break
+            selected.append((i, line))
+            mid_total += cost
+
+    selected.sort(key=lambda item: item[0])
+    out: list[str] = []
+    prev = -1
+    for i, line in selected:
+        if prev >= 0 and i > prev + 1:
+            out.append("...(部分对话已省略)")
+        out.append(line)
+        prev = i
+    text = "\n".join(out)
+    if len(text) > max_chars:
+        return text[: max_chars - 1].rstrip() + "…"
+    return text
+
+
 def _format_messages_for_prompt(
     messages: List[Dict[str, Any]], max_chars: int = 12000
 ) -> str:
-    """Format message dicts into a readable text block for the summary prompt."""
+    """Format message dicts for the summary prompt.
+
+    Includes user/assistant/tool content so confirmed constraints and tool
+    conclusions survive. When the transcript exceeds *max_chars*, uses coverage
+    packing (head/mid/tail) instead of truncating only the earliest prefix.
+    """
     lines: list[str] = []
-    total = 0
     for msg in messages:
-        role = msg.get("role", "unknown")
-        content = msg.get("content") or ""
-        if not isinstance(content, str):
+        if not isinstance(msg, dict):
             continue
-        # Skip tool messages — they add noise to the summary.
-        if role == "tool":
+        line = _message_to_summary_line(msg)
+        if line is not None:
+            lines.append(line)
+
+    if not lines:
+        return ""
+
+    full = "\n".join(lines)
+    if len(full) <= max_chars:
+        return full
+    return _pack_lines_with_coverage(lines, max_chars)
+
+
+def chunk_messages_for_summary(
+    messages: List[Dict[str, Any]],
+    *,
+    max_chars_per_chunk: int = _SUMMARY_CHUNK_CHARS,
+) -> List[List[Dict[str, Any]]]:
+    """Split *messages* into contiguous chunks by formatted size.
+
+    Each chunk stays within *max_chars_per_chunk* (single oversized message
+    becomes its own chunk). Used by map-reduce summary so the whole compress
+    region is covered, not only the first 12k characters.
+    """
+    if not messages:
+        return [[]]
+    if max_chars_per_chunk <= 0:
+        return [list(messages)]
+
+    chunks: List[List[Dict[str, Any]]] = []
+    current: List[Dict[str, Any]] = []
+    current_chars = 0
+
+    for msg in messages:
+        if not isinstance(msg, dict):
             continue
-        label = {"user": "用户", "assistant": "助手"}.get(role, role)
-        line = f"{label}: {content}"
-        if total + len(line) > max_chars:
-            lines.append("...(部分对话已省略)")
-            break
-        lines.append(line)
-        total += len(line)
-    return "\n".join(lines)
+        line = _message_to_summary_line(msg) or ""
+        cost = len(line) + 1
+        if current and current_chars + cost > max_chars_per_chunk:
+            chunks.append(current)
+            current = []
+            current_chars = 0
+        current.append(msg)
+        current_chars += cost
+
+    if current:
+        chunks.append(current)
+    return chunks or [[]]

--- a/src/everbot/core/session/history_compaction.py
+++ b/src/everbot/core/session/history_compaction.py
@@ -1,0 +1,569 @@
+"""Long-session history compaction policy (issue #166).
+
+Unified entry for pre-turn and save-path compaction:
+- token budget gate (trigger / target)
+- LLM summary + tool-chain-safe recent window (via SessionCompressor helpers)
+- safe window trim fallback when summary fails
+- never silently drop messages that cannot be reduced safely
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Sequence, Tuple, Union
+
+from .history_utils import (
+    COMPACT_TOKEN_BUDGET,
+    COMPACT_WINDOW_TOKENS,
+    _estimate_tokens,
+    _is_heartbeat,
+    _is_placeholder,
+)
+logger = logging.getLogger(__name__)
+
+# Default max summary budget (tokens); chars ≈ tokens * 3.
+DEFAULT_MAX_SUMMARY_TOKENS = 2_000
+
+SummarizeFn = Callable[[str, List[Dict[str, Any]]], Awaitable[str]]
+
+
+@dataclass(frozen=True)
+class HistoryCompactionConfig:
+    """Resolved compaction settings (agent > global > default)."""
+
+    enabled: bool = True
+    trigger_tokens: int = COMPACT_TOKEN_BUDGET
+    target_recent_tokens: int = COMPACT_WINDOW_TOKENS
+    max_summary_tokens: int = DEFAULT_MAX_SUMMARY_TOKENS
+
+
+@dataclass
+class CompactionResult:
+    """Outcome of :meth:`HistoryCompactionPolicy.ensure_within_budget`."""
+
+    history: List[Dict[str, Any]]
+    changed: bool
+    outcome: str
+    reason: str
+    before_tokens: int
+    after_tokens: int
+    summary_tokens: int
+    retained_messages: int
+
+    def to_event_payload(self, *, provider: str = "", session_id: str = "") -> Dict[str, Any]:
+        """Structured timeline/log fields (no history body)."""
+        payload: Dict[str, Any] = {
+            "type": "history_compaction",
+            "provider": provider,
+            "reason": self.reason,
+            "before_tokens": self.before_tokens,
+            "after_tokens": self.after_tokens,
+            "summary_tokens": self.summary_tokens,
+            "retained_messages": self.retained_messages,
+            "outcome": self.outcome,
+        }
+        if session_id:
+            payload["session_id"] = session_id
+        return payload
+
+
+def resolve_history_compaction_config(
+    config: Optional[Dict[str, Any]] = None,
+    agent_name: Optional[str] = None,
+) -> HistoryCompactionConfig:
+    """Resolve config with priority: agent > global > default.
+
+    Paths:
+      - ``everbot.agents.<agent_name>.session.history_compaction.*``
+      - ``everbot.session.history_compaction.*``
+    Invalid values log a warning and fall back to defaults (never raise).
+    """
+    defaults = HistoryCompactionConfig()
+    if not isinstance(config, dict):
+        return defaults
+
+    everbot = config.get("everbot", {})
+    if not isinstance(everbot, dict):
+        return defaults
+
+    global_raw = (everbot.get("session") or {}).get("history_compaction") or {}
+    if not isinstance(global_raw, dict):
+        global_raw = {}
+
+    agent_raw: Dict[str, Any] = {}
+    if agent_name:
+        agent_cfg = (everbot.get("agents") or {}).get(agent_name) or {}
+        if isinstance(agent_cfg, dict):
+            session_cfg = agent_cfg.get("session") or {}
+            if isinstance(session_cfg, dict):
+                raw = session_cfg.get("history_compaction") or {}
+                if isinstance(raw, dict):
+                    agent_raw = raw
+
+    merged: Dict[str, Any] = {**global_raw, **agent_raw}
+    return _sanitize_config(merged, defaults)
+
+
+def _sanitize_config(
+    raw: Dict[str, Any], defaults: HistoryCompactionConfig
+) -> HistoryCompactionConfig:
+    enabled = defaults.enabled
+    if "enabled" in raw:
+        val = raw["enabled"]
+        if isinstance(val, bool):
+            enabled = val
+        else:
+            logger.warning(
+                "Invalid history_compaction.enabled=%r; using default %s",
+                val,
+                defaults.enabled,
+            )
+
+    trigger = defaults.trigger_tokens
+    if "trigger_tokens" in raw:
+        try:
+            t = int(raw["trigger_tokens"])
+            if t >= 1000:
+                trigger = t
+            else:
+                logger.warning(
+                    "Invalid history_compaction.trigger_tokens=%r (<1000); using default",
+                    raw["trigger_tokens"],
+                )
+        except (TypeError, ValueError):
+            logger.warning(
+                "Invalid history_compaction.trigger_tokens=%r; using default",
+                raw["trigger_tokens"],
+            )
+
+    target = defaults.target_recent_tokens
+    if "target_recent_tokens" in raw:
+        try:
+            t = int(raw["target_recent_tokens"])
+            if t >= 500:
+                target = t
+            else:
+                logger.warning(
+                    "Invalid history_compaction.target_recent_tokens=%r (<500); using default",
+                    raw["target_recent_tokens"],
+                )
+        except (TypeError, ValueError):
+            logger.warning(
+                "Invalid history_compaction.target_recent_tokens=%r; using default",
+                raw["target_recent_tokens"],
+            )
+
+    if target > trigger:
+        logger.warning(
+            "history_compaction.target_recent_tokens (%s) > trigger_tokens (%s); "
+            "clamping target to trigger",
+            target,
+            trigger,
+        )
+        target = trigger
+
+    max_summary = defaults.max_summary_tokens
+    if "max_summary_tokens" in raw:
+        try:
+            t = int(raw["max_summary_tokens"])
+            if 200 <= t <= 8000:
+                max_summary = t
+            else:
+                logger.warning(
+                    "Invalid history_compaction.max_summary_tokens=%r; using default",
+                    raw["max_summary_tokens"],
+                )
+        except (TypeError, ValueError):
+            logger.warning(
+                "Invalid history_compaction.max_summary_tokens=%r; using default",
+                raw["max_summary_tokens"],
+            )
+
+    return HistoryCompactionConfig(
+        enabled=enabled,
+        trigger_tokens=trigger,
+        target_recent_tokens=target,
+        max_summary_tokens=max_summary,
+    )
+
+
+# ── Tool-chain safety ────────────────────────────────────────────────
+
+
+def _tool_call_ids(msg: Dict[str, Any]) -> List[str]:
+    ids: List[str] = []
+    for tc in msg.get("tool_calls") or []:
+        if isinstance(tc, dict) and tc.get("id"):
+            ids.append(str(tc["id"]))
+    return ids
+
+
+def validate_tool_pairing(messages: Sequence[Dict[str, Any]]) -> List[str]:
+    """Return error codes for illegal tool sequences; empty list means valid.
+
+    - ``orphan_tool:<id>`` — tool result without a prior assistant tool_call in window
+    - ``unmatched_tool_call:<id>`` — tool_call closed by a later non-tool message without result
+
+    Unfinished tool chains at the **end** of the list are allowed (open pending).
+    """
+    errors: List[str] = []
+    pending: Dict[str, int] = {}
+
+    for i, msg in enumerate(messages):
+        if not isinstance(msg, dict):
+            continue
+        role = msg.get("role")
+        if role == "assistant":
+            if pending:
+                for tcid in list(pending):
+                    errors.append(f"unmatched_tool_call:{tcid}")
+                pending.clear()
+            for tcid in _tool_call_ids(msg):
+                pending[tcid] = i
+        elif role == "tool":
+            tcid = msg.get("tool_call_id")
+            if not tcid or str(tcid) not in pending:
+                errors.append(f"orphan_tool:{tcid or 'missing'}")
+            else:
+                del pending[str(tcid)]
+        elif role == "user":
+            if pending:
+                for tcid in list(pending):
+                    errors.append(f"unmatched_tool_call:{tcid}")
+                pending.clear()
+        # other roles ignored
+    return errors
+
+
+def _find_assistant_for_tool(
+    messages: Sequence[Dict[str, Any]], tool_idx: int
+) -> Optional[int]:
+    """Locate the assistant message that owns ``messages[tool_idx]`` tool_call_id."""
+    tcid = messages[tool_idx].get("tool_call_id")
+    if not tcid:
+        return None
+    for j in range(tool_idx - 1, -1, -1):
+        if messages[j].get("role") == "assistant" and str(tcid) in _tool_call_ids(
+            messages[j]
+        ):
+            return j
+    return None
+
+
+def find_safe_window_start(
+    messages: Sequence[Dict[str, Any]], token_budget: int
+) -> int:
+    """Return inclusive start index of a tool-safe recent window.
+
+    Accumulates tokens from the tail up to *token_budget*, then expands the
+    cut point so the retained slice has no orphan tool messages. Always keeps
+    at least the last message when the list is non-empty.
+    """
+    n = len(messages)
+    if n == 0:
+        return 0
+
+    window_start = n
+    accumulated = 0
+    for j in range(n - 1, -1, -1):
+        msg_tokens = _estimate_tokens([messages[j]])
+        if accumulated > 0 and accumulated + msg_tokens > token_budget:
+            break
+        accumulated += msg_tokens
+        window_start = j
+        if accumulated >= token_budget and j < n - 1:
+            # filled budget; keep what we have (may be over if single msg is huge)
+            if accumulated > token_budget and window_start < n - 1:
+                # last added blew budget and we already had messages — drop it
+                window_start = j + 1
+                break
+            break
+
+    if window_start >= n:
+        window_start = n - 1
+
+    # Prefer keeping the latest user turn with its assistant/tool chain
+    # (design: at least the newest user message + related tool chain).
+    if window_start > 0 and messages[window_start].get("role") != "user":
+        for j in range(window_start - 1, -1, -1):
+            if messages[j].get("role") == "user":
+                window_start = j
+                break
+
+    return _expand_to_safe_boundary(messages, window_start)
+
+
+def _expand_to_safe_boundary(
+    messages: Sequence[Dict[str, Any]], start: int
+) -> int:
+    """Expand *start* leftward until ``messages[start:]`` has valid tool pairing."""
+    if start <= 0:
+        return 0
+
+    # If cut lands on tool, jump to owning assistant.
+    if messages[start].get("role") == "tool":
+        asst = _find_assistant_for_tool(messages, start)
+        if asst is not None:
+            start = asst
+        else:
+            start = max(0, start - 1)
+
+    # Expand until validation passes or we hit 0.
+    while start > 0:
+        errs = validate_tool_pairing(messages[start:])
+        if not errs:
+            return start
+        # Prefer jumping to assistant for leading orphan tool.
+        if messages[start].get("role") == "tool":
+            asst = _find_assistant_for_tool(messages, start)
+            if asst is not None and asst < start:
+                start = asst
+                continue
+        start -= 1
+    return 0
+
+
+def safe_window_trim(
+    messages: List[Dict[str, Any]], token_budget: int
+) -> Tuple[List[Dict[str, Any]], bool]:
+    """Trim to a tool-safe recent window without injecting a summary.
+
+    Returns ``(trimmed, reduced)`` where *reduced* is True only when the
+    result is strictly shorter than the input and tool pairing is valid.
+    Never returns a structurally invalid sequence; on failure returns the
+    original list with ``reduced=False``.
+    """
+    if not messages:
+        return messages, False
+
+    start = find_safe_window_start(messages, token_budget)
+    if start <= 0:
+        # Cannot drop anything without starting at 0.
+        # Still may be over budget (single huge message / full chain).
+        trimmed = list(messages)
+        if validate_tool_pairing(trimmed):
+            return messages, False
+        # start==0 means full list kept
+        return messages, False
+
+    trimmed = list(messages[start:])
+    if validate_tool_pairing(trimmed):
+        return messages, False
+    if len(trimmed) >= len(messages):
+        return messages, False
+    return trimmed, True
+
+
+def looks_like_summary_error(text: str) -> bool:
+    """Heuristic: oneshot LLM error strings must not become history summaries."""
+    if not text or not str(text).strip():
+        return True
+    t = str(text).strip()
+    low = t.lower()
+    if t.startswith("Error") or t.startswith("oneshot LLM") or t.startswith("LLM call failed"):
+        return True
+    if "traceback" in low or "runtimeerror" in low:
+        return True
+    if low.startswith("http ") and ("error" in low or "failed" in low):
+        return True
+    if "llm call failed" in low or "oneshot llm" in low:
+        return True
+    return False
+
+
+def truncate_summary(text: str, max_summary_tokens: int) -> str:
+    """Bound summary body by char budget ``max_summary_tokens * 3``."""
+    if max_summary_tokens <= 0:
+        return text
+    max_chars = max_summary_tokens * 3
+    if len(text) <= max_chars:
+        return text
+    return text[: max_chars - 1].rstrip() + "…"
+
+
+def split_chat_and_heartbeat(
+    history: List[Dict[str, Any]],
+) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+    """Separate chat messages from heartbeat/placeholder (appended at tail later)."""
+    chat = [
+        m
+        for m in history
+        if isinstance(m, dict) and not _is_heartbeat(m) and not _is_placeholder(m)
+    ]
+    heartbeat = [
+        m
+        for m in history
+        if isinstance(m, dict) and (_is_heartbeat(m) or _is_placeholder(m))
+    ]
+    return chat, heartbeat
+
+
+class HistoryCompactionPolicy:
+    """Orchestrate threshold check, summary compress, and safe-window fallback."""
+
+    async def ensure_within_budget(
+        self,
+        history: List[Dict[str, Any]],
+        config: HistoryCompactionConfig,
+        *,
+        summarize: Optional[Union[SummarizeFn, Any]] = None,
+    ) -> CompactionResult:
+        """Compress *history* when over trigger budget.
+
+        *summarize* may be an async ``(old_summary, messages) -> str`` callable
+        or a :class:`SessionCompressor` instance. Required only when compression
+        is attempted; under-threshold / disabled paths do not call it.
+        """
+        original = list(history) if history else []
+        chat, heartbeat = split_chat_and_heartbeat(original)
+        before = _estimate_tokens(chat)
+
+        def _result(
+            hist: List[Dict[str, Any]],
+            *,
+            changed: bool,
+            outcome: str,
+            reason: str,
+            summary_tokens: int = 0,
+        ) -> CompactionResult:
+            after_chat, _ = split_chat_and_heartbeat(hist)
+            return CompactionResult(
+                history=hist,
+                changed=changed,
+                outcome=outcome,
+                reason=reason,
+                before_tokens=before,
+                after_tokens=_estimate_tokens(after_chat),
+                summary_tokens=summary_tokens,
+                retained_messages=len(after_chat),
+            )
+
+        if not config.enabled:
+            return _result(original, changed=False, outcome="skipped", reason="disabled")
+
+        if before <= config.trigger_tokens:
+            return _result(original, changed=False, outcome="skipped", reason="under_trigger")
+
+        # --- Attempt summary + safe window via compressor helpers ---
+        summarized: Optional[List[Dict[str, Any]]] = None
+        summary_tokens = 0
+        summary_error: Optional[str] = None
+
+        if summarize is not None:
+            try:
+                summarized, summary_tokens = await self._try_summarize(
+                    chat, config, summarize
+                )
+            except Exception as exc:
+                logger.exception("History summary failed; will try safe window trim")
+                summary_error = str(exc)[:200]
+                summarized = None
+
+        if summarized is not None:
+            merged = summarized + heartbeat
+            if (
+                not validate_tool_pairing(summarized)
+                and _estimate_tokens(summarized) < before
+            ):
+                return _result(
+                    merged,
+                    changed=True,
+                    outcome="summarized",
+                    reason="over_trigger",
+                    summary_tokens=summary_tokens,
+                )
+            # Invalid structure — discard summary path
+            logger.warning(
+                "Summarized history failed tool pairing validation; discarding"
+            )
+            summarized = None
+
+        # --- Safe window trim fallback ---
+        trimmed, reduced = safe_window_trim(chat, config.target_recent_tokens)
+        if reduced and not validate_tool_pairing(trimmed):
+            after = _estimate_tokens(trimmed)
+            if after >= before:
+                # No actual reduction
+                return _result(
+                    original,
+                    changed=False,
+                    outcome="kept_original",
+                    reason=summary_error or "trim_no_reduction",
+                )
+            # Still over target but smaller → over_budget if minimal keep is huge
+            outcome = "window_trimmed"
+            if after > config.target_recent_tokens:
+                # Check if we kept everything that is a single oversize chain
+                min_start = find_safe_window_start(chat, 1)  # force minimal keep
+                min_slice = chat[min_start:]
+                if len(min_slice) == len(trimmed) and after > config.target_recent_tokens:
+                    outcome = "over_budget_unavoidable"
+            return _result(
+                trimmed + heartbeat,
+                changed=True,
+                outcome=outcome,
+                reason=summary_error or "summary_failed",
+            )
+
+        # Cannot safely reduce
+        # Detect over_budget_unavoidable: single message / min chain already over target
+        min_start = find_safe_window_start(chat, config.target_recent_tokens)
+        min_tokens = _estimate_tokens(chat[min_start:]) if chat else 0
+        if min_start == 0 and min_tokens > config.target_recent_tokens:
+            return _result(
+                original,
+                changed=False,
+                outcome="over_budget_unavoidable",
+                reason="single_message_or_chain_over_target",
+            )
+
+        return _result(
+            original,
+            changed=False,
+            outcome="kept_original",
+            reason=summary_error or "cannot_safely_reduce",
+        )
+
+    async def _try_summarize(
+        self,
+        chat: List[Dict[str, Any]],
+        config: HistoryCompactionConfig,
+        summarize: Union[SummarizeFn, Any],
+    ) -> Tuple[Optional[List[Dict[str, Any]]], int]:
+        """Run summary compression; return (history_or_None, summary_tokens)."""
+        from .compressor import (
+            extract_existing_summary,
+            inject_summary,
+            SessionCompressor,
+        )
+
+        old_summary, remaining = extract_existing_summary(chat)
+        window_start = find_safe_window_start(remaining, config.target_recent_tokens)
+        # Guarantee at least last message
+        if window_start >= len(remaining) and remaining:
+            window_start = len(remaining) - 1
+
+        to_compress = remaining[:window_start]
+        to_keep = remaining[window_start:]
+        if not to_compress:
+            return None, 0
+
+        # Call summarize
+        if isinstance(summarize, SessionCompressor):
+            new_summary = await summarize._generate_summary(old_summary, to_compress)
+        elif callable(summarize):
+            new_summary = await summarize(old_summary, to_compress)
+        else:
+            return None, 0
+
+        if looks_like_summary_error(new_summary):
+            logger.warning("Rejecting summary that looks like an error string")
+            return None, 0
+
+        new_summary = truncate_summary(new_summary, config.max_summary_tokens)
+        summary_tokens = max(1, len(new_summary) // 3) if new_summary else 0
+        result = inject_summary(new_summary, to_keep)
+        if validate_tool_pairing(result):
+            return None, 0
+        return result, summary_tokens

--- a/src/everbot/core/session/history_utils.py
+++ b/src/everbot/core/session/history_utils.py
@@ -11,7 +11,7 @@ Public API:
 
 from __future__ import annotations
 
-from typing import List
+from typing import Any, Dict, List
 
 MAX_HEARTBEAT_MESSAGES = 20
 COMPACT_TOKEN_BUDGET = 40_000

--- a/src/everbot/core/session/persistence.py
+++ b/src/everbot/core/session/persistence.py
@@ -307,15 +307,37 @@ class SessionPersistence:
                 failure_memory=failure_memory or {},
             )
 
-            # Compress history for long-lived sessions before persisting.
-            if data.session_type in ("primary", "channel") and provider.needs_history_restore():
-                # dolphin: 进程内 history 压缩(需 context)。
-                # milkie: serve 返回全量 history,无 in-process 压缩(由 serve 端负责)。
+            # Compress history for long-lived sessions before persisting (#166).
+            # Shared policy for all providers; disk mirror stays lean.
+            if data.session_type in ("primary", "channel"):
                 try:
-                    compressor = SessionCompressor(agent.executor.context)
-                    data.history_messages = await compressor.compress_history(
-                        data.history_messages
+                    from ...infra.config import get_config
+                    from .history_compaction import (
+                        HistoryCompactionPolicy,
+                        resolve_history_compaction_config,
                     )
+                    from .history_utils import _estimate_tokens, _is_heartbeat, _is_placeholder
+
+                    agent_name = getattr(agent, "name", "") or ""
+                    cfg = resolve_history_compaction_config(get_config(), agent_name)
+                    chat_est = [
+                        m for m in (data.history_messages or [])
+                        if isinstance(m, dict)
+                        and not _is_heartbeat(m)
+                        and not _is_placeholder(m)
+                    ]
+                    # Only construct compressor / call LLM path when over trigger.
+                    if cfg.enabled and _estimate_tokens(chat_est) > cfg.trigger_tokens:
+                        compressor = SessionCompressor(
+                            getattr(getattr(agent, "executor", None), "context", None),
+                            max_summary_tokens=cfg.max_summary_tokens,
+                        )
+                        policy = HistoryCompactionPolicy()
+                        result = await policy.ensure_within_budget(
+                            data.history_messages, cfg, summarize=compressor
+                        )
+                        if result.changed:
+                            data.history_messages = result.history
                 except Exception:
                     logger.warning("History compression failed; saving uncompressed", exc_info=True)
 

--- a/src/everbot/core/session/session.py
+++ b/src/everbot/core/session/session.py
@@ -1033,6 +1033,7 @@ class SessionManager:
 
             # Apply to live provider history (bounded I/O)
             apply_ok = True
+            apply_failure_reason = "provider_import_failed"
             try:
                 import_fn = getattr(provider, "import_session", None)
                 if callable(import_fn):
@@ -1091,6 +1092,7 @@ class SessionManager:
                 return result
             except Exception:
                 apply_ok = False
+                apply_failure_reason = "provider_import_failed"
                 logger.warning(
                     "history_compaction apply failed (session=%s)",
                     session_id,
@@ -1102,7 +1104,7 @@ class SessionManager:
                     history=history,
                     changed=False,
                     outcome="apply_failed",
-                    reason=result.reason or "provider_import_failed",
+                    reason=apply_failure_reason,
                     before_tokens=result.before_tokens,
                     after_tokens=result.before_tokens,
                     summary_tokens=result.summary_tokens,

--- a/src/everbot/core/session/session.py
+++ b/src/everbot/core/session/session.py
@@ -13,10 +13,19 @@ from contextlib import asynccontextmanager
 import logging
 
 from .compressor import SessionCompressor
+from .history_compaction import (
+    CompactionResult,
+    HistoryCompactionPolicy,
+    resolve_history_compaction_config,
+)
 from . import session_ids as _sid
 from . import session_mailbox as _mailbox
 
 logger = logging.getLogger(__name__)
+
+# Bound provider export/import during pre-turn compaction so a stalled
+# sidecar cannot block the event loop forever (issue #166 / review F-007).
+_COMPACTION_PROVIDER_IO_TIMEOUT_SECONDS = 15.0
 
 
 # Re-export SessionData for backward compatibility
@@ -369,14 +378,29 @@ class SessionManager:
         timeout: float = 10.0,
         blocking: bool = True,
         bump_updated_at: bool = True,
+        lock_already_held: bool = False,
     ) -> Optional[SessionData]:
         """Atomic read-modify-write with dual-layer locking.
 
         Layer 1: asyncio.Lock (in-process, reduces contention among coroutines).
         Layer 2: fcntl.flock (cross-process, protects daemon vs web).
 
+        When the caller already holds both locks (e.g. core_service chat turn),
+        pass ``lock_already_held=True`` to skip re-acquisition and avoid
+        self-deadlock on the non-reentrant asyncio lock / flock.
+
         Returns updated SessionData on success, None if lock not acquired.
         """
+        if lock_already_held:
+            return await self.persistence.update_atomic(
+                session_id,
+                mutator,
+                timeout=timeout,
+                blocking=blocking,
+                bump_updated_at=bump_updated_at,
+                lock_already_held=True,
+            )
+
         lock = self._get_lock(session_id)
         wait_started = time.perf_counter()
         try:
@@ -575,15 +599,34 @@ class SessionManager:
         created_at_hint = provider.get_variable(agent, "session_created_at")
 
         # Compress history for long-lived sessions before entering the lock.
-        if (
-            SessionManager.infer_session_type(session_id) in ("primary", "channel")
-            and provider.needs_history_restore()
-        ):
-            # dolphin: 进程内 history 压缩(需 context)。
-            # milkie: serve 返回全量 history,无 in-process 压缩。
+        # Shared policy for all providers (milkie included); applies to alfred mirror.
+        if SessionManager.infer_session_type(session_id) in ("primary", "channel"):
             try:
-                compressor = SessionCompressor(agent.executor.context)
-                serializable_history = await compressor.compress_history(serializable_history)
+                from ...infra.config import get_config
+                from .history_utils import _estimate_tokens, _is_heartbeat, _is_placeholder
+
+                agent_name = getattr(agent, "name", "") or ""
+                cfg = resolve_history_compaction_config(get_config(), agent_name)
+                chat_est = [
+                    m for m in serializable_history
+                    if isinstance(m, dict)
+                    and not _is_heartbeat(m)
+                    and not _is_placeholder(m)
+                ]
+                if cfg.enabled and _estimate_tokens(chat_est) > cfg.trigger_tokens:
+                    compressor = SessionCompressor(
+                        getattr(getattr(agent, "executor", None), "context", None),
+                        max_summary_tokens=cfg.max_summary_tokens,
+                    )
+                    policy = HistoryCompactionPolicy()
+                    result = await policy.ensure_within_budget(
+                        serializable_history, cfg, summarize=compressor
+                    )
+                    if result.changed:
+                        serializable_history = result.history
+                        self._emit_compaction_event(
+                            session_id, result, provider_name=type(provider).__name__
+                        )
             except Exception:
                 logger.warning("History compression failed; saving uncompressed", exc_info=True)
 
@@ -858,6 +901,7 @@ class SessionManager:
             - tool_output: 工具输出返回
             - skill: Skill 执行
             - turn_end: 本轮处理结束
+            - history_compaction: long-session history budget apply (#166)
         """
         with self._timeline_lock:
             if session_id not in self._timeline_events:
@@ -867,6 +911,279 @@ class SessionManager:
             # 防止内存泄漏：超过上限时移除最早的事件
             if len(events) > self.MAX_TIMELINE_EVENTS:
                 self._timeline_events[session_id] = events[-self.MAX_TIMELINE_EVENTS:]
+
+    def _emit_compaction_event(
+        self,
+        session_id: str,
+        result: CompactionResult,
+        *,
+        provider_name: str = "",
+    ) -> None:
+        """Write history_compaction timeline + log (no history body)."""
+        if result.outcome == "skipped" and not result.changed:
+            return
+        event = result.to_event_payload(provider=provider_name, session_id=session_id)
+        self.append_timeline_event(session_id, event)
+        logger.info(
+            "history_compaction session=%s outcome=%s before_tokens=%s after_tokens=%s "
+            "summary_tokens=%s retained_messages=%s reason=%s provider=%s",
+            session_id,
+            result.outcome,
+            result.before_tokens,
+            result.after_tokens,
+            result.summary_tokens,
+            result.retained_messages,
+            result.reason,
+            provider_name,
+        )
+
+    async def maybe_compact_session_history(
+        self,
+        agent: Any,
+        session_id: str,
+        agent_name: str,
+        *,
+        config: Optional[Dict[str, Any]] = None,
+        lock_already_held: bool = False,
+    ) -> CompactionResult:
+        """Pre-turn history compaction: export → policy → apply → persist mirror.
+
+        Never raises into the chat path: failures become ``kept_original`` /
+        ``apply_failed`` outcomes with timeline observability (S5).
+
+        When invoked from a chat turn that already holds the session lock
+        (core_service), pass ``lock_already_held=True`` so the atomic mirror
+        write does not re-enter the non-reentrant lock.
+        """
+        from ..agent.provider import provider_for
+        from ...infra.config import get_config
+
+        cfg = resolve_history_compaction_config(
+            config if config is not None else get_config(),
+            agent_name,
+        )
+        empty = CompactionResult(
+            history=[],
+            changed=False,
+            outcome="skipped",
+            reason="no_history",
+            before_tokens=0,
+            after_tokens=0,
+            summary_tokens=0,
+            retained_messages=0,
+        )
+        # Gate before any provider I/O — disabled sessions must not export.
+        if not cfg.enabled:
+            empty.outcome = "skipped"
+            empty.reason = "disabled"
+            return empty
+
+        try:
+            provider = provider_for(agent)
+            provider_name = type(provider).__name__
+            try:
+                # Off-loop + hard deadline: milkie sync client uses timeout=None.
+                portable = await asyncio.wait_for(
+                    asyncio.to_thread(provider.export_session, agent),
+                    timeout=_COMPACTION_PROVIDER_IO_TIMEOUT_SECONDS,
+                )
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "history_compaction export timed out after %.1fs (session=%s)",
+                    _COMPACTION_PROVIDER_IO_TIMEOUT_SECONDS,
+                    session_id,
+                )
+                empty.reason = "export_timeout"
+                empty.outcome = "kept_original"
+                self._emit_compaction_event(
+                    session_id, empty, provider_name=provider_name
+                )
+                return empty
+            except Exception as exc:
+                logger.warning(
+                    "history_compaction export failed (session=%s): %s",
+                    session_id,
+                    exc,
+                )
+                empty.reason = f"export_failed:{exc}"[:200]
+                empty.outcome = "kept_original"
+                self._emit_compaction_event(session_id, empty, provider_name=provider_name)
+                return empty
+
+            history = list(portable.get("history_messages") or [])
+            if not history:
+                return empty
+
+            compressor = SessionCompressor(
+                getattr(getattr(agent, "executor", None), "context", None),
+                max_summary_tokens=cfg.max_summary_tokens,
+            )
+            policy = HistoryCompactionPolicy()
+            result = await policy.ensure_within_budget(
+                history, cfg, summarize=compressor
+            )
+
+            if not result.changed:
+                # Still emit fail-closed outcomes for observability
+                if result.outcome not in ("skipped",):
+                    self._emit_compaction_event(
+                        session_id, result, provider_name=provider_name
+                    )
+                return result
+
+            # Apply to live provider history (bounded I/O)
+            apply_ok = True
+            try:
+                import_fn = getattr(provider, "import_session", None)
+                if callable(import_fn):
+                    await asyncio.wait_for(
+                        asyncio.to_thread(
+                            import_fn,
+                            agent,
+                            {
+                                "history_messages": result.history,
+                                "variables": portable.get("variables") or {},
+                                "session_id": session_id,
+                            },
+                        ),
+                        timeout=_COMPACTION_PROVIDER_IO_TIMEOUT_SECONDS,
+                    )
+                else:
+                    # Fallback: process-local history variable when present
+                    from ...infra.dolphin_compat import KEY_HISTORY
+
+                    try:
+                        await asyncio.wait_for(
+                            asyncio.to_thread(
+                                provider.set_variable,
+                                agent,
+                                KEY_HISTORY,
+                                result.history,
+                            ),
+                            timeout=_COMPACTION_PROVIDER_IO_TIMEOUT_SECONDS,
+                        )
+                    except Exception:
+                        apply_ok = False
+                        logger.warning(
+                            "history_compaction apply fallback set_variable failed",
+                            exc_info=True,
+                        )
+            except asyncio.TimeoutError:
+                apply_ok = False
+                logger.warning(
+                    "history_compaction apply timed out after %.1fs (session=%s)",
+                    _COMPACTION_PROVIDER_IO_TIMEOUT_SECONDS,
+                    session_id,
+                )
+                result = CompactionResult(
+                    history=history,
+                    changed=False,
+                    outcome="apply_failed",
+                    reason="import_timeout",
+                    before_tokens=result.before_tokens,
+                    after_tokens=result.before_tokens,
+                    summary_tokens=result.summary_tokens,
+                    retained_messages=len(history),
+                )
+                self._emit_compaction_event(
+                    session_id, result, provider_name=provider_name
+                )
+                return result
+            except Exception:
+                apply_ok = False
+                logger.warning(
+                    "history_compaction apply failed (session=%s)",
+                    session_id,
+                    exc_info=True,
+                )
+
+            if not apply_ok:
+                result = CompactionResult(
+                    history=history,
+                    changed=False,
+                    outcome="apply_failed",
+                    reason=result.reason or "provider_import_failed",
+                    before_tokens=result.before_tokens,
+                    after_tokens=result.before_tokens,
+                    summary_tokens=result.summary_tokens,
+                    retained_messages=len(history),
+                )
+                self._emit_compaction_event(
+                    session_id, result, provider_name=provider_name
+                )
+                return result
+
+            # Persist alfred session mirror (history + timeline) without re-export.
+            # Must use lock_already_held when the chat turn already owns the locks.
+            persist_ok = True
+            try:
+                def _mutator(session_data: SessionData) -> None:
+                    session_data.history_messages = list(result.history)
+                    meta = dict(session_data.variables or {})
+                    meta["_history_compaction"] = {
+                        "outcome": result.outcome,
+                        "before_tokens": result.before_tokens,
+                        "after_tokens": result.after_tokens,
+                        "summary_tokens": result.summary_tokens,
+                    }
+                    session_data.variables = meta
+
+                updated = await self.update_atomic(
+                    session_id,
+                    _mutator,
+                    timeout=10.0,
+                    blocking=True,
+                    lock_already_held=lock_already_held,
+                )
+                if updated is None:
+                    persist_ok = False
+                    logger.warning(
+                        "history_compaction persist mirror failed (session=%s): "
+                        "lock not acquired (lock_already_held=%s)",
+                        session_id,
+                        lock_already_held,
+                    )
+            except Exception:
+                persist_ok = False
+                logger.warning(
+                    "history_compaction persist mirror failed (session=%s)",
+                    session_id,
+                    exc_info=True,
+                )
+
+            if not persist_ok:
+                # Live provider already has compacted history; mirror write failed.
+                # Keep changed=True so chat continues on reduced base, but mark
+                # outcome for observability (do not silently claim full success).
+                result = CompactionResult(
+                    history=result.history,
+                    changed=True,
+                    outcome="persist_failed",
+                    reason=result.reason or "atomic_mirror_write_failed",
+                    before_tokens=result.before_tokens,
+                    after_tokens=result.after_tokens,
+                    summary_tokens=result.summary_tokens,
+                    retained_messages=result.retained_messages,
+                )
+
+            self._emit_compaction_event(
+                session_id, result, provider_name=provider_name
+            )
+            return result
+        except Exception as exc:
+            logger.warning(
+                "history_compaction unexpected failure (session=%s): %s",
+                session_id,
+                exc,
+                exc_info=True,
+            )
+            empty.outcome = "kept_original"
+            empty.reason = f"unexpected:{exc}"[:200]
+            try:
+                self._emit_compaction_event(session_id, empty, provider_name="")
+            except Exception:
+                pass
+            return empty
 
     def get_timeline(self, session_id: str) -> list:
         """Get in-memory timeline events for a session."""

--- a/tests/unit/test_history_compaction.py
+++ b/tests/unit/test_history_compaction.py
@@ -910,7 +910,10 @@ class TestSessionManagerCompact:
                     session = body.get("session") or {}
                     self.imported.append(session)
                     self.history = _history_from_portable(session)
-                    return httpx.Response(200, json={"ok": True})
+                    return httpx.Response(
+                        200,
+                        json={"contextId": "c1", "conditionApplied": True},
+                    )
                 if path.endswith("/chat"):
                     # First LLM request base = live serve history after import.
                     self.chat_history_snapshots.append(list(self.history))

--- a/tests/unit/test_history_compaction.py
+++ b/tests/unit/test_history_compaction.py
@@ -1,0 +1,1434 @@
+"""Unit tests for long-session history compaction policy (#166).
+
+Covers design plan U1–U10: threshold gate, tool-safe window, summary merge,
+summary failure → safe trim, kept_original, over-budget, config priority,
+events, and tool-history regression.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from src.everbot.core.session.history_compaction import (
+    CompactionResult,
+    HistoryCompactionConfig,
+    HistoryCompactionPolicy,
+    find_safe_window_start,
+    looks_like_summary_error,
+    resolve_history_compaction_config,
+    truncate_summary,
+    validate_tool_pairing,
+)
+from src.everbot.core.session.history_utils import _estimate_tokens
+from src.everbot.core.session.compressor import SUMMARY_TAG, inject_summary
+
+
+# ── Factories ────────────────────────────────────────────────────────
+
+
+def _user(content: str) -> dict:
+    return {"role": "user", "content": content}
+
+
+def _assistant(content: str, tool_calls=None) -> dict:
+    msg = {"role": "assistant", "content": content}
+    if tool_calls is not None:
+        msg["tool_calls"] = tool_calls
+    return msg
+
+
+def _tool(tcid: str, content: str = "ok") -> dict:
+    return {"role": "tool", "tool_call_id": tcid, "content": content}
+
+
+def _tc(tcid: str, name: str = "search", args: str = "{}"):
+    return {
+        "id": tcid,
+        "type": "function",
+        "function": {"name": name, "arguments": args},
+    }
+
+
+def _bulk_history(n_pairs: int, payload: str = "x" * 300) -> list:
+    """Build n_pairs user/assistant pairs with large content (~tokens each)."""
+    msgs = []
+    for i in range(n_pairs):
+        msgs.append(_user(f"user-{i} {payload}"))
+        msgs.append(_assistant(f"asst-{i} {payload}"))
+    return msgs
+
+
+# ── U1: token threshold gate ─────────────────────────────────────────
+
+
+class TestThresholdGate:
+    @pytest.mark.asyncio
+    async def test_under_trigger_unchanged(self):
+        history = _bulk_history(2, payload="hi")
+        cfg = HistoryCompactionConfig(enabled=True, trigger_tokens=40_000)
+        summarize = AsyncMock(return_value="summary")
+        result = await HistoryCompactionPolicy().ensure_within_budget(
+            history, cfg, summarize=summarize
+        )
+        assert result.changed is False
+        assert result.outcome == "skipped"
+        assert result.reason == "under_trigger"
+        assert result.history == history
+        summarize.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_over_trigger_enters_compress_path(self):
+        # ~ (300*2 + overhead) * n pairs → exceed 500 tokens easily
+        history = _bulk_history(40, payload="p" * 200)
+        assert _estimate_tokens(history) > 500
+        cfg = HistoryCompactionConfig(
+            enabled=True,
+            trigger_tokens=500,
+            target_recent_tokens=200,
+        )
+        summarize = AsyncMock(return_value="compressed facts and open tasks")
+        result = await HistoryCompactionPolicy().ensure_within_budget(
+            history, cfg, summarize=summarize
+        )
+        assert result.changed is True
+        assert result.outcome == "summarized"
+        assert result.after_tokens < result.before_tokens
+        assert result.after_tokens <= result.before_tokens * 0.7  # ≥30% drop
+        summarize.assert_called_once()
+        assert SUMMARY_TAG in result.history[0]["content"]
+
+
+# ── U2 / U10: tool-safe window ───────────────────────────────────────
+
+
+class TestSafeWindowToolBoundary:
+    def test_window_start_expands_to_assistant_tool_call(self):
+        history = [
+            _user("early constraint: never delete files"),
+            _assistant("ok"),
+            _user("search docs"),
+            _assistant("calling", tool_calls=[_tc("c1")]),
+            _tool("c1", "big result " * 100),
+            _assistant("done"),
+            _user("recent q"),
+            _assistant("recent a"),
+        ]
+        # Force cut that would land on tool if naive
+        start = find_safe_window_start(history, token_budget=50)
+        window = history[start:]
+        assert validate_tool_pairing(window) == []
+        # If tool is in window, owning assistant must be too
+        for i, m in enumerate(window):
+            if m.get("role") == "tool":
+                assert any(
+                    m.get("tool_call_id") in [
+                        tc.get("id") for tc in (w.get("tool_calls") or [])
+                    ]
+                    for w in window[:i]
+                    if w.get("role") == "assistant"
+                )
+
+    def test_compress_with_tool_history_keeps_pairing(self):
+        """U10 / S3: tool chain spanning cut stays valid after summary."""
+        old = _bulk_history(30, payload="old " * 80)
+        tool_block = [
+            _user("use tool"),
+            _assistant("run", tool_calls=[_tc("t1"), _tc("t2")]),
+            _tool("t1", "r1 " * 50),
+            _tool("t2", "r2 " * 50),
+            _assistant("both done"),
+            _user("latest"),
+            _assistant("latest reply"),
+        ]
+        history = old + tool_block
+        start = find_safe_window_start(history, token_budget=400)
+        window = history[start:]
+        assert validate_tool_pairing(window) == []
+        # Recent messages retained
+        assert window[-1]["content"] == "latest reply"
+
+
+# ── U3: unfinished tool chain at tail ────────────────────────────────
+
+
+class TestUnfinishedToolChain:
+    def test_incomplete_chain_retained_in_window(self):
+        history = _bulk_history(20, payload="z" * 100) + [
+            _user("do work"),
+            _assistant("calling", tool_calls=[_tc("open1")]),
+            # no tool result yet — unfinished
+        ]
+        start = find_safe_window_start(history, token_budget=300)
+        window = history[start:]
+        assert any(
+            m.get("role") == "assistant" and m.get("tool_calls") for m in window
+        )
+        assert validate_tool_pairing(window) == []  # open pending at end is OK
+        # tool_call must not be orphaned by cutting mid-chain
+        assert window[-1].get("role") == "assistant"
+
+
+# ── U4: existing summary merge ───────────────────────────────────────
+
+
+class TestExistingSummaryMerge:
+    @pytest.mark.asyncio
+    async def test_only_one_summary_pair_and_old_text_passed(self):
+        summary_pair = inject_summary("旧摘要内容", [])
+        rest = _bulk_history(35, payload="m" * 150)
+        history = summary_pair + rest
+        cfg = HistoryCompactionConfig(
+            trigger_tokens=200, target_recent_tokens=150, max_summary_tokens=500
+        )
+        summarize = AsyncMock(return_value="更新后的完整摘要")
+        result = await HistoryCompactionPolicy().ensure_within_budget(
+            history, cfg, summarize=summarize
+        )
+        assert result.changed is True
+        # Only one SUMMARY_TAG user message
+        tags = [
+            m
+            for m in result.history
+            if m.get("role") == "user"
+            and isinstance(m.get("content"), str)
+            and SUMMARY_TAG in m["content"]
+        ]
+        assert len(tags) == 1
+        # Old summary text fed into summarize
+        assert summarize.call_args[0][0] == "旧摘要内容"
+
+
+# ── U5: summary failure → safe trim ──────────────────────────────────
+
+
+class TestSummaryFailureSafeTrim:
+    @pytest.mark.asyncio
+    async def test_summary_raise_then_window_trimmed(self):
+        history = _bulk_history(40, payload="q" * 200)
+        cfg = HistoryCompactionConfig(trigger_tokens=300, target_recent_tokens=200)
+        summarize = AsyncMock(side_effect=RuntimeError("LLM down"))
+        result = await HistoryCompactionPolicy().ensure_within_budget(
+            history, cfg, summarize=summarize
+        )
+        assert result.changed is True
+        assert result.outcome in ("window_trimmed", "over_budget_unavoidable")
+        assert result.after_tokens < result.before_tokens
+        assert validate_tool_pairing(result.history) == []
+
+    @pytest.mark.asyncio
+    async def test_error_string_summary_rejected(self):
+        history = _bulk_history(40, payload="q" * 200)
+        cfg = HistoryCompactionConfig(trigger_tokens=300, target_recent_tokens=200)
+        summarize = AsyncMock(return_value="oneshot LLM HTTP 500: boom")
+        result = await HistoryCompactionPolicy().ensure_within_budget(
+            history, cfg, summarize=summarize
+        )
+        # Must not inject error as summary body
+        for m in result.history:
+            if m.get("role") == "assistant" and isinstance(m.get("content"), str):
+                assert "oneshot LLM HTTP" not in m["content"]
+        assert result.outcome in (
+            "window_trimmed",
+            "over_budget_unavoidable",
+            "kept_original",
+        )
+
+
+# ── U6: cannot safely reduce ─────────────────────────────────────────
+
+
+class TestKeptOriginal:
+    @pytest.mark.asyncio
+    async def test_minimal_history_kept_when_trim_impossible(self):
+        # Two-message history forced over trigger; each message alone exceeds target.
+        # Safe trim must not empty history or leave an illegal sequence.
+        history = [
+            _user("constraint " + "X" * 3000),
+            _assistant("ack " + "Y" * 3000),
+        ]
+        cfg = HistoryCompactionConfig(
+            trigger_tokens=10,  # force trigger
+            target_recent_tokens=5,
+        )
+        summarize = AsyncMock(side_effect=RuntimeError("no"))
+        result = await HistoryCompactionPolicy().ensure_within_budget(
+            history, cfg, summarize=summarize
+        )
+        assert len(result.history) >= 1
+        assert validate_tool_pairing(result.history) == []
+        # Must not silently drop everything
+        assert any(
+            isinstance(m.get("content"), str) and m["content"]
+            for m in result.history
+        )
+        assert result.outcome in (
+            "kept_original",
+            "over_budget_unavoidable",
+            "window_trimmed",
+        )
+        if result.outcome == "kept_original":
+            assert result.changed is False
+
+
+# ── U7: single oversized message ─────────────────────────────────────
+
+
+class TestOverBudgetUnavoidable:
+    @pytest.mark.asyncio
+    async def test_single_huge_tool_json_not_truncated(self):
+        huge_args = '{"data":"' + ("Z" * 50_000) + '"}'
+        history = [
+            _user("run"),
+            _assistant("call", tool_calls=[_tc("big1", "write", huge_args)]),
+            _tool("big1", "done"),
+            _assistant("finished"),
+        ]
+        cfg = HistoryCompactionConfig(trigger_tokens=100, target_recent_tokens=50)
+        summarize = AsyncMock(side_effect=RuntimeError("skip"))
+        result = await HistoryCompactionPolicy().ensure_within_budget(
+            history, cfg, summarize=summarize
+        )
+        # Tool arguments must remain intact if messages kept
+        for m in result.history:
+            if m.get("tool_calls"):
+                args = m["tool_calls"][0]["function"]["arguments"]
+                assert args == huge_args
+                assert "Z" * 1000 in args
+        assert result.outcome in (
+            "over_budget_unavoidable",
+            "kept_original",
+            "window_trimmed",
+        )
+
+
+# ── U8: config priority ──────────────────────────────────────────────
+
+
+class TestConfigResolve:
+    def test_defaults(self):
+        cfg = resolve_history_compaction_config(None)
+        assert cfg.enabled is True
+        assert cfg.trigger_tokens == 40_000
+        assert cfg.target_recent_tokens == 20_000
+        assert cfg.max_summary_tokens == 2_000
+
+    def test_agent_overrides_global(self):
+        config = {
+            "everbot": {
+                "session": {
+                    "history_compaction": {
+                        "trigger_tokens": 30_000,
+                        "target_recent_tokens": 15_000,
+                    }
+                },
+                "agents": {
+                    "demo_agent": {
+                        "session": {
+                            "history_compaction": {
+                                "trigger_tokens": 25_000,
+                            }
+                        }
+                    }
+                },
+            }
+        }
+        cfg = resolve_history_compaction_config(config, "demo_agent")
+        assert cfg.trigger_tokens == 25_000
+        assert cfg.target_recent_tokens == 15_000
+
+    @pytest.mark.asyncio
+    async def test_enabled_false_skips_summarize(self):
+        history = _bulk_history(40, payload="p" * 200)
+        cfg = HistoryCompactionConfig(enabled=False, trigger_tokens=10)
+        summarize = AsyncMock(return_value="x")
+        result = await HistoryCompactionPolicy().ensure_within_budget(
+            history, cfg, summarize=summarize
+        )
+        assert result.outcome == "skipped"
+        assert result.reason == "disabled"
+        assert result.changed is False
+        summarize.assert_not_called()
+
+    def test_invalid_values_fallback(self):
+        config = {
+            "everbot": {
+                "session": {
+                    "history_compaction": {
+                        "trigger_tokens": 5,  # too small
+                        "max_summary_tokens": 99999,
+                    }
+                }
+            }
+        }
+        cfg = resolve_history_compaction_config(config)
+        assert cfg.trigger_tokens == 40_000
+        assert cfg.max_summary_tokens == 2_000
+
+
+# ── U9: event payload ────────────────────────────────────────────────
+
+
+class TestEventPayload:
+    def test_event_fields_no_body(self):
+        r = CompactionResult(
+            history=[{"role": "user", "content": "SECRET_BODY"}],
+            changed=True,
+            outcome="summarized",
+            reason="over_trigger",
+            before_tokens=90000,
+            after_tokens=20000,
+            summary_tokens=400,
+            retained_messages=42,
+        )
+        payload = r.to_event_payload(provider="MilkieProvider", session_id="s1")
+        assert payload["type"] == "history_compaction"
+        assert payload["before_tokens"] == 90000
+        assert payload["after_tokens"] == 20000
+        assert payload["outcome"] == "summarized"
+        assert payload["summary_tokens"] == 400
+        assert payload["retained_messages"] == 42
+        assert payload["provider"] == "MilkieProvider"
+        assert payload["session_id"] == "s1"
+        blob = str(payload)
+        assert "SECRET_BODY" not in blob
+
+
+# ── Helpers ──────────────────────────────────────────────────────────
+
+
+class TestHelpers:
+    def test_validate_orphan_tool(self):
+        msgs = [_user("hi"), _tool("missing", "x")]
+        errs = validate_tool_pairing(msgs)
+        assert any(e.startswith("orphan_tool:") for e in errs)
+
+    def test_validate_complete_chain(self):
+        msgs = [
+            _user("hi"),
+            _assistant("x", tool_calls=[_tc("a")]),
+            _tool("a"),
+            _assistant("done"),
+        ]
+        assert validate_tool_pairing(msgs) == []
+
+    def test_looks_like_summary_error(self):
+        assert looks_like_summary_error("") is True
+        assert looks_like_summary_error("oneshot LLM HTTP 500: x") is True
+        assert looks_like_summary_error("用户要求完成任务") is False
+
+    def test_truncate_summary(self):
+        text = "字" * 1000
+        out = truncate_summary(text, max_summary_tokens=10)  # 30 chars
+        assert len(out) <= 30
+        assert out.endswith("…")
+
+
+# ── S1 quantitative fixture ──────────────────────────────────────────
+
+
+class TestS1TokenReduction:
+    @pytest.mark.asyncio
+    async def test_fixture_drops_at_least_30_percent(self):
+        """Reproducible large history: early constraint + bulk + tool chain."""
+        early = [
+            _user("CRITICAL_CONSTRAINT: always use Python 3.11 and never rm -rf"),
+            _assistant("Understood, I will follow that constraint."),
+        ]
+        bulk = _bulk_history(80, payload=("history filler " * 40))
+        tools = [
+            _user("search the codebase"),
+            _assistant("searching", tool_calls=[_tc("s1", "grep", '{"q":"foo"}')]),
+            _tool("s1", "match line " * 200),
+            _assistant("found matches"),
+            _user("continue with the open task"),
+            _assistant("working on open task now"),
+        ]
+        history = early + bulk + tools
+        baseline = _estimate_tokens(history)
+        assert baseline > 10_000
+
+        cfg = HistoryCompactionConfig(
+            trigger_tokens=5_000,
+            target_recent_tokens=3_000,
+            max_summary_tokens=500,
+        )
+        summarize = AsyncMock(
+            return_value=(
+                "User CRITICAL_CONSTRAINT: always use Python 3.11 and never rm -rf. "
+                "Open task: continue codebase search. Prior work summarized."
+            )
+        )
+        result = await HistoryCompactionPolicy().ensure_within_budget(
+            history, cfg, summarize=summarize
+        )
+        assert result.changed is True
+        drop = (baseline - result.after_tokens) / baseline
+        assert drop >= 0.30, f"expected ≥30% drop, got {drop:.1%} ({baseline}→{result.after_tokens})"
+        assert validate_tool_pairing(result.history) == []
+        # Constraint preserved in summary or recent window
+        blob = " ".join(
+            (m.get("content") or "")
+            for m in result.history
+            if isinstance(m.get("content"), str)
+        )
+        assert "CRITICAL_CONSTRAINT" in blob or "Python 3.11" in blob
+        assert "open task" in blob.lower() or "working on open task" in blob
+
+
+# ── SessionManager orchestration (light) ─────────────────────────────
+
+
+class TestSessionManagerCompact:
+    @pytest.mark.asyncio
+    async def test_disabled_config_no_import(self, tmp_path):
+        from src.everbot.core.session.session import SessionManager
+
+        sm = SessionManager(tmp_path)
+        agent = MagicMock()
+        agent.name = "demo"
+        agent.context_id = "sess1"
+
+        mock_provider = MagicMock()
+        mock_provider.export_session.return_value = {
+            "history_messages": _bulk_history(50, payload="p" * 200),
+            "variables": {},
+        }
+        mock_provider.import_session = MagicMock()
+
+        with patch(
+            "src.everbot.core.agent.provider.provider_for", return_value=mock_provider
+        ):
+            result = await sm.maybe_compact_session_history(
+                agent,
+                "sess1",
+                "demo",
+                config={
+                    "everbot": {
+                        "session": {"history_compaction": {"enabled": False}}
+                    }
+                },
+            )
+        assert result.outcome == "skipped"
+        mock_provider.export_session.assert_not_called()
+        mock_provider.import_session.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_export_timeout_keeps_original_and_returns(self, tmp_path, monkeypatch):
+        """Stalled provider export must not hang forever (F-007)."""
+        import src.everbot.core.session.session as session_mod
+        from src.everbot.core.session.session import SessionManager
+
+        # Fail fast in tests
+        monkeypatch.setattr(
+            session_mod, "_COMPACTION_PROVIDER_IO_TIMEOUT_SECONDS", 0.05
+        )
+
+        sm = SessionManager(tmp_path)
+        agent = MagicMock()
+        agent.name = "demo"
+        agent.context_id = "sess1"
+
+        def _hang(_agent):
+            import time
+
+            time.sleep(2.0)
+            return {"history_messages": [], "variables": {}}
+
+        mock_provider = MagicMock()
+        mock_provider.export_session.side_effect = _hang
+        mock_provider.import_session = MagicMock()
+
+        with patch(
+            "src.everbot.core.agent.provider.provider_for", return_value=mock_provider
+        ):
+            t0 = time.monotonic()
+            result = await sm.maybe_compact_session_history(
+                agent,
+                "sess1",
+                "demo",
+                config={
+                    "everbot": {
+                        "session": {
+                            "history_compaction": {
+                                "enabled": True,
+                                "trigger_tokens": 1000,
+                                "target_recent_tokens": 500,
+                            }
+                        }
+                    }
+                },
+            )
+            elapsed = time.monotonic() - t0
+
+        assert result.outcome == "kept_original"
+        assert result.reason == "export_timeout"
+        assert elapsed < 1.0, f"must not block on hung export; elapsed={elapsed:.2f}s"
+        mock_provider.import_session.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_apply_and_timeline_on_success(self, tmp_path):
+        from src.everbot.core.session.session import SessionManager
+
+        sm = SessionManager(tmp_path)
+        agent = MagicMock()
+        agent.name = "demo"
+        agent.context_id = "sess1"
+        agent.executor = MagicMock()
+        agent.executor.context = None
+
+        history = _bulk_history(80, payload=("p" * 400))
+        mock_provider = MagicMock()
+        mock_provider.export_session.return_value = {
+            "history_messages": history,
+            "variables": {},
+        }
+        mock_provider.import_session = MagicMock()
+
+        with patch(
+            "src.everbot.core.agent.provider.provider_for", return_value=mock_provider
+        ), patch(
+            "src.everbot.core.session.session.SessionCompressor._generate_summary",
+            new_callable=AsyncMock,
+            return_value="summary of old work and constraints",
+        ), patch.object(
+            sm, "update_atomic", new_callable=AsyncMock, return_value=MagicMock()
+        ):
+            result = await sm.maybe_compact_session_history(
+                agent,
+                "sess1",
+                "demo",
+                config={
+                    "everbot": {
+                        "session": {
+                            "history_compaction": {
+                                "enabled": True,
+                                "trigger_tokens": 2000,
+                                "target_recent_tokens": 1000,
+                            }
+                        }
+                    }
+                },
+            )
+
+        assert result.changed is True
+        mock_provider.import_session.assert_called_once()
+        events = sm.get_timeline("sess1")
+        assert any(e.get("type") == "history_compaction" for e in events)
+        ev = next(e for e in events if e.get("type") == "history_compaction")
+        assert "before_tokens" in ev and "after_tokens" in ev
+        assert "SECRET" not in str(ev)
+
+    @pytest.mark.asyncio
+    async def test_persist_under_held_session_lock(self, tmp_path):
+        """F-001: pre-turn path holds the in-process lock; compact must not
+        re-enter update_atomic. With lock_already_held=True, mirror is written.
+        """
+        import time as _time
+        from src.everbot.core.session.session import SessionManager
+        from src.everbot.core.session.session_data import SessionData
+
+        sm = SessionManager(tmp_path)
+        session_id = "web_session_demo_agent"
+        history = _bulk_history(80, payload=("p" * 400))
+        # Seed disk session so update_atomic mutates an existing file.
+        seed = SessionData(
+            session_id=session_id,
+            agent_name="demo",
+            model_name="gpt-4",
+            session_type="channel",
+            history_messages=list(history),
+            variables={},
+        )
+        await sm.persistence.save_data(seed)
+
+        agent = MagicMock()
+        agent.name = "demo"
+        agent.context_id = session_id
+        agent.executor = MagicMock()
+        agent.executor.context = None
+
+        live_history = {"msgs": list(history)}
+
+        class _RecordingProvider:
+            def export_session(self, _agent):
+                return {"history_messages": list(live_history["msgs"]), "variables": {}}
+
+            def import_session(self, _agent, portable_state):
+                live_history["msgs"] = list(portable_state["history_messages"])
+
+        provider = _RecordingProvider()
+        lock = sm._get_lock(session_id)
+        await lock.acquire()
+        try:
+            t0 = _time.monotonic()
+            with patch(
+                "src.everbot.core.agent.provider.provider_for", return_value=provider
+            ), patch(
+                "src.everbot.core.session.session.SessionCompressor._generate_summary",
+                new_callable=AsyncMock,
+                return_value="summary of old work; CRITICAL_CONSTRAINT use Python 3.11",
+            ):
+                result = await sm.maybe_compact_session_history(
+                    agent,
+                    session_id,
+                    "demo",
+                    config={
+                        "everbot": {
+                            "session": {
+                                "history_compaction": {
+                                    "enabled": True,
+                                    "trigger_tokens": 2000,
+                                    "target_recent_tokens": 1000,
+                                }
+                            }
+                        }
+                    },
+                    lock_already_held=True,
+                )
+            elapsed = _time.monotonic() - t0
+        finally:
+            lock.release()
+
+        assert result.changed is True
+        assert result.outcome != "persist_failed"
+        # Must not burn the 10s lock timeout (F-001 regression).
+        assert elapsed < 3.0, f"compact under held lock took {elapsed:.1f}s"
+        # Live history is the compacted set used by the next LLM call (S1/S4).
+        assert len(live_history["msgs"]) < len(history)
+        drop = (result.before_tokens - result.after_tokens) / max(result.before_tokens, 1)
+        assert drop >= 0.30
+        loaded = await sm.load_session(session_id)
+        assert loaded is not None
+        assert loaded.history_messages == live_history["msgs"]
+        assert loaded.variables.get("_history_compaction", {}).get("outcome") == result.outcome
+
+    @pytest.mark.asyncio
+    async def test_milkie_import_chat_first_request_and_tool_round(self, tmp_path):
+        """S1/S3/S4 F-002: real MilkieProvider path — export → compact →
+        /session/import → /chat first request uses reduced base; tool round OK.
+
+        Uses a controllable FakeMilkieServe (httpx MockTransport) so the test
+        exercises import_session rewrite + run_turn /chat, not in-memory stubs.
+        """
+        import json
+        import httpx
+
+        from src.everbot.core.agent.provider.milkie.provider import (
+            MilkieAgentHandle,
+            MilkieProvider,
+        )
+        from src.everbot.core.session.session import SessionManager
+        from src.everbot.core.session.session_data import SessionData
+
+        early = [
+            _user("CRITICAL_CONSTRAINT: always use Python 3.11"),
+            _assistant("Understood, I will use Python 3.11."),
+        ]
+        bulk = _bulk_history(60, payload="payload-" + ("z" * 350))
+        tool_tail = [
+            _user("search the repo for open task"),
+            _assistant(
+                "searching", tool_calls=[_tc("tc_live", "search", '{"q":"open"}')]
+            ),
+            _tool("tc_live", "found files A B C"),
+            _assistant("working on open task with results"),
+        ]
+        history = early + bulk + tool_tail
+        baseline = _estimate_tokens(history)
+        assert baseline > 5000
+
+        def _to_milkie_messages(msgs):
+            out = []
+            for m in msgs:
+                role = m.get("role")
+                if role == "user":
+                    out.append(
+                        {
+                            "role": "user",
+                            "content": [
+                                {"type": "text", "text": m.get("content") or ""}
+                            ],
+                        }
+                    )
+                elif role == "assistant":
+                    content = []
+                    if m.get("content"):
+                        content.append({"type": "text", "text": m["content"]})
+                    for tc in m.get("tool_calls") or []:
+                        fn = (tc or {}).get("function") or {}
+                        args = fn.get("arguments") or "{}"
+                        try:
+                            inp = json.loads(args) if isinstance(args, str) else args
+                        except Exception:
+                            inp = {}
+                        content.append(
+                            {
+                                "type": "tool_use",
+                                "id": tc.get("id"),
+                                "name": fn.get("name"),
+                                "input": inp,
+                            }
+                        )
+                    out.append({"role": "assistant", "content": content})
+                elif role == "tool":
+                    out.append(
+                        {
+                            "role": "tool",
+                            "content": [
+                                {
+                                    "type": "tool_result",
+                                    "tool_use_id": m.get("tool_call_id"),
+                                    "content": m.get("content") or "",
+                                }
+                            ],
+                        }
+                    )
+            return out
+
+        def _portable_from_history(msgs, context_id="c1", run_id="run-old"):
+            regions = [
+                {
+                    "id": "header",
+                    "section": "header",
+                    "content": {"text": "system"},
+                }
+            ]
+            for i, m in enumerate(msgs):
+                if m.get("role") != "user":
+                    continue
+                # Pair with following assistant text (tools folded in export path)
+                asst = ""
+                j = i + 1
+                while j < len(msgs) and msgs[j].get("role") != "user":
+                    cur = msgs[j]
+                    if cur.get("role") == "assistant" and isinstance(
+                        cur.get("content"), str
+                    ):
+                        asst += (cur.get("content") or "") + " "
+                    j += 1
+                regions.append(
+                    {
+                        "id": f"history:turn-{i}",
+                        "section": "history",
+                        "target": "message",
+                        "content": {
+                            "userInput": m.get("content") or "",
+                            "assistantText": asst.strip(),
+                        },
+                    }
+                )
+            return {
+                "manifest": {
+                    "schemaVersion": 1,
+                    "contextId": context_id,
+                    "latestRunId": run_id,
+                    "exportedAt": 1_700_000_000_000,
+                },
+                "events": [
+                    {
+                        "id": "evt-start",
+                        "type": "agent.run.started",
+                        "runId": run_id,
+                        "payload": {
+                            "previousRunId": "run-prev",
+                            "contextId": context_id,
+                        },
+                    },
+                    {
+                        "id": "evt-cp",
+                        "type": "agent.checkpoint",
+                        "runId": run_id,
+                        "payload": {
+                            "checkpoint": {
+                                "checkpointId": "cp-1",
+                                "context": {
+                                    "regions": {"epoch": 1, "regions": regions}
+                                },
+                            }
+                        },
+                    },
+                ],
+                "variables": {},
+            }
+
+        def _history_from_portable(session: dict) -> list:
+            """Recover approximate alfred history from imported region pairs."""
+            msgs = []
+            for event in session.get("events") or []:
+                if event.get("type") != "agent.checkpoint":
+                    continue
+                regions = (
+                    ((event.get("payload") or {}).get("checkpoint") or {})
+                    .get("context", {})
+                    .get("regions", {})
+                )
+                region_list = (
+                    regions.get("regions") if isinstance(regions, dict) else regions
+                ) or []
+                for r in region_list:
+                    if not str(r.get("id") or "").startswith("history:turn"):
+                        continue
+                    content = r.get("content") or {}
+                    user = content.get("userInput") or ""
+                    asst = content.get("assistantText") or ""
+                    msgs.append(_user(user))
+                    # Unfold tool prose folded by milkie rewrite when present.
+                    if "[tool_call" in asst or "[tool_result" in asst:
+                        msgs.append(_assistant(asst))
+                    else:
+                        msgs.append(_assistant(asst))
+            return msgs
+
+        class FakeMilkieServe:
+            """In-process milkie serve: history/export/import/chat."""
+
+            def __init__(self, seed_history):
+                self.history = list(seed_history)
+                self.chat_history_snapshots: list = []
+                self.chat_calls = 0
+                self.imported: list = []
+
+            def handler(self, request: httpx.Request) -> httpx.Response:
+                path = request.url.path
+                body = json.loads(request.content) if request.content else {}
+                if path.endswith("/session/history"):
+                    return httpx.Response(
+                        200,
+                        json={"messages": _to_milkie_messages(self.history)},
+                    )
+                if path.endswith("/session/export"):
+                    return httpx.Response(
+                        200,
+                        json=_portable_from_history(
+                            self.history, context_id=body.get("contextId") or "c1"
+                        ),
+                    )
+                if path.endswith("/session/import"):
+                    session = body.get("session") or {}
+                    self.imported.append(session)
+                    self.history = _history_from_portable(session)
+                    return httpx.Response(200, json={"ok": True})
+                if path.endswith("/chat"):
+                    # First LLM request base = live serve history after import.
+                    self.chat_history_snapshots.append(list(self.history))
+                    self.chat_calls += 1
+                    user_input = body.get("input") or ""
+                    # Simulate serve appending the turn (multi-tool continue).
+                    self.history.append(_user(user_input))
+                    if self.chat_calls == 1:
+                        sse = "".join(
+                            f"event: {ev}\ndata: {json.dumps(d)}\n\n"
+                            for ev, d in [
+                                ("agent.run.started", {"contextId": "c1"}),
+                                ("message_delta", {"text": "ack after compact"}),
+                                (
+                                    "agent.run.completed",
+                                    {
+                                        "status": "completed",
+                                        "output": "ack after compact",
+                                    },
+                                ),
+                            ]
+                        )
+                        self.history.append(_assistant("ack after compact"))
+                    else:
+                        # Tool round continuation.
+                        tcid = "tc_next"
+                        self.history.append(
+                            _assistant(
+                                "calling",
+                                tool_calls=[_tc(tcid, "read_file", "{}")],
+                            )
+                        )
+                        self.history.append(_tool(tcid, "file contents ok"))
+                        self.history.append(_assistant("done with tool"))
+                        sse = "".join(
+                            f"event: {ev}\ndata: {json.dumps(d)}\n\n"
+                            for ev, d in [
+                                ("agent.run.started", {"contextId": "c1"}),
+                                ("message_delta", {"text": "done with tool"}),
+                                (
+                                    "agent.run.completed",
+                                    {
+                                        "status": "completed",
+                                        "output": "done with tool",
+                                    },
+                                ),
+                            ]
+                        )
+                    return httpx.Response(
+                        200,
+                        headers={"content-type": "text/event-stream"},
+                        content=sse.encode("utf-8"),
+                    )
+                return httpx.Response(404, json={"error": f"unexpected {path}"})
+
+        serve = FakeMilkieServe(history)
+        transport = httpx.MockTransport(serve.handler)
+        sync_client = httpx.Client(transport=transport)
+        async_client = httpx.AsyncClient(transport=transport)
+        provider = MilkieProvider(
+            "http://sidecar", client=async_client, sync_client=sync_client
+        )
+
+        sm = SessionManager(tmp_path)
+        session_id = "web_session_demo_agent"
+        seed = SessionData(
+            session_id=session_id,
+            agent_name="demo",
+            model_name="gpt-4",
+            session_type="channel",
+            history_messages=list(history),
+            variables={},
+        )
+        await sm.persistence.save_data(seed)
+
+        agent = MilkieAgentHandle(
+            base_url="http://sidecar", context_id="c1", name="demo"
+        )
+
+        try:
+            with patch(
+                "src.everbot.core.agent.provider.provider_for", return_value=provider
+            ), patch(
+                "src.everbot.core.session.session.SessionCompressor._generate_summary",
+                new_callable=AsyncMock,
+                return_value=(
+                    "CRITICAL_CONSTRAINT: always use Python 3.11. "
+                    "Open task: continue codebase search."
+                ),
+            ):
+                result = await sm.maybe_compact_session_history(
+                    agent,
+                    session_id,
+                    "demo",
+                    config={
+                        "everbot": {
+                            "session": {
+                                "history_compaction": {
+                                    "enabled": True,
+                                    "trigger_tokens": 2000,
+                                    "target_recent_tokens": 1500,
+                                }
+                            }
+                        }
+                    },
+                    lock_already_held=False,
+                )
+
+            assert result.changed is True
+            assert serve.imported, "must POST /session/import before chat"
+            # Live serve history is the compacted base (not the bulk filler).
+            after_base = _estimate_tokens(serve.history)
+            drop = (baseline - after_base) / baseline
+            assert drop >= 0.30, f"expected ≥30% drop, got {drop:.1%}"
+            blob = " ".join(
+                (m.get("content") or "")
+                for m in serve.history
+                if isinstance(m.get("content"), str)
+            )
+            assert "CRITICAL_CONSTRAINT" in blob or "Python 3.11" in blob
+            assert "payload-" not in blob or len(serve.history) < len(history)
+
+            # First /chat uses post-import history as LLM base (S1/S4).
+            events = [
+                e
+                async for e in provider.run_turn(
+                    agent, "continue after compact"
+                )
+            ]
+            assert events
+            assert serve.chat_history_snapshots
+            first_req = serve.chat_history_snapshots[0]
+            first_tokens = _estimate_tokens(first_req)
+            drop2 = (baseline - first_tokens) / baseline
+            assert drop2 >= 0.30, f"first /chat base drop {drop2:.1%}"
+            assert validate_tool_pairing(result.history) == []
+
+            # Second /chat = tool-style continue on compacted session (S3).
+            events2 = [
+                e async for e in provider.run_turn(agent, "read the next file")
+            ]
+            assert events2
+            assert validate_tool_pairing(serve.history) == []
+            assert any(
+                m.get("role") == "tool" and m.get("tool_call_id") == "tc_next"
+                for m in serve.history
+            )
+
+            loaded = await sm.load_session(session_id)
+            assert loaded is not None
+            assert loaded.variables.get("_history_compaction", {}).get("outcome") == (
+                result.outcome
+            )
+        finally:
+            sync_client.close()
+            await async_client.aclose()
+
+
+# ── F-004: full-region summary coverage ───────────────────────────────
+
+
+class TestSummaryRegionCoverage:
+    def test_format_includes_late_constraint_and_tool_fact(self):
+        """Prefix bulk must not starve late constraint + tool conclusion (F-004)."""
+        from src.everbot.core.session.compressor import _format_messages_for_prompt
+
+        early_noise = _bulk_history(40, payload="NOISE_" + ("n" * 400))
+        late = [
+            _user("LATE_CONSTRAINT: deploy only to staging"),
+            _assistant(
+                "checking",
+                tool_calls=[_tc("t_late", "env_check", '{"env":"staging"}')],
+            ),
+            _tool("t_late", "TOOL_CONCLUSION: staging healthy, prod locked"),
+            _assistant("will deploy to staging only"),
+        ]
+        msgs = early_noise + late
+        text = _format_messages_for_prompt(msgs, max_chars=12_000)
+        assert "LATE_CONSTRAINT" in text
+        assert "TOOL_CONCLUSION" in text or "staging healthy" in text
+
+    def test_chunk_messages_covers_full_region(self):
+        from src.everbot.core.session.compressor import (
+            chunk_messages_for_summary,
+            _format_messages_for_prompt,
+        )
+
+        early = _bulk_history(30, payload="EARLY_" + ("e" * 300))
+        mid = [_user("MID_FACT: deadline is Friday"), _assistant("noted deadline")]
+        late = [
+            _user("LATE_CONSTRAINT: never force-push main"),
+            _assistant("ok"),
+            _tool("tx", "TOOL_FACT: branch protected"),
+        ]
+        # tool without assistant is ok for formatter/chunker unit tests
+        msgs = early + mid + late
+        chunks = chunk_messages_for_summary(msgs, max_chars_per_chunk=3000)
+        assert len(chunks) >= 2
+        joined = "\n".join(_format_messages_for_prompt(c, max_chars=50_000) for c in chunks)
+        assert "LATE_CONSTRAINT" in joined
+        assert "TOOL_FACT" in joined
+        # Every source message accounted for across chunks
+        assert sum(len(c) for c in chunks) == len(
+            [m for m in msgs if isinstance(m, dict)]
+        )
+
+    @pytest.mark.asyncio
+    async def test_generate_summary_map_reduce_sees_late_facts(self):
+        """Map-reduce path: LLM prompts include late-region facts (F-004)."""
+        from src.everbot.core.session.compressor import SessionCompressor
+
+        early = _bulk_history(25, payload="BULK_" + ("b" * 350))
+        late = [
+            _user("LATE_CONSTRAINT: use Python 3.11 only"),
+            _assistant(
+                "verifying",
+                tool_calls=[_tc("tv", "python", '{"v":"3.11"}')],
+            ),
+            _tool("tv", "TOOL_CONCLUSION: interpreter is 3.11.9"),
+            _assistant("confirmed 3.11"),
+        ]
+        msgs = early + late
+        prompts: list[str] = []
+
+        async def fake_llm(_ctx, prompt, **_kw):
+            prompts.append(prompt)
+            # Echo markers so reduce still carries them
+            bits = []
+            if "LATE_CONSTRAINT" in prompt:
+                bits.append("LATE_CONSTRAINT: use Python 3.11 only")
+            if "TOOL_CONCLUSION" in prompt:
+                bits.append("TOOL_CONCLUSION: interpreter is 3.11.9")
+            return " ".join(bits) or "partial summary of bulk"
+
+        compressor = SessionCompressor(None)
+        with patch(
+            "src.everbot.core.agent.provider.oneshot_llm_provider"
+        ) as mock_oneshot:
+            mock_oneshot.return_value.call_llm = AsyncMock(side_effect=fake_llm)
+            summary = await compressor._generate_summary("", msgs)
+
+        assert prompts, "must call oneshot LLM"
+        all_prompts = "\n".join(prompts)
+        assert "LATE_CONSTRAINT" in all_prompts
+        assert "TOOL_CONCLUSION" in all_prompts or "3.11.9" in all_prompts
+        assert "LATE_CONSTRAINT" in summary or "Python 3.11" in summary
+
+    @pytest.mark.asyncio
+    async def test_map_reduce_covers_more_than_eight_chunks_last_chunk_fact(self):
+        """F-004: >8 map chunks must still process the last chunk (no silent drop).
+
+        Reviewer repro: ~30 × 3k-char messages → 10 chunks; critical fact in
+        chunk index 9 must enter a map prompt and survive into the final summary.
+        """
+        from src.everbot.core.session.compressor import (
+            SessionCompressor,
+            chunk_messages_for_summary,
+            _SUMMARY_CHUNK_CHARS,
+        )
+
+        msgs = [
+            _user(f"MSG_{i:02d} " + ("x" * 3000)) for i in range(29)
+        ]
+        msgs.append(
+            _user(
+                "CRITICAL_LAST_CONSTRAINT: only Python 3.11 "
+                + ("y" * 2000)
+            )
+        )
+        msgs.append(
+            _assistant(
+                "verifying last fact",
+                tool_calls=[_tc("t_last", "check", '{"v":"3.11"}')],
+            )
+        )
+        msgs.append(_tool("t_last", "TOOL_LAST_FACT: interpreter 3.11.9 confirmed"))
+
+        chunks = chunk_messages_for_summary(
+            msgs, max_chars_per_chunk=_SUMMARY_CHUNK_CHARS
+        )
+        assert len(chunks) > 8, f"need >8 chunks for F-004 repro, got {len(chunks)}"
+        last_chunk_text = "\n".join(
+            (m.get("content") or "") for m in chunks[-1]
+        )
+        assert "CRITICAL_LAST_CONSTRAINT" in last_chunk_text
+
+        map_prompts: list[str] = []
+        reduce_prompts: list[str] = []
+        map_calls = 0
+
+        async def fake_llm(_ctx, prompt, **_kw):
+            nonlocal map_calls
+            # Map prompts contain raw dialogue lines; reduce uses [分段摘要...]
+            if "[分段摘要" in prompt:
+                reduce_prompts.append(prompt)
+                bits = []
+                if "CRITICAL_LAST_CONSTRAINT" in prompt:
+                    bits.append("CRITICAL_LAST_CONSTRAINT: only Python 3.11")
+                if "TOOL_LAST_FACT" in prompt or "3.11.9" in prompt:
+                    bits.append("TOOL_LAST_FACT: interpreter 3.11.9")
+                return " ".join(bits) or "merged partial summaries"
+            map_prompts.append(prompt)
+            map_calls += 1
+            bits = []
+            if "CRITICAL_LAST_CONSTRAINT" in prompt:
+                bits.append("CRITICAL_LAST_CONSTRAINT: only Python 3.11")
+            if "TOOL_LAST_FACT" in prompt:
+                bits.append("TOOL_LAST_FACT: interpreter 3.11.9")
+            return " ".join(bits) or "partial map summary bulk chunk"
+
+        compressor = SessionCompressor(None)
+        with patch(
+            "src.everbot.core.agent.provider.oneshot_llm_provider"
+        ) as mock_oneshot:
+            mock_oneshot.return_value.call_llm = AsyncMock(side_effect=fake_llm)
+            summary = await compressor._generate_summary("", msgs)
+
+        # Every chunk must be mapped — not only the first 8
+        assert map_calls == len(chunks), (
+            f"map must cover all {len(chunks)} chunks, got {map_calls}"
+        )
+        all_map = "\n".join(map_prompts)
+        assert "CRITICAL_LAST_CONSTRAINT" in all_map
+        assert "TOOL_LAST_FACT" in all_map or "3.11.9" in all_map
+        # Final summary must carry the late-region fact (via map echo → reduce)
+        assert (
+            "CRITICAL_LAST_CONSTRAINT" in summary
+            or "Python 3.11" in summary
+            or "TOOL_LAST_FACT" in summary
+        )
+
+    @pytest.mark.asyncio
+    async def test_map_subcall_empty_fails_closed_no_partial_summary(self):
+        """F-005: any empty map result aborts; no partial summary is returned.
+
+        A late-chunk map returning empty must not let earlier partials be
+        reduced and committed, which would silently drop that chunk's facts.
+        """
+        from src.everbot.core.session.compressor import (
+            SessionCompressor,
+            chunk_messages_for_summary,
+            _SUMMARY_CHUNK_CHARS,
+        )
+
+        msgs = [_user(f"MSG_{i:02d} " + ("x" * 3000)) for i in range(12)]
+        msgs.append(_user("CRITICAL_FACT_IN_LATE_CHUNK: only use Python 3.11"))
+        chunks = chunk_messages_for_summary(
+            msgs, max_chars_per_chunk=_SUMMARY_CHUNK_CHARS
+        )
+        assert len(chunks) >= 3, f"need multi-chunk map, got {len(chunks)}"
+
+        map_calls = 0
+
+        async def fake_llm(_ctx, prompt, **_kw):
+            nonlocal map_calls
+            if "[分段摘要" in prompt:
+                return "merged partial — should never be reached"
+            map_calls += 1
+            # Fail the last map chunk with empty output (fail-closed).
+            if "CRITICAL_FACT_IN_LATE_CHUNK" in prompt:
+                return ""
+            return f"partial map summary for bulk chunk {map_calls}"
+
+        compressor = SessionCompressor(None)
+        with patch(
+            "src.everbot.core.agent.provider.oneshot_llm_provider"
+        ) as mock_oneshot:
+            mock_oneshot.return_value.call_llm = AsyncMock(side_effect=fake_llm)
+            with pytest.raises(RuntimeError, match="Map summary failed"):
+                await compressor._generate_summary("", msgs)
+
+        assert map_calls == len(chunks), (
+            "map must attempt every chunk before abort; "
+            f"expected {len(chunks)}, got {map_calls}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_map_subcall_error_text_fails_closed_no_partial_summary(self):
+        """F-005: error-like map output aborts the whole summary generation."""
+        from src.everbot.core.session.compressor import (
+            SessionCompressor,
+            chunk_messages_for_summary,
+            _SUMMARY_CHUNK_CHARS,
+        )
+
+        msgs = [_user(f"MSG_{i:02d} " + ("y" * 3000)) for i in range(12)]
+        chunks = chunk_messages_for_summary(
+            msgs, max_chars_per_chunk=_SUMMARY_CHUNK_CHARS
+        )
+        assert len(chunks) >= 2
+
+        async def fake_llm(_ctx, prompt, **_kw):
+            if "[分段摘要" in prompt:
+                return "should not reduce"
+            # Second map call returns error-like text
+            if "MSG_06" in prompt or "MSG_07" in prompt or "MSG_08" in prompt:
+                return "oneshot LLM HTTP 500: timeout"
+            return "partial map ok"
+
+        compressor = SessionCompressor(None)
+        with patch(
+            "src.everbot.core.agent.provider.oneshot_llm_provider"
+        ) as mock_oneshot:
+            mock_oneshot.return_value.call_llm = AsyncMock(side_effect=fake_llm)
+            with pytest.raises(RuntimeError, match="Map summary failed"):
+                await compressor._generate_summary("", msgs)
+
+    @pytest.mark.asyncio
+    async def test_reduce_subcall_empty_fails_closed_no_partial_summary(self):
+        """F-005: empty reduce batch aborts; no incomplete merge is returned."""
+        from src.everbot.core.session.compressor import (
+            SessionCompressor,
+            chunk_messages_for_summary,
+            _SUMMARY_CHUNK_CHARS,
+        )
+
+        # Enough map partials to force at least one multi-partial reduce batch.
+        msgs = [_user(f"MSG_{i:02d} " + ("z" * 3000)) for i in range(20)]
+        chunks = chunk_messages_for_summary(
+            msgs, max_chars_per_chunk=_SUMMARY_CHUNK_CHARS
+        )
+        assert len(chunks) >= 3
+
+        reduce_calls = 0
+
+        async def fake_llm(_ctx, prompt, **_kw):
+            nonlocal reduce_calls
+            if "[分段摘要" in prompt:
+                reduce_calls += 1
+                # First reduce batch fails empty — must not drop and continue.
+                return ""
+            return f"map partial {prompt[:40]}"
+
+        compressor = SessionCompressor(None)
+        with patch(
+            "src.everbot.core.agent.provider.oneshot_llm_provider"
+        ) as mock_oneshot:
+            mock_oneshot.return_value.call_llm = AsyncMock(side_effect=fake_llm)
+            with pytest.raises(RuntimeError, match="Reduce summary failed"):
+                await compressor._generate_summary("", msgs)
+
+        assert reduce_calls >= 1
+
+    @pytest.mark.asyncio
+    async def test_reduce_subcall_error_text_fails_closed_no_partial_summary(self):
+        """F-005: error-like reduce output aborts; partials are not committed."""
+        from src.everbot.core.session.compressor import (
+            SessionCompressor,
+            chunk_messages_for_summary,
+            _SUMMARY_CHUNK_CHARS,
+        )
+
+        msgs = [_user(f"MSG_{i:02d} " + ("w" * 3000)) for i in range(20)]
+        chunks = chunk_messages_for_summary(
+            msgs, max_chars_per_chunk=_SUMMARY_CHUNK_CHARS
+        )
+        assert len(chunks) >= 3
+
+        async def fake_llm(_ctx, prompt, **_kw):
+            if "[分段摘要" in prompt:
+                return "oneshot LLM HTTP 503: service unavailable"
+            return "map partial ok"
+
+        compressor = SessionCompressor(None)
+        with patch(
+            "src.everbot.core.agent.provider.oneshot_llm_provider"
+        ) as mock_oneshot:
+            mock_oneshot.return_value.call_llm = AsyncMock(side_effect=fake_llm)
+            with pytest.raises(RuntimeError, match="Reduce summary failed"):
+                await compressor._generate_summary("", msgs)
+
+    @pytest.mark.asyncio
+    async def test_map_fail_closed_propagates_to_policy_fallback(self):
+        """F-005/S5: map failure via real compressor path → safe trim / keep, not partial summary."""
+        from src.everbot.core.session.compressor import SessionCompressor
+        from src.everbot.core.session.history_compaction import (
+            HistoryCompactionConfig,
+            HistoryCompactionPolicy,
+        )
+
+        history = _bulk_history(40, payload="q" * 400)
+        # Force multi-chunk map by using large compress region.
+        cfg = HistoryCompactionConfig(
+            trigger_tokens=300, target_recent_tokens=200, max_summary_tokens=500
+        )
+
+        map_n = 0
+
+        async def flaky_llm(_ctx, prompt, **_kw):
+            nonlocal map_n
+            if "[分段摘要" in prompt:
+                return "reduce should not matter"
+            map_n += 1
+            if map_n == 2:
+                return ""  # empty second map chunk
+            return f"partial ok {map_n}"
+
+        compressor = SessionCompressor(None)
+
+        async def summarize(old_summary, to_compress):
+            return await compressor._generate_summary(old_summary, to_compress)
+
+        with patch(
+            "src.everbot.core.agent.provider.oneshot_llm_provider"
+        ) as mock_oneshot:
+            mock_oneshot.return_value.call_llm = AsyncMock(side_effect=flaky_llm)
+            result = await HistoryCompactionPolicy().ensure_within_budget(
+                history, cfg, summarize=summarize
+            )
+
+        # Must not inject a partial summary as if success.
+        for m in result.history:
+            content = m.get("content")
+            if isinstance(content, str):
+                assert "partial ok" not in content
+        assert result.outcome in (
+            "window_trimmed",
+            "over_budget_unavoidable",
+            "kept_original",
+        )
+        assert validate_tool_pairing(result.history) == []

--- a/tests/unit/test_milkie_provider.py
+++ b/tests/unit/test_milkie_provider.py
@@ -1301,3 +1301,194 @@ def test_agent_sandbox_no_override_follows_global(monkeypatch):
 def test_agent_sandbox_defaults_false_when_unset(monkeypatch):
     _set_cfg(monkeypatch, {"everbot": {}})
     assert provider_mod._agent_sandbox_enabled("a") is False
+
+
+# ── #166 import_session: export → rewrite history regions → /session/import ──
+
+
+def _sample_portable_session(context_id: str = "c1", run_id: str = "run-old") -> dict:
+    """Minimal milkie PortableSession with one history region in a checkpoint."""
+    return {
+        "manifest": {
+            "schemaVersion": 1,
+            "contextId": context_id,
+            "latestRunId": run_id,
+            "exportedAt": 1_700_000_000_000,
+        },
+        "events": [
+            {
+                "id": "evt-start",
+                "type": "agent.run.started",
+                "runId": run_id,
+                "payload": {"previousRunId": "run-prev", "contextId": context_id},
+            },
+            {
+                "id": "evt-cp",
+                "type": "agent.checkpoint",
+                "runId": run_id,
+                "payload": {
+                    "checkpoint": {
+                        "checkpointId": "cp-1",
+                        "context": {
+                            "regions": {
+                                "epoch": 3,
+                                "regions": [
+                                    {
+                                        "id": "header",
+                                        "section": "header",
+                                        "content": {"text": "system"},
+                                    },
+                                    {
+                                        "id": "history:turn-0",
+                                        "section": "history",
+                                        "target": "message",
+                                        "content": {
+                                            "userInput": "old bulk message " + ("x" * 200),
+                                            "assistantText": "old reply " + ("y" * 200),
+                                        },
+                                    },
+                                    {
+                                        "id": "history:turn-1",
+                                        "section": "history",
+                                        "target": "message",
+                                        "content": {
+                                            "userInput": "another old",
+                                            "assistantText": "another reply",
+                                        },
+                                    },
+                                ],
+                            }
+                        },
+                    }
+                },
+            },
+        ],
+        "variables": {"k": "v"},
+    }
+
+
+def test_import_session_with_manifest_posts_import_as_is():
+    """Native PortableSession (has manifest) is POSTed to /session/import unchanged."""
+    session = _sample_portable_session()
+    cap: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        cap["url"] = str(request.url)
+        cap["body"] = json.loads(request.content)
+        return httpx.Response(200, json={"ok": True})
+
+    client = httpx.Client(transport=httpx.MockTransport(handler))
+    try:
+        p = MilkieProvider("http://x", sync_client=client)
+        p.import_session(MilkieAgentHandle("http://sidecar", "c1"), session)
+    finally:
+        client.close()
+
+    assert cap["url"].endswith("/session/import")
+    assert cap["body"]["session"]["manifest"]["contextId"] == "c1"
+    assert cap["body"]["session"]["manifest"]["latestRunId"] == "run-old"
+
+
+def test_import_session_from_compacted_history_rewrites_and_imports():
+    """#166 S4: alfred {history_messages} → export live portable → rewrite
+    history:turn-* regions → POST /session/import under same contextId.
+
+    Asserts the next serve history base is the compacted set (not the bulk).
+    """
+    live = _sample_portable_session(context_id="c1", run_id="run-old")
+    compacted = [
+        {"role": "user", "content": "[summary] CRITICAL_CONSTRAINT: use Python 3.11"},
+        {"role": "assistant", "content": "ack summary"},
+        {"role": "user", "content": "search the repo for open task"},
+        {
+            "role": "assistant",
+            "content": "searching",
+            "tool_calls": [
+                {
+                    "id": "tc_live",
+                    "type": "function",
+                    "function": {"name": "search", "arguments": '{"q":"open"}'},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "tc_live", "content": "found A B C"},
+        {"role": "assistant", "content": "working on open task"},
+    ]
+    calls: list = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        body = json.loads(request.content) if request.content else {}
+        calls.append({"path": path, "body": body})
+        if path.endswith("/session/export"):
+            assert body == {"contextId": "c1"}
+            return httpx.Response(200, json=live)
+        if path.endswith("/session/import"):
+            return httpx.Response(200, json={"ok": True})
+        return httpx.Response(404, json={"error": f"unexpected {path}"})
+
+    client = httpx.Client(transport=httpx.MockTransport(handler))
+    try:
+        p = MilkieProvider("http://x", sync_client=client)
+        p.import_session(
+            MilkieAgentHandle("http://sidecar", "c1"),
+            {"history_messages": compacted, "variables": {}, "session_id": "c1"},
+        )
+    finally:
+        client.close()
+
+    paths = [c["path"] for c in calls]
+    assert any(p.endswith("/session/export") for p in paths)
+    assert any(p.endswith("/session/import") for p in paths)
+
+    import_body = next(c["body"] for c in calls if c["path"].endswith("/session/import"))
+    session = import_body["session"]
+    assert session["manifest"]["contextId"] == "c1"
+    # New run id so append-on-import does not collide with pre-compact history.
+    assert session["manifest"]["latestRunId"] != "run-old"
+    assert str(session["manifest"]["latestRunId"]).startswith("compact-")
+
+    # Checkpoint history regions rewritten from compacted messages; bulk gone.
+    cp_events = [
+        e for e in session["events"] if e.get("type") == "agent.checkpoint"
+    ]
+    assert cp_events
+    regions = (
+        cp_events[0]["payload"]["checkpoint"]["context"]["regions"]["regions"]
+    )
+    hist_regions = [
+        r for r in regions if str(r.get("id") or "").startswith("history:turn-")
+    ]
+    # Header kept; old bulk turn content replaced.
+    assert any(r.get("id") == "header" for r in regions)
+    hist_blob = json.dumps(hist_regions, ensure_ascii=False)
+    assert "old bulk message" not in hist_blob
+    assert "CRITICAL_CONSTRAINT" in hist_blob or "Python 3.11" in hist_blob
+    assert "open task" in hist_blob.lower() or "search" in hist_blob.lower()
+    # Tool chain folded into assistant text (milkie pair regions).
+    assert "tc_live" in hist_blob or "tool_call" in hist_blob or "tool_result" in hist_blob
+
+    # previousRunId chain broken so getSessionHistory does not walk old runs.
+    started = [e for e in session["events"] if e.get("type") == "agent.run.started"]
+    assert started
+    assert "previousRunId" not in (started[0].get("payload") or {})
+
+
+def test_import_session_export_404_raises():
+    """Missing serve session must raise so apply_failed is observable upstream."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/session/export"):
+            return httpx.Response(404, json={"error": "not found"})
+        return httpx.Response(500, json={"error": "unexpected"})
+
+    client = httpx.Client(transport=httpx.MockTransport(handler))
+    try:
+        p = MilkieProvider("http://x", sync_client=client)
+        with pytest.raises(RuntimeError, match="no session"):
+            p.import_session(
+                MilkieAgentHandle("http://sidecar", "missing"),
+                {"history_messages": [{"role": "user", "content": "x"}]},
+            )
+    finally:
+        client.close()

--- a/tests/unit/test_milkie_provider.py
+++ b/tests/unit/test_milkie_provider.py
@@ -14,6 +14,7 @@ from src.everbot.core.agent.provider.milkie.provider import (
     MilkieAgentError,
     MilkieAgentHandle,
     MilkieProvider,
+    MilkieSessionImportConflict,
 )
 
 
@@ -1424,7 +1425,9 @@ def test_import_session_from_compacted_history_rewrites_and_imports():
             assert body == {"contextId": "c1"}
             return httpx.Response(200, json=live)
         if path.endswith("/session/import"):
-            return httpx.Response(200, json={"ok": True})
+            return httpx.Response(
+                200, json={"contextId": "c1", "conditionApplied": True}
+            )
         return httpx.Response(404, json={"error": f"unexpected {path}"})
 
     client = httpx.Client(transport=httpx.MockTransport(handler))
@@ -1442,6 +1445,7 @@ def test_import_session_from_compacted_history_rewrites_and_imports():
     assert any(p.endswith("/session/import") for p in paths)
 
     import_body = next(c["body"] for c in calls if c["path"].endswith("/session/import"))
+    assert import_body["expectedLatestRunId"] == "run-old"
     session = import_body["session"]
     assert session["manifest"]["contextId"] == "c1"
     # New run id so append-on-import does not collide with pre-compact history.
@@ -1472,6 +1476,34 @@ def test_import_session_from_compacted_history_rewrites_and_imports():
     started = [e for e in session["events"] if e.get("type") == "agent.run.started"]
     assert started
     assert "previousRunId" not in (started[0].get("payload") or {})
+
+
+def test_import_session_sends_expected_latest_run_and_surfaces_conflict():
+    """A late compaction import must be rejected instead of rewinding a newer turn."""
+    live = _sample_portable_session(context_id="c1", run_id="run-old")
+    cap: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content) if request.content else {}
+        if request.url.path.endswith("/session/export"):
+            return httpx.Response(200, json=live)
+        if request.url.path.endswith("/session/import"):
+            cap["body"] = body
+            return httpx.Response(409, json={"error": "session advanced"})
+        return httpx.Response(404)
+
+    client = httpx.Client(transport=httpx.MockTransport(handler))
+    try:
+        provider = MilkieProvider("http://x", sync_client=client)
+        with pytest.raises(MilkieSessionImportConflict):
+            provider.import_session(
+                MilkieAgentHandle("http://sidecar", "c1"),
+                {"history_messages": [{"role": "user", "content": "summary"}]},
+            )
+    finally:
+        client.close()
+
+    assert cap["body"]["expectedLatestRunId"] == "run-old"
 
 
 def test_import_session_export_404_raises():

--- a/tests/unit/test_session_compressor.py
+++ b/tests/unit/test_session_compressor.py
@@ -89,21 +89,36 @@ class TestFormatMessages:
         assert "用户: 你好" in text
         assert "助手: 你好！" in text
 
-    def test_skips_tool_messages(self):
+    def test_includes_tool_messages_and_calls(self):
+        """#166 F-004: tool conclusions must enter the summary prompt."""
         msgs = [
             {"role": "user", "content": "搜索"},
-            {"role": "assistant", "content": "ok", "tool_calls": [{"id": "1"}]},
-            {"role": "tool", "content": "result", "tool_call_id": "1"},
+            {
+                "role": "assistant",
+                "content": "ok",
+                "tool_calls": [
+                    {
+                        "id": "1",
+                        "type": "function",
+                        "function": {"name": "search", "arguments": '{"q":"x"}'},
+                    }
+                ],
+            },
+            {"role": "tool", "content": "TOOL_FACT_ABC", "tool_call_id": "1"},
             {"role": "assistant", "content": "结果"},
         ]
         text = _format_messages_for_prompt(msgs)
-        assert "tool" not in text.lower()
-        assert "result" not in text
+        assert "TOOL_FACT_ABC" in text
+        assert "search" in text
+        assert "工具结果" in text
 
-    def test_truncation(self):
-        msgs = [{"role": "user", "content": "a" * 5000} for _ in range(10)]
+    def test_truncation_covers_tail_not_prefix_only(self):
+        """Over budget: head+tail packing retains late lines (F-004)."""
+        msgs = [{"role": "user", "content": f"early-{i} " + ("a" * 400)} for i in range(20)]
+        msgs.append({"role": "user", "content": "LATE_CONSTRAINT_Z9 use Python 3.11"})
         text = _format_messages_for_prompt(msgs, max_chars=8000)
         assert "省略" in text
+        assert "LATE_CONSTRAINT_Z9" in text
 
 
 # ── Threshold / compression logic tests ──────────────────────────────

--- a/tests/unit/test_session_manager_core.py
+++ b/tests/unit/test_session_manager_core.py
@@ -1553,7 +1553,7 @@ class TestPersistenceSaveMilkieSafe:
 
     - export_session routes through provider (serve /session/history).
     - session_created_at routes through provider.get_variable.
-    - SessionCompressor (in-process) is guarded by needs_history_restore → skipped.
+    - Under-threshold history does not construct SessionCompressor (#166).
     """
 
     def _patch_provider(self, monkeypatch, provider):
@@ -1596,13 +1596,13 @@ class TestPersistenceSaveMilkieSafe:
         self._patch_provider(monkeypatch, _MilkieProvider())
 
         p = SessionPersistence(tmp_path)
-        # primary session_type → would normally compress (dolphin) — must skip for milkie.
+        # Short history is under trigger → compressor not constructed; save still works.
         handle = SimpleNamespace(name="test_agent", base_url="http://x", context_id="c1")
 
         await p.save("web_session_test_agent", handle, model_name="m")
 
-        # No crash; compression skipped (milkie); data persisted with exported history.
-        assert compressor_built["n"] == 0, "SessionCompressor must be skipped for milkie"
+        # No crash; under-threshold skip; data persisted with exported history.
+        assert compressor_built["n"] == 0, "SessionCompressor must not run under trigger"
         loaded = await p.load("web_session_test_agent")
         assert loaded is not None
         assert loaded.history_messages == [{"role": "user", "content": "hi"}]


### PR DESCRIPTION
## Summary

Closes #166.

- **S1 Pre-turn compaction**: over-threshold history is compacted before the first LLM request (shared policy; default trigger 40k / recent window 20k tokens).
- **S2 Config + observability**: `everbot.session.history_compaction.*` (and per-agent override), timeline `history_compaction` events, usage guide.
- **S3 Tool-safe + fail-closed summary**: safe window boundaries, full-chunk map-reduce (no silent 8-chunk cap), partial/error map-reduce fails closed.
- **S4 Milkie live apply**: export → compact → import so the next `/chat` uses compacted history; continued tool rounds covered in tests.
- **S5 Non-blocking**: lock-already-held on chat-held locks; provider export/import via `asyncio.to_thread` + 15s timeout; disabled config skips export entirely.
- **P1 follow-up**: conditional import with `expectedLatestRunId`; an old or delayed import is rejected rather than rewinding a newer chat checkpoint.
- Docs: `docs/design/166-long-session-history-compaction.md`, `docs/usage/guides/history_compaction.md`.

## Dependency

- Requires [Milkie PR #211](https://github.com/xforce-io/milkie/pull/211), which adds the atomic conditional-import API. Older sidecars are detected through `conditionApplied` and fail closed.

## Test plan

- [x] `python -m pytest tests/unit/test_history_compaction.py tests/unit/test_session_compressor.py tests/unit/test_milkie_provider.py tests/unit/test_session_manager_core.py -q` (197 passed)
- [x] `npm run build` in Milkie
- [x] Milkie conditional-import / HTTP 409 regression tests
- [ ] Manual: long Telegram/Web session over trigger → first turn logs/timeline `history_compaction` with reduced tokens; recent dialogue still usable
- [ ] Manual: `history_compaction.enabled: false` → no export/import, no delay on chat turn