### PR TITLE
fix(#178): sidecar cooldown + inactive event sampling

### DIFF
--- a/src/everbot/core/agent/provider/milkie/pool.py
+++ b/src/everbot/core/agent/provider/milkie/pool.py
@@ -13,12 +13,16 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 from contextlib import asynccontextmanager
 from typing import Any, Callable, Dict, Optional, Tuple
 
 from .sidecar import MilkieSidecar
 
 logger = logging.getLogger(__name__)
+
+# After consecutive spawn failures, fail-fast for this many seconds (#178).
+SIDECAR_SPAWN_COOLDOWN_SECONDS = 60.0
 
 
 def _default_factory(cmd, env):
@@ -40,6 +44,8 @@ class SidecarPool:
         self._locks: Dict[str, asyncio.Lock] = {}
         self._fingerprints: Dict[str, Optional[str]] = {}
         self._inflight: Dict[str, int] = {}
+        self._cooldown_until: Dict[str, float] = {}
+        self._fail_counts: Dict[str, int] = {}
 
     def _lock(self, agent_name: str) -> asyncio.Lock:
         lock = self._locks.get(agent_name)
@@ -105,13 +111,22 @@ class SidecarPool:
     async def _spawn_locked(self, agent_name: str, fingerprint: Optional[str] = None) -> Any:
         # 指纹在 _build 之前取(_build 自己会再跑 discover):若两者之间技能恰好又变,
         # 指纹偏旧 → 下一轮多一次重生(冗余但安全);反向(指纹偏新)会漏刷新,不可取。
+        now = time.monotonic()
+        cool_until = float(self._cooldown_until.get(agent_name, 0.0) or 0.0)
+        if cool_until > now:
+            remaining = cool_until - now
+            raise RuntimeError(
+                f"sidecar spawn cooldown active for '{agent_name}' "
+                f"({remaining:.0f}s remaining)"
+            )
+
         if fingerprint is None and self._fingerprint is not None:
             fingerprint = await self._current_fingerprint(agent_name)
         cmd, env = self._build(agent_name)
         sidecar = self._factory(cmd, env)
         try:
             await sidecar.start()
-        except BaseException:
+        except BaseException as exc:
             # start() 已 spawn 子进程后才失败(如 ready 超时)→ 子进程已存活
             # 但未入池。必须 close() 回收,否则 orphan milkie serve 泄漏。
             # close 错误吞掉(best-effort),re-raise 原始异常。
@@ -119,9 +134,32 @@ class SidecarPool:
                 await sidecar.close()
             except BaseException:
                 pass
+            fails = int(self._fail_counts.get(agent_name, 0) or 0) + 1
+            self._fail_counts[agent_name] = fails
+            # Enter cooldown after repeated failures to stop thrash storms (#178).
+            # First failure remains immediately retryable (existing pool contract).
+            if fails >= 2:
+                self._cooldown_until[agent_name] = now + float(SIDECAR_SPAWN_COOLDOWN_SECONDS)
+                logger.warning(
+                    "sidecar pool: spawn failed for '%s' (failures=%d); cooldown %.0fs: %s",
+                    agent_name,
+                    fails,
+                    float(SIDECAR_SPAWN_COOLDOWN_SECONDS),
+                    exc,
+                )
+            else:
+                logger.warning(
+                    "sidecar pool: spawn failed for '%s' (failures=%d): %s",
+                    agent_name,
+                    fails,
+                    exc,
+                )
             raise
         self._sidecars[agent_name] = sidecar
-        self._fingerprints[agent_name] = fingerprint
+        self._fail_counts[agent_name] = 0
+        self._cooldown_until.pop(agent_name, None)
+        if self._fingerprint is not None:
+            self._fingerprints[agent_name] = fingerprint
         return sidecar
 
     async def _current_fingerprint(self, agent_name: str) -> Optional[str]:

--- a/src/everbot/core/runtime/heartbeat.py
+++ b/src/everbot/core/runtime/heartbeat.py
@@ -49,6 +49,9 @@ from ...infra.user_data import get_user_data_manager
 
 logger = logging.getLogger(__name__)
 
+# Sample high-frequency inactive skips so heartbeat_events.jsonl stays usable (#178).
+INACTIVE_EVENT_SAMPLE_SECONDS = 60.0
+
 # Error markers that indicate non-retryable (permanent) failures.
 # Matching is case-insensitive against ``str(exception)``.
 _PERMANENT_ERROR_MARKERS: list[str] = [
@@ -393,6 +396,17 @@ If not, reply with `HEARTBEAT_OK`.
     def _write_heartbeat_event(self, event_type: str, **kwargs: Any) -> None:
         """Write a structured heartbeat event to the JSONL events file."""
         try:
+            # Throttle inactive skips: keep observability without 1Hz floods.
+            if event_type == "skipped" and str(kwargs.get("reason") or "") == "inactive":
+                now = datetime.now()
+                last = getattr(self, "_last_inactive_event_at", None)
+                if (
+                    last is not None
+                    and (now - last).total_seconds() < float(INACTIVE_EVENT_SAMPLE_SECONDS)
+                ):
+                    return
+                self._last_inactive_event_at = now
+
             from ...infra.logging_utils import rotate_log_file_if_needed
             user_data = get_user_data_manager()
             events_file = user_data.heartbeat_events_file

--- a/tests/unit/test_sidecar_cooldown_inactive_sample.py
+++ b/tests/unit/test_sidecar_cooldown_inactive_sample.py
@@ -1,0 +1,82 @@
+"""Minimal coverage for #178: sidecar spawn cooldown + inactive event sampling."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.everbot.core.agent.provider.milkie.pool import SidecarPool
+from src.everbot.core.runtime.heartbeat import HeartbeatRunner
+
+
+class _FailSidecar:
+    def __init__(self, *_a, **_k):
+        self.closed = 0
+
+    async def start(self):
+        raise RuntimeError("spawn failed")
+
+    async def close(self):
+        self.closed += 1
+
+
+@pytest.mark.asyncio
+async def test_sidecar_pool_cooldown_after_repeated_failures(monkeypatch):
+    monkeypatch.setattr(
+        "src.everbot.core.agent.provider.milkie.pool.SIDECAR_SPAWN_COOLDOWN_SECONDS",
+        60,
+    )
+    starts = {"n": 0}
+
+    def factory(cmd, env):
+        starts["n"] += 1
+        return _FailSidecar()
+
+    pool = SidecarPool(build=lambda name: (["c"], {}), sidecar_factory=factory)
+    with pytest.raises(RuntimeError, match="spawn failed"):
+        await pool.get_or_spawn("alice")
+    assert starts["n"] == 1
+    # First failure remains immediately retryable.
+    with pytest.raises(RuntimeError, match="spawn failed"):
+        await pool.get_or_spawn("alice")
+    assert starts["n"] == 2
+    # Repeated failure enters cooldown and fail-fasts without spawning.
+    with pytest.raises(RuntimeError, match="cooldown"):
+        await pool.get_or_spawn("alice")
+    assert starts["n"] == 2
+
+
+def test_inactive_skip_events_are_sampled(tmp_path: Path, monkeypatch):
+    events_file = tmp_path / "heartbeat_events.jsonl"
+    udm = MagicMock()
+    udm.heartbeat_events_file = events_file
+    monkeypatch.setattr(
+        "src.everbot.core.runtime.heartbeat.get_user_data_manager",
+        lambda: udm,
+    )
+    monkeypatch.setattr(
+        "src.everbot.core.runtime.heartbeat.INACTIVE_EVENT_SAMPLE_SECONDS",
+        60,
+    )
+
+    sm = MagicMock()
+    sm.get_primary_session_id = lambda n: f"web_session_{n}"
+    sm.get_heartbeat_session_id = lambda n: f"heartbeat_session_{n}"
+    runner = HeartbeatRunner(
+        agent_name="demo",
+        workspace_path=tmp_path,
+        session_manager=sm,
+        agent_factory=MagicMock(),
+        interval_minutes=1,
+        active_hours=(0, 24),
+    )
+    runner._write_heartbeat_event("skipped", reason="inactive")
+    runner._write_heartbeat_event("skipped", reason="inactive")
+    runner._write_heartbeat_event("skipped", reason="inactive")
+    lines = events_file.read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == 1
+    payload = json.loads(lines[0])
+    assert payload["reason"] == "inactive"


### PR DESCRIPTION
## Summary
- SidecarPool cooldown after repeated spawn failures
- Sample inactive skipped heartbeat events

Closes #178