### PR TITLE
fix(#179): mailbox cap + active channel job mirror

### DIFF
--- a/src/everbot/core/runtime/cron_delivery.py
+++ b/src/everbot/core/runtime/cron_delivery.py
@@ -145,7 +145,7 @@ class CronDelivery:
         detail: Optional[str],
         run_id: str,
     ) -> bool:
-        """Deposit isolated job result to primary mailbox."""
+        """Deposit isolated job result to primary mailbox and active channel."""
         event = build_system_event(
             event_type=event_type,
             source_session_id=source_session_id,
@@ -156,12 +156,42 @@ class CronDelivery:
             suppress_if_stale=False,
             dedupe_key=f"{event_type}:{self.agent_name}:{run_id}:{source_session_id}",
         )
-        return await self.session_manager.deposit_mailbox_event(
+        ok = await self.session_manager.deposit_mailbox_event(
             self.primary_session_id,
             event,
             timeout=5.0,
             blocking=True,
         )
+        # Mirror to the newest active non-web channel so TG users can drain it.
+        getter = getattr(self.session_manager, "get_active_channel_session_id", None)
+        channel_session_id = None
+        if callable(getter):
+            try:
+                maybe = getter(self.agent_name)
+                if inspect.isawaitable(maybe):
+                    maybe = await maybe
+                if isinstance(maybe, str) and maybe.strip():
+                    channel_session_id = maybe.strip()
+            except Exception:
+                logger.debug(
+                    "[%s] active channel lookup failed", self.agent_name, exc_info=True
+                )
+        if channel_session_id and channel_session_id != self.primary_session_id:
+            try:
+                await self.session_manager.deposit_mailbox_event(
+                    channel_session_id,
+                    dict(event),
+                    timeout=5.0,
+                    blocking=True,
+                )
+            except Exception:
+                logger.warning(
+                    "[%s] Failed to mirror job event to channel session %s",
+                    self.agent_name,
+                    channel_session_id,
+                    exc_info=True,
+                )
+        return ok
 
     def _event_scope_kwargs(self) -> dict[str, Optional[str]]:
         """Build routing kwargs for realtime events."""

--- a/src/everbot/core/session/session.py
+++ b/src/everbot/core/session/session.py
@@ -193,6 +193,51 @@ class SessionManager:
                     latest = ts
         return latest
 
+    def get_active_channel_session_id(self, agent_name: str) -> Optional[str]:
+        """Return newest non-web channel session id for one agent, if any.
+
+        Used to mirror primary mailbox deposits so Telegram-active users can
+        drain background events without opening the web primary session.
+        """
+        from ..channel.session_resolver import ChannelSessionResolver
+
+        patterns: list[str] = []
+        for channel_type, prefix in ChannelSessionResolver._PREFIX_MAP.items():
+            if channel_type == "web":
+                continue
+            patterns.append(f"{prefix}{agent_name}{ChannelSessionResolver._SEP}*.json")
+
+        best_id: Optional[str] = None
+        best_ts: Optional[float] = None
+        seen_paths: set[Path] = set()
+        for pattern in patterns:
+            for session_path in self.persistence.sessions_dir.glob(pattern):
+                if session_path in seen_paths or not session_path.is_file():
+                    continue
+                seen_paths.add(session_path)
+                try:
+                    raw = json.loads(session_path.read_text(encoding="utf-8"))
+                except Exception:
+                    continue
+                session_type = raw.get("session_type") or self.infer_session_type(
+                    raw.get("session_id") or session_path.stem
+                )
+                if session_type != "channel":
+                    continue
+                if raw.get("agent_name") not in {None, "", agent_name}:
+                    continue
+                ua = raw.get("updated_at")
+                if not ua:
+                    continue
+                try:
+                    ts = datetime.fromisoformat(ua).timestamp()
+                except (ValueError, TypeError):
+                    continue
+                if best_ts is None or ts > best_ts:
+                    best_ts = ts
+                    best_id = str(raw.get("session_id") or session_path.stem)
+        return best_id
+
     def record_metric(self, name: str, delta: float = 1.0) -> None:
         """Increment one runtime metric counter."""
         key = str(name or "").strip()

--- a/src/everbot/core/session/session_mailbox.py
+++ b/src/everbot/core/session/session_mailbox.py
@@ -19,6 +19,38 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+DEFAULT_MAX_MAILBOX_EVENTS = 50
+
+
+def trim_mailbox_events(
+    events: list[Dict[str, Any]],
+    *,
+    max_events: int | None = None,
+) -> list[Dict[str, Any]]:
+    """Keep at most ``max_events`` mailbox items, preferring newest + higher priority."""
+    limit = DEFAULT_MAX_MAILBOX_EVENTS if max_events is None else int(max_events)
+    if limit <= 0:
+        return []
+    items = [e for e in events if isinstance(e, dict)]
+    if len(items) <= limit:
+        return items
+
+    def _sort_key(event: Dict[str, Any]) -> tuple:
+        ts = parse_iso_datetime(event.get("timestamp"))
+        # Missing timestamps sort as oldest.
+        ts_ord = ts.timestamp() if ts is not None else float("-inf")
+        try:
+            priority = int(event.get("priority") or 0)
+        except (TypeError, ValueError):
+            priority = 0
+        return (ts_ord, priority)
+
+    ranked = sorted(items, key=_sort_key, reverse=True)
+    kept = ranked[:limit]
+    kept_ids = {id(e) for e in kept}
+    # Preserve relative order of survivors from the original list.
+    return [e for e in items if id(e) in kept_ids]
+
 def parse_iso_datetime(value: Any) -> Optional[datetime]:
     """Parse an ISO datetime string → UTC datetime, or None."""
     if not isinstance(value, str) or not value.strip():
@@ -101,7 +133,7 @@ async def deposit_mailbox_event(
                 dropped_duplicate["value"] = True
 
         mailbox.append(dict(event_obj))
-        session_data.mailbox = mailbox
+        session_data.mailbox = trim_mailbox_events(mailbox)
         inserted["value"] = True
 
     # bump_updated_at=False: mailbox deposits are background writes and must not

--- a/tests/unit/test_cron_delivery.py
+++ b/tests/unit/test_cron_delivery.py
@@ -194,3 +194,42 @@ class TestRealtimeEmit:
             events._subscribers.clear()
 
         assert captured[0].get("projection_source_id") is None
+
+
+class TestDepositJobEventActiveChannelMirror:
+    @pytest.mark.asyncio
+    async def test_mirrors_to_active_channel_session(self):
+        sm = AsyncMock()
+        sm.deposit_mailbox_event.return_value = True
+        sm.get_active_channel_session_id = lambda agent_name: "tg_session_test_agent__1"
+        d = _make_delivery(session_manager=sm)
+
+        await d.deposit_job_event(
+            event_type="job_failed",
+            source_session_id="job_abc_123",
+            summary="failed",
+            detail="connection failed",
+            run_id="run_x",
+        )
+
+        assert sm.deposit_mailbox_event.await_count == 2
+        targets = [c.args[0] for c in sm.deposit_mailbox_event.await_args_list]
+        assert targets == ["web_session_test", "tg_session_test_agent__1"]
+
+    @pytest.mark.asyncio
+    async def test_no_mirror_when_no_active_channel(self):
+        sm = AsyncMock()
+        sm.deposit_mailbox_event.return_value = True
+        sm.get_active_channel_session_id = lambda agent_name: None
+        d = _make_delivery(session_manager=sm)
+
+        await d.deposit_job_event(
+            event_type="job_failed",
+            source_session_id="job_abc_123",
+            summary="failed",
+            detail="x",
+            run_id="run_y",
+        )
+
+        sm.deposit_mailbox_event.assert_awaited_once()
+        assert sm.deposit_mailbox_event.await_args.args[0] == "web_session_test"

--- a/tests/unit/test_session_mailbox.py
+++ b/tests/unit/test_session_mailbox.py
@@ -283,3 +283,82 @@ async def test_ack_mailbox_does_not_update_activity_time(tmp_path: Path):
     assert after == before, (
         f"Ack mailbox should not update activity time: {before!r} -> {after!r}."
     )
+
+
+def test_trim_mailbox_events_keeps_newest_within_limit():
+    from src.everbot.core.session.session_mailbox import trim_mailbox_events
+
+    events = [
+        {"event_id": f"e{i}", "timestamp": f"2026-07-29T10:00:{i:02d}+00:00", "priority": 0}
+        for i in range(5)
+    ]
+    trimmed = trim_mailbox_events(events, max_events=3)
+    assert [e["event_id"] for e in trimmed] == ["e2", "e3", "e4"]
+
+
+def test_trim_mailbox_events_prefers_higher_priority_when_tied():
+    from src.everbot.core.session.session_mailbox import trim_mailbox_events
+
+    events = [
+        {"event_id": "low", "timestamp": "2026-07-29T10:00:00+00:00", "priority": 0},
+        {"event_id": "high", "timestamp": "2026-07-29T10:00:00+00:00", "priority": 10},
+        {"event_id": "mid", "timestamp": "2026-07-29T09:00:00+00:00", "priority": 1},
+    ]
+    trimmed = trim_mailbox_events(events, max_events=2)
+    ids = {e["event_id"] for e in trimmed}
+    assert ids == {"low", "high"}
+
+
+@pytest.mark.asyncio
+async def test_deposit_mailbox_enforces_max_events(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(
+        "src.everbot.core.session.session_mailbox.DEFAULT_MAX_MAILBOX_EVENTS",
+        3,
+    )
+    manager = SessionManager(tmp_path)
+    session_id = "web_session_demo_agent"
+    for i in range(5):
+        ok = await manager.deposit_mailbox_event(
+            session_id,
+            {
+                "event_id": f"evt_{i}",
+                "event_type": "job_failed",
+                "summary": f"fail {i}",
+                "timestamp": f"2026-07-29T10:0{i}:00+00:00",
+            },
+        )
+        assert ok is True
+
+    loaded = await manager.load_session(session_id)
+    assert loaded is not None
+    assert len(loaded.mailbox) == 3
+    assert [e["event_id"] for e in loaded.mailbox] == ["evt_2", "evt_3", "evt_4"]
+
+
+@pytest.mark.asyncio
+async def test_get_active_channel_session_id_picks_newest(tmp_path: Path):
+    manager = SessionManager(tmp_path)
+    # seed two channel sessions via raw files
+    old = {
+        "session_id": "tg_session_demo_agent__1",
+        "agent_name": "demo_agent",
+        "model_name": "x",
+        "session_type": "channel",
+        "history_messages": [],
+        "mailbox": [],
+        "variables": {},
+        "created_at": "2026-07-01T00:00:00+00:00",
+        "updated_at": "2026-07-20T00:00:00+00:00",
+        "state": "active",
+        "events": [],
+        "timeline": [],
+        "context_trace": {},
+        "revision": 1,
+    }
+    new = dict(old)
+    new["session_id"] = "tg_session_demo_agent__2"
+    new["updated_at"] = "2026-07-28T00:00:00+00:00"
+    (tmp_path / "tg_session_demo_agent__1.json").write_text(json.dumps(old), encoding="utf-8")
+    (tmp_path / "tg_session_demo_agent__2.json").write_text(json.dumps(new), encoding="utf-8")
+
+    assert manager.get_active_channel_session_id("demo_agent") == "tg_session_demo_agent__2"


### PR DESCRIPTION
## Summary
- Hard-cap mailbox at 50 events on deposit (newest + priority)
- Resolve newest active channel session id
- Mirror job completed/failed deposits to that channel

## Test plan
- [x] session mailbox trim/deposit/active-channel unit tests
- [x] cron_delivery mirror unit tests

Closes #179