### PR TITLE
fix(#177): daemon lock/KeepAlive clean exit and err rotate

### DIFF
--- a/src/everbot/cli/launch_agent.py
+++ b/src/everbot/cli/launch_agent.py
@@ -90,7 +90,9 @@ def build_launch_agent_plist(*, project_root: Path, alfred_home: Path) -> Dict[s
 
     return {
         "Label": LAUNCH_AGENT_LABEL,
-        "ProgramArguments": ["/bin/bash", "-lc", shell_command],
+        # Non-login, non-interactive bash avoids sourcing ~/.zshrc / Oh My Zsh
+        # when launchd restarts the job (#177).
+        "ProgramArguments": ["/bin/bash", "--noprofile", "--norc", "-c", shell_command],
         "WorkingDirectory": str(project_root),
         "RunAtLoad": True,
         "KeepAlive": True,

--- a/src/everbot/cli/launch_agent.py
+++ b/src/everbot/cli/launch_agent.py
@@ -95,7 +95,9 @@ def build_launch_agent_plist(*, project_root: Path, alfred_home: Path) -> Dict[s
         "ProgramArguments": ["/bin/bash", "--noprofile", "--norc", "-c", shell_command],
         "WorkingDirectory": str(project_root),
         "RunAtLoad": True,
-        "KeepAlive": True,
+        # Restart only after crash/non-zero exit. exit 0 (including
+        # already-running) must not thrash KeepAlive (#177).
+        "KeepAlive": {"SuccessfulExit": False},
         "StandardOutPath": str(logs_dir / "everbot.out"),
         "StandardErrorPath": str(logs_dir / "everbot.err"),
         "EnvironmentVariables": environment,

--- a/src/everbot/cli/main.py
+++ b/src/everbot/cli/main.py
@@ -6,12 +6,14 @@ import asyncio
 import argparse
 import logging
 import signal
+import sys
 from pathlib import Path
 
 from ..infra.user_data import get_user_data_manager
 from ..infra.config import load_config, get_config, save_config, get_default_config
 from ..infra.log_cleanup import cleanup_alfred_logs
 from ..infra.logging_utils import configure_daemon_logging
+from ..infra.process import DaemonAlreadyRunningError, rotate_file_if_large
 from .daemon import EverBotDaemon
 from .launch_agent import cmd_service_install, cmd_service_status, cmd_service_uninstall
 from ..core.runtime.control import get_local_status, run_heartbeat_once
@@ -171,8 +173,17 @@ def cmd_start(args):
     log_level = args.log_level or "INFO"
     configure_daemon_logging(level=log_level)
 
-    # 启动守护进程
-    asyncio.run(cmd_start_async(args))
+    # Bound launchd StandardErrorPath growth before the process attaches (#177).
+    user_data = get_user_data_manager()
+    rotate_file_if_large(user_data.logs_dir / "everbot.err")
+    rotate_file_if_large(user_data.logs_dir / "everbot.out")
+
+    # 启动守护进程. Already-running is success for KeepAlive supervisors.
+    try:
+        asyncio.run(cmd_start_async(args))
+    except DaemonAlreadyRunningError as exc:
+        print(str(exc), file=sys.stderr)
+        raise SystemExit(0) from None
 
 
 def cmd_config(args):

--- a/src/everbot/infra/process.py
+++ b/src/everbot/infra/process.py
@@ -10,6 +10,14 @@ from pathlib import Path
 from typing import Optional
 
 
+class DaemonAlreadyRunningError(RuntimeError):
+    """Raised when another EverBot daemon already holds the singleton lock.
+
+    Callers that implement launchd KeepAlive should treat this as a successful
+    no-op (exit 0) so the service manager does not thrash restart loops.
+    """
+
+
 class DaemonLock:
     """File-lock based singleton guard for the daemon process.
 
@@ -22,8 +30,11 @@ class DaemonLock:
         self._fd: Optional[int] = None
 
     def acquire(self) -> None:
-        """Acquire an exclusive lock. Raises ``RuntimeError`` if another
-        daemon instance already holds the lock."""
+        """Acquire an exclusive lock.
+
+        Raises:
+            DaemonAlreadyRunningError: another daemon instance already holds the lock.
+        """
         self._lock_path.parent.mkdir(parents=True, exist_ok=True)
         self._fd = os.open(str(self._lock_path), os.O_CREAT | os.O_RDWR)
         try:
@@ -31,7 +42,7 @@ class DaemonLock:
         except OSError:
             os.close(self._fd)
             self._fd = None
-            raise RuntimeError(
+            raise DaemonAlreadyRunningError(
                 f"Another EverBot daemon is already running (lock: {self._lock_path})"
             )
 
@@ -104,3 +115,49 @@ def is_pid_running(pid: int) -> bool:
         return True
     return True
 
+
+def rotate_file_if_large(
+    path: Path,
+    *,
+    max_bytes: int = 10 * 1024 * 1024,
+    backups: int = 3,
+) -> bool:
+    """Rotate ``path`` when it exceeds ``max_bytes``.
+
+    Renames existing backups upward (``.N`` -> ``.N+1``), moves the live file to
+    ``.1``, then creates a fresh empty file at ``path``. Returns True if a
+    rotation happened.
+    """
+    if max_bytes <= 0:
+        return False
+    try:
+        size = path.stat().st_size
+    except FileNotFoundError:
+        return False
+    except OSError:
+        return False
+    if size <= max_bytes:
+        return False
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    # Drop the oldest backup first, then shift .N -> .(N+1).
+    oldest = path.with_name(f"{path.name}.{backups}")
+    if oldest.exists():
+        try:
+            oldest.unlink()
+        except OSError:
+            pass
+    for index in range(backups - 1, 0, -1):
+        src = path.with_name(f"{path.name}.{index}")
+        dst = path.with_name(f"{path.name}.{index + 1}")
+        if src.exists():
+            try:
+                src.replace(dst)
+            except OSError:
+                pass
+    try:
+        path.replace(path.with_name(f"{path.name}.1"))
+    except OSError:
+        return False
+    path.write_bytes(b"")
+    return True

--- a/src/everbot/infra/process.py
+++ b/src/everbot/infra/process.py
@@ -124,9 +124,10 @@ def rotate_file_if_large(
 ) -> bool:
     """Rotate ``path`` when it exceeds ``max_bytes``.
 
-    Renames existing backups upward (``.N`` -> ``.N+1``), moves the live file to
-    ``.1``, then creates a fresh empty file at ``path``. Returns True if a
-    rotation happened.
+    Copies the live file to ``.1`` (shifting older backups) and **truncates the
+    original inode in place**. launchd keeps StandardErrorPath FDs open across
+    exec, so rename-and-recreate would leave writers attached to the backup.
+    Returns True if a rotation happened.
     """
     if max_bytes <= 0:
         return False
@@ -155,9 +156,16 @@ def rotate_file_if_large(
                 src.replace(dst)
             except OSError:
                 pass
+
+    backup = path.with_name(f"{path.name}.1")
     try:
-        path.replace(path.with_name(f"{path.name}.1"))
+        # Copy then truncate the same inode so open FDs keep writing the live path.
+        with path.open("rb") as src_fh:
+            payload = src_fh.read()
+        with backup.open("wb") as dst_fh:
+            dst_fh.write(payload)
+        with path.open("r+b") as live_fh:
+            live_fh.truncate(0)
     except OSError:
         return False
-    path.write_bytes(b"")
     return True

--- a/tests/unit/test_cmd_start_already_running.py
+++ b/tests/unit/test_cmd_start_already_running.py
@@ -1,0 +1,39 @@
+"""CLI start must exit cleanly when another daemon already holds the lock (#177)."""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from src.everbot.infra.process import DaemonAlreadyRunningError
+
+
+def test_cmd_start_already_running_exits_zero(capsys):
+    """Lock conflict is a successful no-op for KeepAlive, not a crash loop."""
+    # importlib avoids `src.everbot.cli.main` resolving to the exported main() function
+    # from src.everbot.cli.__init__ in some import orders.
+    cli_main = importlib.import_module("src.everbot.cli.main")
+
+    async def _boom(_args):
+        raise DaemonAlreadyRunningError(
+            "Another EverBot daemon is already running (lock: /tmp/x)"
+        )
+
+    with patch.object(cli_main, "cmd_start_async", side_effect=_boom):
+        with patch.object(cli_main, "configure_daemon_logging"):
+            with patch.object(cli_main, "get_user_data_manager") as mock_udm:
+                mock_udm.return_value.logs_dir = Path("/tmp")
+                with patch.object(cli_main, "rotate_file_if_large"):
+                    with pytest.raises(SystemExit) as exc_info:
+                        cli_main.cmd_start(
+                            SimpleNamespace(log_level="INFO", config=None)
+                        )
+
+    assert exc_info.value.code == 0
+    err = capsys.readouterr().err
+    assert "already running" in err.lower()
+    assert "Traceback" not in err

--- a/tests/unit/test_launch_agent.py
+++ b/tests/unit/test_launch_agent.py
@@ -17,7 +17,7 @@ def test_build_launch_agent_plist_contains_expected_fields(tmp_path: Path) -> No
 
     assert plist["Label"] == LAUNCH_AGENT_LABEL
     assert plist["RunAtLoad"] is True
-    assert plist["KeepAlive"] is True
+    assert plist["KeepAlive"] == {"SuccessfulExit": False}
     assert plist["WorkingDirectory"] == str(project_root.resolve())
     # Non-login, non-interactive bash: never load ~/.zshrc / Oh My Zsh (#177).
     assert plist["ProgramArguments"][:4] == [

--- a/tests/unit/test_launch_agent.py
+++ b/tests/unit/test_launch_agent.py
@@ -19,8 +19,16 @@ def test_build_launch_agent_plist_contains_expected_fields(tmp_path: Path) -> No
     assert plist["RunAtLoad"] is True
     assert plist["KeepAlive"] is True
     assert plist["WorkingDirectory"] == str(project_root.resolve())
-    assert plist["ProgramArguments"][:2] == ["/bin/bash", "-lc"]
-    shell_command = plist["ProgramArguments"][2]
+    # Non-login, non-interactive bash: never load ~/.zshrc / Oh My Zsh (#177).
+    assert plist["ProgramArguments"][:4] == [
+        "/bin/bash",
+        "--noprofile",
+        "--norc",
+        "-c",
+    ]
+    shell_command = plist["ProgramArguments"][4]
     assert "exec python -m src.everbot.cli start" in shell_command
     assert f"export ALFRED_HOME='{alfred_home.resolve()}'" in shell_command
+    assert "-lc" not in plist["ProgramArguments"]
+    assert "-l" not in plist["ProgramArguments"]
     assert plist["EnvironmentVariables"]["PYTHONPATH"] == str(project_root.resolve())

--- a/tests/unit/test_process_utils.py
+++ b/tests/unit/test_process_utils.py
@@ -50,13 +50,15 @@ def test_daemon_lock_second_acquire_raises_already_running(tmp_path: Path):
 
 
 def test_rotate_file_if_large_rotates_and_truncates(tmp_path: Path):
-    """Oversized log files are rotated aside and replaced with an empty file."""
+    """Oversized logs are copied to .1 and the live inode is truncated in place."""
     err = tmp_path / "everbot.err"
     err.write_bytes(b"x" * 100)
+    live_inode = err.stat().st_ino
     rotated = rotate_file_if_large(err, max_bytes=50, backups=2)
     assert rotated is True
     assert err.exists()
     assert err.stat().st_size == 0
+    assert err.stat().st_ino == live_inode
     assert (tmp_path / "everbot.err.1").exists()
     assert (tmp_path / "everbot.err.1").stat().st_size == 100
 

--- a/tests/unit/test_process_utils.py
+++ b/tests/unit/test_process_utils.py
@@ -6,7 +6,17 @@ from pathlib import Path
 import tempfile
 import os
 
-from src.everbot.infra.process import write_pid_file, read_pid_file, remove_pid_file, is_pid_running
+import pytest
+
+from src.everbot.infra.process import (
+    DaemonAlreadyRunningError,
+    DaemonLock,
+    write_pid_file,
+    read_pid_file,
+    remove_pid_file,
+    is_pid_running,
+    rotate_file_if_large,
+)
 
 
 def test_pid_file_roundtrip():
@@ -23,3 +33,39 @@ def test_pid_file_roundtrip():
 def test_is_pid_running_current_process():
     """Current process PID should be running."""
     assert is_pid_running(os.getpid()) is True
+
+
+def test_daemon_lock_second_acquire_raises_already_running(tmp_path: Path):
+    """Second exclusive acquire must raise DaemonAlreadyRunningError, not bare RuntimeError."""
+    lock_path = tmp_path / "everbot.lock"
+    first = DaemonLock(lock_path)
+    first.acquire()
+    try:
+        second = DaemonLock(lock_path)
+        with pytest.raises(DaemonAlreadyRunningError) as exc_info:
+            second.acquire()
+        assert "already running" in str(exc_info.value).lower()
+    finally:
+        first.release()
+
+
+def test_rotate_file_if_large_rotates_and_truncates(tmp_path: Path):
+    """Oversized log files are rotated aside and replaced with an empty file."""
+    err = tmp_path / "everbot.err"
+    err.write_bytes(b"x" * 100)
+    rotated = rotate_file_if_large(err, max_bytes=50, backups=2)
+    assert rotated is True
+    assert err.exists()
+    assert err.stat().st_size == 0
+    assert (tmp_path / "everbot.err.1").exists()
+    assert (tmp_path / "everbot.err.1").stat().st_size == 100
+
+
+def test_rotate_file_if_large_noop_when_small(tmp_path: Path):
+    """Files under the size limit are left untouched."""
+    err = tmp_path / "everbot.err"
+    err.write_text("ok\n", encoding="utf-8")
+    rotated = rotate_file_if_large(err, max_bytes=50, backups=2)
+    assert rotated is False
+    assert err.read_text(encoding="utf-8") == "ok\n"
+    assert not (tmp_path / "everbot.err.1").exists()


### PR DESCRIPTION
## Summary
- `DaemonAlreadyRunningError` + CLI `start` exits 0 with one-line stderr
- LaunchAgent uses `/bin/bash --noprofile --norc -c` (no zshrc/OMZ)
- Rotate `everbot.err` / `everbot.out` when over 10MB on start

## Test plan
- [x] `pytest tests/unit/test_process_utils.py tests/unit/test_launch_agent.py tests/unit/test_cmd_start_already_running.py`
- [ ] After service reinstall: secondary start does not grow err with traceback/zshrc

Closes #177