### PR TITLE
fix(#187): restore Milkie skill evaluation observability

### DIFF
--- a/docs/design/187-skill-observation.md
+++ b/docs/design/187-skill-observation.md
@@ -1,0 +1,175 @@
+# 【SLM】恢复 Milkie 技能评估观测并消除空跑假成功
+
+- Issue: #187
+- 状态: Approved
+- 最后更新: 2026-08-02
+
+## 1. 背景
+
+生产 routine 已切换到 Milkie，但 routine 完成后的 SLM 记录仍从 Dolphin 时代的 trajectory 中查找 `_load_resource_skill`。`MilkieProvider.init_trajectory()` 是 no-op，因此新 routine 即使真实调用 `skill_request`，也不会产生新的 `EvaluationSegment`。另一方面，Skill Evaluate 在没有日志或当前版本没有新增样本时返回 `None`，cron 将其记录为 `job_completed`，造成“任务成功”与“评估过新样本”无法区分。现场数据中 Milkie run 持续到 2026-08-02，而 routine trajectory、生产技能有效样本和评估报告均停在 2026-06-03—04。概要设计见 Issue #187 的 Approved 评论。
+
+## 2. 名词解释
+
+| 术语 | 含义 |
+|------|------|
+| canonical observation | provider 将私有事件归一化后的技能加载事实，包含技能名及观测完整性，不暴露底层事件存储格式 |
+| complete observation | provider 看到了本轮正常终态，能判定技能集合为空或非空 |
+| no changes | 观测链路正常，但当前版本没有尚未覆盖的新评估样本 |
+| observation unavailable | provider 未提供技能观测能力，或本轮事件流缺少可判定终态；不得解释为“没有调用技能” |
+| eligible segment | 属于当前技能版本、包含上下文或输出、且尚未被现有报告覆盖的样本 |
+
+## 3. 设计目标与非目标
+
+- **目标**：Milkie routine 的成功技能加载在不生成 legacy trajectory 的情况下落为可追踪样本。
+- **目标**：同一 session 内同一 skill/version 幂等，只形成一条 routine 级评估样本。
+- **目标**：Skill Evaluate 终态明确区分 evaluated、no changes 与 LLM unavailable，并携带 observed/eligible/evaluated 计数。
+- **目标**：真实 Milkie sidecar E2E 覆盖“技能请求 → 样本 → 评估报告 → 再次执行 no changes”。
+- **非目标**：回填 2026-06-04 之后已经丢失的历史调用。
+- **非目标**：改变 Judge 算法、版本晋升/回滚阈值或技能业务输出。
+- **非目标**：要求 provider 复制 Milkie event store 为 Dolphin trajectory。
+
+## 4. 能力与功能设计
+
+routine 成功结束后，cron 从当前 agent 对应 provider 读取本轮 `SkillObservationBatch`。批次完整且包含技能时，按唯一技能名调用现有 `SkillLogRecorder`；完整且为空时不写样本，但保留“观测成功、零技能”的可判定语义；不完整时写结构化 `skill_observation_unavailable` 事件，并把最新观测健康状态原子写入 skill logs 目录，不把它当作零技能。下一轮完整观测会覆盖该状态，使链路自动恢复。
+
+Skill Evaluate 返回内部结构化 `JobOutcome`：
+
+- `completed`：至少一个 eligible segment 被纳入新报告；事件带计数。
+- `skipped/no_changes`：观测日志存在但没有尚未覆盖的 eligible segment，或日志目录为空；不再写 `job_completed`。
+- `degraded/llm_unavailable`：存在 eligible segment，但 Judge 暂时不可用；保留现有重试语义。
+- `degraded/observation_unavailable`：最新 provider 观测批次不完整；即使没有新 JSONL，也不得降级成 no changes。
+
+### 4.1 UI / UX
+
+N/A — 无新页面。运维通过 heartbeat JSONL/job 事件读取稳定状态和计数。
+
+## 5. 设计思路与折衷
+
+选择在 `AgentProvider` 边界增加只读的技能观测批次，而不是让 SLM 解析 Milkie JSONL/SQLite。Milkie 在 `run_turn` 内已看到原生 `tool.requested` / `tool.responded`，可以在成功的 `skill_request` 响应处记录被加载的技能；cron 只消费 provider 中立结果。该方案保持事件事实源唯一，也允许未来 provider 自行映射私有事件。
+
+Milkie 只把 `skill_request` 工具结果中 `status=ok` 的请求视为技能加载成功；not_found/unavailable 不形成技能样本。重复加载在 provider 批次和 cron 记录两层去重。事件流必须看到成功的 `agent.run.completed` 才标记 batch complete；异常终止沿原任务失败路径处理。
+
+保留 trajectory 解析作为无观测方法的兼容回退，但不作为 Milkie 主路径。放弃从任务描述、prompt 或 manifest 推断技能，因为这些信息只说明意图/可用性，不能证明真实调用。放弃仅增加 warning，因为它不能恢复样本，也不能修正假成功终态。
+
+## 6. 架构设计
+
+### 6.1 逻辑分层
+
+```mermaid
+flowchart LR
+  M["Milkie SSE\ntool.requested/responded"] --> P["MilkieProvider\nSkillObservationBatch"]
+  L["Legacy trajectory"] --> F["compat fallback"]
+  P --> C["CronExecutor\nrecord observed skills"]
+  F --> C
+  C --> H["latest observation health\natomic JSON"]
+  C --> S["SkillLogRecorder\nEvaluationSegment JSONL"]
+  H --> E["Skill Evaluate"]
+  S --> E
+  E --> O{"JobOutcome"}
+  O -->|eligible > 0| DONE["job_completed + counts"]
+  O -->|eligible = 0| SKIP["job_skipped/no_changes"]
+  O -->|judge unavailable| DEG["job_degraded"]
+```
+
+### 6.2 核心业务流程
+
+```mermaid
+sequenceDiagram
+  participant R as Routine
+  participant M as MilkieProvider
+  participant C as CronExecutor
+  participant S as SkillLogRecorder
+  participant E as Skill Evaluate
+
+  R->>M: run_turn
+  M->>M: skill_request(name) requested
+  M->>M: tool.responded(status=ok, output.status=ok)
+  M->>M: agent.run.completed
+  R-->>C: final output
+  C->>M: get_skill_observations(agent)
+  M-->>C: complete batch [skill]
+  C->>S: maybe_record(skill, session, output)
+  S-->>E: segment JSONL
+  E->>E: select current-version eligible segments
+  E-->>C: completed(counts) or skipped(no_changes)
+```
+
+失败路径：Milkie run 抛错时 routine 保持既有 failed/retry 行为，不记录 completed 样本；provider 不支持观测且没有可用 trajectory 时，cron 发出 observation unavailable 事件；Judge 超时继续转换为可重试 degraded。
+
+## 7. 模块设计
+
+| 模块 | 契约变化 |
+|------|----------|
+| `core/agent/provider/base.py` | 新增 `SkillObservationBatch` 数据契约与 `get_skill_observations(agent)` 可选能力 |
+| `core/agent/provider/milkie/provider.py` | 在 handle 内维护当前 turn 的 pending skill requests、成功加载集合和 complete 标志 |
+| `core/runtime/cron.py` | routine 完成后优先读取 provider observation；仅在能力缺失时回退 trajectory；落盘结果返回计数并记录不可用事件 |
+| `core/slm/segment_logger.py` | 原子保存/读取最新观测健康状态，使评估任务能区分零样本与观测中断 |
+| `core/slm/skill_log_recorder.py` | 暴露不影响主任务的观测状态写入适配器 |
+| `core/jobs/result.py` | 定义 provider-neutral job outcome：completed/skipped/degraded 及结构化 detail |
+| `core/jobs/skill_evaluate.py` | 统计 observed/eligible/evaluated segments，零变化返回 skipped outcome |
+| `core/runtime/cron.py::_invoke_job` | 将 JobOutcome 映射为准确的 heartbeat 事件，不再把所有正常返回统一写作 completed |
+
+观测批次不持久化工具参数和完整 skill instructions，只保留去重后的技能名、完整性和稳定原因码。技能版本继续由 `SkillLogRecorder` 从真实 `SKILL.md` 解析，避免 provider 与 SLM version manager 重复实现版本选择。
+
+## 8. API / CLI 设计
+
+`AgentProvider` 新增可选同步读取能力：
+
+```python
+@dataclass(frozen=True)
+class SkillObservationBatch:
+    skill_names: tuple[str, ...]
+    complete: bool
+    reason: str = ""
+
+def get_skill_observations(self, agent: Any) -> SkillObservationBatch: ...
+```
+
+job 内部返回契约：
+
+```python
+@dataclass(frozen=True)
+class JobOutcome:
+    status: Literal["completed", "skipped", "degraded"]
+    reason: str
+    summary: str = ""
+    detail: dict[str, Any] = field(default_factory=dict)
+```
+
+heartbeat 事件字段保持向后兼容，并新增：`observed_count`、`eligible_count`、`evaluated_count`、`reason`。既有返回字符串的 job 仍走原路径。
+
+## 9. 边界考虑
+
+- `skill_request` hit 与 miss 必须通过 tool result 区分，miss 不计入样本。
+- 同一技能重复请求、SSE 重放和 routine 重试不得在同一 session 形成重复 segment。
+- provider handle 每个 turn 开始前清空临时观测，避免前一轮污染后一轮。
+- 无 terminal、JSON 异常或能力缺失不能被解释为“零技能”；损坏的观测状态文件按 unavailable 处理。
+- 失败技能调用可以在未来扩展为 failed segment；本 issue 只记录成功加载后产生的 routine 最终输出，保持现有评估语义。
+- 不记录密钥、工具原始参数或完整 instructions；输出继续受现有 4 KiB inline / artifact 规则保护。
+- 并发 sidecar handle 相互隔离；单 handle 当前只允许其既有 turn 生命周期内读取本轮批次。
+
+## 10. 迁移 / 兼容 / 回滚
+
+无需数据迁移。旧 JSONL 和 eval report 格式不变；新增 `.observation_state.json` 只保存最新健康状态，不存在时兼容既有目录。Milkie 使用新 provider observation；缺少新方法的测试替身/旧 provider 使用 trajectory 兼容回退。回滚时可忽略该状态文件并删除新 provider 方法和 JobOutcome 映射，但会重新出现 #187 的观测断链，因此生产回滚必须同步告警。
+
+## 11. 测试计划
+
+- **E2E**：使用现有 fake OpenAI + 真实 `milkie serve`，强制 `skill_request` hit；不创建 trajectory。断言 provider batch complete、技能名准确、SkillLogRecorder 生成唯一 segment；用确定性 Judge 执行真实 Skill Evaluate 文件管线，断言 eval report `segment_count=1`、job outcome completed 且计数为 1；第二次执行断言 skipped/no_changes。若本机无 Milkie dist，测试允许 skip，但交付验证必须在配置了 `MILKIE_CLI` 的环境实际跑通并记录命令输出。
+- **Integration**：Milkie SSE hit/miss/重复/无 terminal；cron provider observation 优先级、trajectory fallback、unavailable event；观测健康状态到 degraded outcome；JobOutcome 到 completed/skipped/degraded 事件映射；segment 到报告的新增覆盖计数。
+- **Unit**：skill name 参数解析、batch reset/dedupe、观测状态原子读写及损坏处理、JobOutcome 序列化、eligible 增量计数和零样本状态。
+
+## 12. 开放问题 / 决策记录
+
+- 2026-08-02：Approved L1 后选择 provider observation，不重建 trajectory。
+- 2026-08-02：Milkie 成功加载以 `tool.responded.status=ok` 且结果 payload `status=ok` 为准；仅看到 request 不足以证明加载。
+- 2026-08-02：历史缺口不回填，避免用 prompt/manifest 制造不可证明的样本。
+
+## 13. 关联
+
+- Issue #187
+- 概要：Issue #187 Approved 设计评论
+- PR：待创建
+- `src/everbot/core/agent/provider/base.py`
+- `src/everbot/core/agent/provider/milkie/provider.py`
+- `src/everbot/core/runtime/cron.py`
+- `src/everbot/core/jobs/skill_evaluate.py`

--- a/docs/design/187-skill-observation.md
+++ b/docs/design/187-skill-observation.md
@@ -1,7 +1,7 @@
 # 【SLM】恢复 Milkie 技能评估观测并消除空跑假成功
 
 - Issue: #187
-- 状态: Approved
+- 状态: Implemented
 - 最后更新: 2026-08-02
 
 ## 1. 背景
@@ -168,7 +168,7 @@ heartbeat 事件字段保持向后兼容，并新增：`observed_count`、`eligi
 
 - Issue #187
 - 概要：Issue #187 Approved 设计评论
-- PR：待创建
+- PR：[GitHub #189](https://github.com/xforce-io/alfred/pull/189)
 - `src/everbot/core/agent/provider/base.py`
 - `src/everbot/core/agent/provider/milkie/provider.py`
 - `src/everbot/core/runtime/cron.py`

--- a/src/everbot/core/agent/provider/base.py
+++ b/src/everbot/core/agent/provider/base.py
@@ -7,17 +7,31 @@ from the allowlisted compat layer instead.
 """
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, AsyncIterator, Optional, Protocol, runtime_checkable
+
+
+@dataclass(frozen=True)
+class SkillObservationBatch:
+    """Provider-neutral skill loads observed during the latest turn.
+
+    ``complete`` distinguishes a genuine zero-skill turn from a provider that
+    could not prove what happened.  Consumers must never treat an incomplete
+    batch as an empty successful observation.
+    """
+
+    skill_names: tuple[str, ...]
+    complete: bool
+    reason: str = ""
 
 
 @runtime_checkable
 class AgentProvider(Protocol):
     """Provider-neutral port for agent-runtime capabilities.
 
-    The active implementation (currently :class:`DolphinProvider`) hides all
-    dolphin-specific types behind this surface so that alfred's mainline code
-    never imports dolphin directly.
+    Implementations hide runtime-specific types behind this surface so that
+    alfred's mainline code remains provider-neutral.
     """
 
     async def create_agent(
@@ -72,6 +86,10 @@ class AgentProvider(Protocol):
     def get_variable(self, agent: Any, key: str) -> Any: ...
 
     def init_trajectory(self, agent: Any, path: str, overwrite: bool = False) -> None: ...
+
+    def get_skill_observations(self, agent: Any) -> SkillObservationBatch:
+        """Return successful skill loads from the agent's latest turn."""
+        ...
 
     def set_session_id(self, agent: Any, session_id: str) -> None: ...
 

--- a/src/everbot/core/agent/provider/milkie/provider.py
+++ b/src/everbot/core/agent/provider/milkie/provider.py
@@ -15,7 +15,7 @@ import json
 import logging
 import uuid
 from contextlib import asynccontextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, AsyncIterator, Optional
 
@@ -23,6 +23,7 @@ import httpx
 
 from .adapter import milkie_event_to_progress
 from .sse import SSEParser
+from ..base import SkillObservationBatch
 from .....infra.milkie_trace import capture_trace_report
 from .....infra.user_data import get_user_data_manager
 
@@ -239,6 +240,13 @@ class MilkieAgentHandle:
     # #47: milkie 的单次运行 id(milkie#140 经终止帧回传),provider 私有 —— 供
     # Provider 据此定位落盘 trace(`milkie trace <runId>`)。绝不进中立 _progress。
     last_run_id: Optional[str] = None
+    # #187: provider-neutral SLM observation for the latest completed turn.
+    # Pending requests are provider-private and paired with tool.responded so
+    # a missing/unavailable skill is never recorded as a successful load.
+    skill_observation_names: set[str] = field(default_factory=set)
+    skill_observation_pending: dict[str, str] = field(default_factory=dict)
+    skill_observation_complete: bool = False
+    skill_observation_reason: str = "turn_not_started"
 
 
 class MilkieAgentError(RuntimeError):
@@ -447,6 +455,10 @@ class MilkieProvider:
         text = message if isinstance(message, str) else str(message)
         payload = {"contextId": handle.context_id, "input": text, "goal": text}
         pending_error: Optional[dict[str, Any]] = None
+        handle.skill_observation_names.clear()
+        handle.skill_observation_pending.clear()
+        handle.skill_observation_complete = False
+        handle.skill_observation_reason = "terminal_not_seen"
         try:
             # lease 与流同生命周期(#43):turn 在飞期间该 agent 的 sidecar 重生被推迟。
             async with self._lease_base_url(handle) as base_url, client.stream(
@@ -476,6 +488,10 @@ class MilkieProvider:
                         if event == "error":
                             pending_error = data
                             continue
+                        if event == "tool.requested":
+                            self._observe_skill_request(handle, data)
+                        elif event == "tool.responded":
+                            self._observe_skill_response(handle, data)
                         if event == "agent.run.completed":
                             # #47: 捕获本轮 runId(milkie#140)到 handle —— 必须在
                             # 下面 error 抛出之前,失败 run 才同样可被留证。runId 是
@@ -498,6 +514,8 @@ class MilkieProvider:
                                     or "unknown error"
                                 )
                                 raise MilkieAgentError(msg, envelope=detail, run_id=run_id)
+                            handle.skill_observation_complete = True
+                            handle.skill_observation_reason = ""
                         item = milkie_event_to_progress(event, data)
                         if item is not None:
                             yield {"_progress": [item]}
@@ -509,6 +527,47 @@ class MilkieProvider:
         finally:
             if owns_client:
                 await client.aclose()
+
+    @staticmethod
+    def _observe_skill_request(handle: MilkieAgentHandle, data: dict[str, Any]) -> None:
+        if data.get("toolName") != "skill_request":
+            return
+        raw = data.get("input")
+        if isinstance(raw, str):
+            try:
+                raw = json.loads(raw)
+            except json.JSONDecodeError:
+                return
+        if not isinstance(raw, dict):
+            return
+        name = str(raw.get("name") or raw.get("skill_name") or "").strip()
+        call_id = str(data.get("toolCallId") or "").strip()
+        if name and call_id:
+            handle.skill_observation_pending[call_id] = name
+
+    @staticmethod
+    def _observe_skill_response(handle: MilkieAgentHandle, data: dict[str, Any]) -> None:
+        call_id = str(data.get("toolCallId") or "").strip()
+        name = handle.skill_observation_pending.pop(call_id, None)
+        if not name or data.get("status") != "ok":
+            return
+        output = data.get("output")
+        if isinstance(output, str):
+            try:
+                output = json.loads(output)
+            except json.JSONDecodeError:
+                return
+        if isinstance(output, dict) and output.get("status") == "ok":
+            handle.skill_observation_names.add(name)
+
+    def get_skill_observations(self, agent: Any) -> SkillObservationBatch:
+        """Return successful ``skill_request`` loads from the latest turn."""
+        handle: MilkieAgentHandle = agent
+        return SkillObservationBatch(
+            skill_names=tuple(sorted(handle.skill_observation_names)),
+            complete=bool(handle.skill_observation_complete),
+            reason=str(handle.skill_observation_reason or ""),
+        )
 
     # -- 运行态查询:is_paused/is_error 暂未由 serve 透出,默认 False(非本次范围)。
     def is_paused(self, agent: Any) -> bool:

--- a/src/everbot/core/jobs/result.py
+++ b/src/everbot/core/jobs/result.py
@@ -1,0 +1,16 @@
+"""Structured outcomes returned by built-in background jobs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+
+@dataclass(frozen=True)
+class JobOutcome:
+    """A machine-readable job terminal, separate from user-visible output."""
+
+    status: Literal["completed", "skipped", "degraded"]
+    reason: str
+    summary: str = ""
+    detail: dict[str, Any] = field(default_factory=dict)

--- a/src/everbot/core/jobs/skill_evaluate.py
+++ b/src/everbot/core/jobs/skill_evaluate.py
@@ -11,9 +11,11 @@ Testing versions that pass evaluation are activated.
 import asyncio
 import logging
 import re
+from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import List, Optional
+from typing import List
 
+from .result import JobOutcome
 from ..runtime.skill_context import SkillContext
 from ..slm.judge import evaluate_skill
 from ..slm.models import EvaluationSegment, EvalReport, VersionStatus
@@ -24,6 +26,20 @@ from ..slm._atomic_io import skill_lock
 logger = logging.getLogger(__name__)
 _SKILL_EVALUATION_TIMEOUT_SECONDS = 120
 MAX_CONSECUTIVE_EVOLVE = 2
+
+
+@dataclass(frozen=True)
+class SkillEvaluationResult:
+    """One skill's report coverage produced by the current job run."""
+
+    summary: str
+    observed_count: int
+    eligible_count: int
+    evaluated_count: int
+
+    def __contains__(self, value: str) -> bool:
+        """Keep the former summary-string assertion style source compatible."""
+        return value in self.summary
 
 _EVOLVE_SYSTEM = (
     "You are a skill improvement assistant. "
@@ -56,14 +72,12 @@ produce an improved version.
 """
 
 
-async def run(context: SkillContext) -> Optional[str]:
+async def run(context: SkillContext) -> JobOutcome:
     """Evaluate all skills that have accumulated new entries since last report.
 
-    Returns None for the typical silent path — actionable skill state
-    changes (promoted / suspended / improved / rolled back) reach the
-    user via ``context.mailbox.deposit`` inside ``_post_evaluate``. Only
-    persistent LLM unavailability is surfaced here, since it indicates a
-    degraded mode the user should know about.
+    Returns a structured terminal outcome so the scheduler can distinguish
+    evaluated samples, a legitimate no-change skip, and degraded observation
+    or judge availability.
     """
     from ...infra.user_data import get_user_data_manager
 
@@ -73,6 +87,20 @@ async def run(context: SkillContext) -> Optional[str]:
     skill_eval_dir = context.skill_eval_dir
 
     seg_logger = SegmentLogger(skill_logs_dir)
+    observation_state = seg_logger.load_observation_state()
+    if observation_state and not observation_state["complete"]:
+        return JobOutcome(
+            status="degraded",
+            reason="observation_unavailable",
+            summary="Latest skill observation batch was incomplete",
+            detail={
+                "observed_count": 0,
+                "eligible_count": 0,
+                "evaluated_count": 0,
+                "observation_reason": observation_state.get("reason", ""),
+                "observation_session_id": observation_state.get("session_id", ""),
+            },
+        )
     # Layered SLM: writable = agent workspace skills (loader layer 0).
     # Read chain mirrors dolphin's loader priority (workspace → user → repo)
     # so bootstrap can find baseline content even when workspace is empty.
@@ -88,12 +116,20 @@ async def run(context: SkillContext) -> Optional[str]:
 
     skill_ids = seg_logger.list_skills()
     if not skill_ids:
-        return None
+        return JobOutcome(
+            status="skipped",
+            reason="no_changes",
+            detail={"observed_count": 0, "eligible_count": 0, "evaluated_count": 0},
+        )
 
     from .llm_errors import LLMTransientError, LLMConfigError
 
-    evaluated = 0
+    observed_count = sum(seg_logger.count(skill_id) for skill_id in skill_ids)
+    eligible_count = 0
+    evaluated_count = 0
+    evaluated_skills = 0
     unavailable = 0
+    failed = 0
     for skill_id in skill_ids:
         # #132: warn (non-blocking) when a stale per-agent override shadows the
         # repo baseline for this skill. Best-effort — never abort evaluation.
@@ -106,12 +142,21 @@ async def run(context: SkillContext) -> Optional[str]:
                 context, seg_logger, ver_mgr, skill_id, udm.sessions_dir,
             )
             if result:
-                evaluated += 1
-                logger.info("Evaluated %s: %s", skill_id, result)
+                evaluated_skills += 1
+                if isinstance(result, SkillEvaluationResult):
+                    eligible_count += result.eligible_count
+                    evaluated_count += result.evaluated_count
+                    summary = result.summary
+                else:  # compatibility for patched/custom evaluators
+                    eligible_count += 1
+                    evaluated_count += 1
+                    summary = str(result)
+                logger.info("Evaluated %s: %s", skill_id, summary)
         except (LLMTransientError, LLMConfigError):
             unavailable += 1
             logger.warning("LLM unavailable during %s evaluation, skipping skill", skill_id)
         except Exception as e:
+            failed += 1
             logger.warning("Failed to evaluate %s: %s", skill_id, e)
 
     for skill_id in skill_ids:
@@ -120,10 +165,38 @@ async def run(context: SkillContext) -> Optional[str]:
         except Exception as e:
             logger.warning("Cleanup failed for %s: %s", skill_id, e)
 
-    logger.info("Evaluated %d/%d skills", evaluated, len(skill_ids))
-    if unavailable:
-        return f"Evaluated {evaluated}/{len(skill_ids)} skills, skipped {unavailable} due to LLM unavailability"
-    return None
+    detail = {
+        "observed_count": observed_count,
+        "eligible_count": eligible_count,
+        "evaluated_count": evaluated_count,
+        "evaluated_skill_count": evaluated_skills,
+        "skill_count": len(skill_ids),
+        "unavailable_skill_count": unavailable,
+        "failed_skill_count": failed,
+    }
+    logger.info(
+        "Skill evaluation observed=%d eligible=%d evaluated=%d skills=%d/%d",
+        observed_count, eligible_count, evaluated_count, evaluated_skills, len(skill_ids),
+    )
+    if unavailable or failed:
+        reason = "llm_unavailable" if unavailable else "evaluation_error"
+        return JobOutcome(
+            status="degraded",
+            reason=reason,
+            summary=(
+                f"Evaluated {evaluated_skills}/{len(skill_ids)} skills; "
+                f"unavailable={unavailable}, failed={failed}"
+            ),
+            detail=detail,
+        )
+    if evaluated_count:
+        return JobOutcome(
+            status="completed",
+            reason="evaluated",
+            summary=f"Evaluated {evaluated_count} segments across {evaluated_skills} skills",
+            detail=detail,
+        )
+    return JobOutcome(status="skipped", reason="no_changes", detail=detail)
 
 
 async def _evaluate_one(
@@ -132,8 +205,8 @@ async def _evaluate_one(
     ver_mgr: VersionManager,
     skill_id: str,
     sessions_dir,
-) -> str | None:
-    """Evaluate a single skill. Returns summary string or None if skipped."""
+) -> SkillEvaluationResult | str | None:
+    """Evaluate one skill and report newly covered samples, or skip it."""
     # Self-heal: ensure this skill has pointer+metadata+snapshot before we
     # do anything. Handles both first-time skills and partial state from
     # crash / manual edit.
@@ -166,6 +239,7 @@ async def _evaluate_one(
     existing = ver_mgr.get_eval_report(skill_id, target_version)
     if existing and existing.segment_count >= len(target_entries):
         return None
+    previous_segment_count = existing.segment_count if existing else 0
 
     segments = [e for e in target_entries if e.skill_output or e.context_before]
     if not segments:
@@ -203,10 +277,15 @@ async def _evaluate_one(
 
         await _post_evaluate(context, ver_mgr, seg_logger, skill_id, target_version, report)
 
-    return (
-        f"v{target_version}: {report.segment_count} segments, "
-        f"critical={report.critical_issue_rate:.0%}, "
-        f"satisfaction={report.mean_satisfaction:.2f}"
+    return SkillEvaluationResult(
+        summary=(
+            f"v{target_version}: {report.segment_count} segments, "
+            f"critical={report.critical_issue_rate:.0%}, "
+            f"satisfaction={report.mean_satisfaction:.2f}"
+        ),
+        observed_count=len(entries),
+        eligible_count=max(0, len(segments) - previous_segment_count),
+        evaluated_count=max(0, report.segment_count - previous_segment_count),
     )
 
 

--- a/src/everbot/core/runtime/cron.py
+++ b/src/everbot/core/runtime/cron.py
@@ -780,10 +780,9 @@ class CronExecutor:
                     ),
                 )
 
-            # SLM: record skill invocations from this isolated agent run.
-            # Reads the just-written trajectory to find _load_resource_skill
-            # calls and writes one segment per unique skill into skill_logs/.
-            self._record_skill_log(task, result, job_session_id)
+            # SLM: persist provider-neutral skill observations from this run.
+            # Legacy trajectory parsing remains a compatibility fallback only.
+            self._record_skill_log(task, result, job_session_id, agent=agent)
 
             return result
         except Exception as exc:
@@ -986,6 +985,28 @@ class CronExecutor:
             result = await job_module.run(context)
 
             duration_ms = int(_time.time() * 1000) - start_ms
+            from ..jobs.result import JobOutcome
+
+            if isinstance(result, JobOutcome):
+                detail = dict(result.detail)
+                if result.status == "skipped":
+                    self._write_event(
+                        "job_skipped", skill=job_name,
+                        duration_ms=duration_ms, reason=result.reason, **detail,
+                    )
+                    return None
+                if result.status == "degraded":
+                    self._write_event(
+                        "job_degraded", skill=job_name,
+                        duration_ms=duration_ms, reason=result.reason, **detail,
+                    )
+                    return result.summary or None
+                self._write_event(
+                    "job_completed", skill=job_name,
+                    duration_ms=duration_ms, reason=result.reason,
+                    result=result.summary[:200], **detail,
+                )
+                return None
             self._write_event(
                 "job_completed", skill=job_name,
                 duration_ms=duration_ms, result=str(result)[:200],
@@ -1103,26 +1124,106 @@ class CronExecutor:
     def _task_mode(task: Any) -> str:
         return str(getattr(task, "execution_mode", "inline") or "inline")
 
-    def _record_skill_log(self, task: Task, output: str, session_id: str) -> None:
+    def _record_skill_log(
+        self,
+        task: Task,
+        output: str,
+        session_id: str,
+        *,
+        agent: Any = None,
+    ) -> int:
         """Record skill invocations to the SLM log after task completion.
 
-        Reads the trajectory file to find which skills the LLM actually
-        loaded via _load_resource_skill(). Each unique skill is recorded once.
+        Provider-native observations are authoritative.  The legacy trajectory
+        parser remains only as a compatibility fallback for providers without
+        the observation capability.
         """
         if self._skill_log_recorder is None:
-            return
+            return 0
         desc = str(getattr(task, "description", "") or "")
-        skill_names = self._extract_skills_from_trajectory(session_id)
-        for skill_name in skill_names:
+        skill_names: list[str]
+        if agent is not None:
+            from ..agent.provider import provider_for
+
             try:
-                self._skill_log_recorder.maybe_record(
+                provider = provider_for(agent)
+                getter = getattr(provider, "get_skill_observations", None)
+            except Exception as exc:
+                logger.warning("Cannot resolve skill observation provider for %s: %s", session_id, exc)
+                self._write_event(
+                    "skill_observation_unavailable",
+                    session_id=session_id,
+                    reason="provider_resolution_error",
+                    error=str(exc)[:200],
+                )
+                self._skill_log_recorder.record_observation_state(
+                    complete=False,
+                    session_id=session_id,
+                    reason="provider_resolution_error",
+                )
+                return 0
+            if callable(getter):
+                try:
+                    batch = getter(agent)
+                    if not batch.complete:
+                        reason = batch.reason or "incomplete_provider_observation"
+                        logger.warning("Skill observation incomplete for %s: %s", session_id, reason)
+                        self._write_event(
+                            "skill_observation_unavailable",
+                            session_id=session_id,
+                            reason=reason,
+                        )
+                        self._skill_log_recorder.record_observation_state(
+                            complete=False,
+                            session_id=session_id,
+                            reason=reason,
+                        )
+                        return 0
+                    skill_names = list(batch.skill_names)
+                except Exception as exc:
+                    logger.warning("Skill observation failed for %s: %s", session_id, exc)
+                    self._write_event(
+                        "skill_observation_unavailable",
+                        session_id=session_id,
+                        reason="provider_observation_error",
+                        error=str(exc)[:200],
+                    )
+                    self._skill_log_recorder.record_observation_state(
+                        complete=False,
+                        session_id=session_id,
+                        reason="provider_observation_error",
+                    )
+                    return 0
+                self._skill_log_recorder.record_observation_state(
+                    complete=True,
+                    session_id=session_id,
+                    observed_skills=len(set(skill_names)),
+                )
+            else:
+                skill_names = self._extract_skills_from_trajectory(session_id)
+        else:
+            skill_names = self._extract_skills_from_trajectory(session_id)
+
+        recorded = 0
+        for skill_name in sorted(set(skill_names)):
+            try:
+                if self._skill_log_recorder.maybe_record(
                     skill_name,
                     session_id=session_id,
                     skill_output=output or "",
                     context_before=desc,
-                )
+                ):
+                    recorded += 1
             except Exception as e:
                 logger.debug("Failed to record skill log for %s: %s", skill_name, e)
+        if agent is not None and recorded != len(set(skill_names)):
+            self._skill_log_recorder.record_observation_state(
+                complete=False,
+                session_id=session_id,
+                reason="segment_persist_failed",
+                observed_skills=len(set(skill_names)),
+            )
+        return recorded
 
     def _extract_skills_from_trajectory(self, session_id: str) -> list[str]:
         """Extract skill names from trajectory tool_calls of _load_resource_skill."""

--- a/src/everbot/core/slm/segment_logger.py
+++ b/src/everbot/core/slm/segment_logger.py
@@ -7,8 +7,9 @@ import json
 import logging
 import time
 from dataclasses import replace
+from datetime import datetime, timezone
 from pathlib import Path
-from typing import List
+from typing import Any, Dict, List, Optional
 
 from .models import EvaluationSegment
 
@@ -36,6 +37,10 @@ class SegmentLogger:
 
     def _artifact_dir(self, skill_id: str) -> Path:
         return self._logs_dir / "_artifacts" / skill_id
+
+    @property
+    def _observation_state_path(self) -> Path:
+        return self._logs_dir / ".observation_state.json"
 
     def _prepare_segment_for_storage(self, segment: EvaluationSegment) -> EvaluationSegment:
         """Persist oversized output out-of-line and keep a concise inline summary."""
@@ -99,6 +104,47 @@ class SegmentLogger:
         path.parent.mkdir(parents=True, exist_ok=True)
         with open(path, "a", encoding="utf-8") as f:
             f.write(segment.to_json() + "\n")
+
+    def save_observation_state(
+        self,
+        *,
+        complete: bool,
+        session_id: str,
+        reason: str = "",
+        observed_skills: int = 0,
+    ) -> None:
+        """Atomically persist whether the latest provider observation was complete."""
+        path = self._observation_state_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "complete": complete,
+            "session_id": session_id,
+            "reason": reason,
+            "observed_skills": observed_skills,
+            "updated_at": datetime.now(timezone.utc).isoformat(),
+        }
+        tmp = path.with_suffix(".tmp")
+        tmp.write_text(json.dumps(payload, ensure_ascii=False) + "\n", encoding="utf-8")
+        tmp.replace(path)
+
+    def load_observation_state(self) -> Optional[Dict[str, Any]]:
+        """Load latest observation health; malformed state is treated as unavailable."""
+        path = self._observation_state_path
+        if not path.exists():
+            return None
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            if not isinstance(data, dict) or not isinstance(data.get("complete"), bool):
+                raise ValueError("invalid observation state")
+            return data
+        except (OSError, ValueError, json.JSONDecodeError) as exc:
+            logger.warning("Failed to load skill observation state: %s", exc)
+            return {
+                "complete": False,
+                "session_id": "",
+                "reason": "observation_state_invalid",
+                "observed_skills": 0,
+            }
 
     def backfill_context_after(
         self, skill_id: str, session_id: str, context_after: str,
@@ -205,8 +251,6 @@ class SegmentLogger:
                 data = json.loads(line)
                 triggered = data.get("triggered_at", "")
                 if triggered:
-                    from datetime import datetime, timezone
-
                     ts = datetime.fromisoformat(triggered).timestamp()
                     if ts < cutoff:
                         continue

--- a/src/everbot/core/slm/skill_log_recorder.py
+++ b/src/everbot/core/slm/skill_log_recorder.py
@@ -109,6 +109,7 @@ class SkillLogRecorder:
         # Boundary check (accepts Optional[str] defensively)
         if not skill_name:
             return False
+
         # Filter internal tools (all starting with "_")
         if skill_name.startswith("_"):
             return False
@@ -158,6 +159,27 @@ class SkillLogRecorder:
             logger.warning(
                 "SkillLogRecorder: failed to write log for skill '%s': %s", skill_name, e
             )
+            return False
+
+    def record_observation_state(
+        self,
+        *,
+        complete: bool,
+        session_id: str,
+        reason: str = "",
+        observed_skills: int = 0,
+    ) -> bool:
+        """Persist health of the latest provider-native observation batch."""
+        try:
+            self._logger.save_observation_state(
+                complete=complete,
+                session_id=session_id,
+                reason=reason,
+                observed_skills=observed_skills,
+            )
+            return True
+        except Exception as exc:
+            logger.warning("SkillLogRecorder: failed to write observation state: %s", exc)
             return False
 
     @staticmethod

--- a/tests/e2e/test_milkie_skill_request_e2e.py
+++ b/tests/e2e/test_milkie_skill_request_e2e.py
@@ -16,7 +16,9 @@ import re
 import threading
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, Dict, List, Optional
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -127,6 +129,10 @@ def _make_web_skill(root: Path) -> Dict[str, Any]:
     # Body must not contain banned discovery phrases: hit tool_result embeds
     # instructions, and trajectory assertions scan tool outputs.
     body = (
+        "---\n"
+        "name: web\n"
+        "version: \"1.0.0\"\n"
+        "---\n"
         "# Web\n\n"
         "Closed-world e2e fixture for skill_request.\n\n"
         "Load via skill_request; use returned instructions and dir.\n"
@@ -295,3 +301,93 @@ async def test_skill_request_hit_and_miss_through_real_sidecar(tmp_path, monkeyp
         )
         assert not re.search(r"find\s+\$HOME|find\s+/Users|find\s+/ ", cmd_blob)
     assert handler_cls.tool_calls_seen == ["skill_request", "skill_request"]
+
+    # #187 S1/S2/S3: real sidecar observation → SLM segment → report → no_changes.
+    # No Dolphin trajectory is created anywhere in this path.
+    batch = provider.get_skill_observations(handle)
+    assert batch.complete is True
+    assert batch.skill_names == ("web",)
+    assert not (tmp_path / "trajectory_job_routine_fixture.json").exists()
+
+    from src.everbot.core.slm.skill_log_recorder import SkillLogRecorder
+    from src.everbot.core.slm.segment_logger import SegmentLogger
+
+    logs_dir = tmp_path / "skill_logs"
+    eval_dir = tmp_path / "skill_eval"
+    skills_root = tmp_path / "skills"
+    recorder = SkillLogRecorder(
+        logs_dir,
+        skill_dirs=[skills_root],
+        eval_base_dir=eval_dir,
+    )
+    assert recorder.record_observation_state(
+        complete=batch.complete,
+        session_id="job_routine_e2e",
+        reason=batch.reason,
+        observed_skills=len(batch.skill_names),
+    )
+    for skill_name in batch.skill_names:
+        assert recorder.maybe_record(
+            skill_name,
+            session_id="job_routine_e2e",
+            context_before="load web skill",
+            skill_output="skill-load-done",
+        )
+
+    segments = SegmentLogger(logs_dir).load("web")
+    assert len(segments) == 1
+    assert segments[0].skill_id == "web"
+    assert segments[0].skill_version == "1.0.0"
+    assert segments[0].session_id == "job_routine_e2e"
+
+    from src.everbot.core.jobs.skill_evaluate import run as run_skill_evaluate
+    from src.everbot.core.slm.models import EvalReport, JudgeResult
+
+    context = SimpleNamespace(
+        agent_name="skillreq",
+        llm=MagicMock(),
+        mailbox=SimpleNamespace(deposit=AsyncMock(return_value=None)),
+        skill_logs_dir=logs_dir,
+        skill_eval_dir=eval_dir,
+    )
+    report = EvalReport(
+        skill_id="web",
+        skill_version="1.0.0",
+        evaluated_at="2026-08-02T00:00:00+00:00",
+        segment_count=1,
+        critical_issue_count=0,
+        critical_issue_rate=0.0,
+        mean_satisfaction=0.9,
+        results=[JudgeResult(
+            segment_index=0,
+            has_critical_issue=False,
+            satisfaction=0.9,
+            reason="e2e fixture ok",
+        )],
+    )
+    udm = MagicMock()
+    udm.skill_logs_dir = logs_dir
+    udm.skills_dir = skills_root
+    udm.repo_skills_dir = skills_root
+    udm.sessions_dir = tmp_path / "sessions"
+    udm.get_agent_writable_skills_dir.return_value = skills_root
+    udm.get_agent_read_skill_dirs.return_value = [skills_root]
+
+    with patch("src.everbot.infra.user_data.get_user_data_manager", return_value=udm), patch(
+        "src.everbot.core.jobs.skill_evaluate.evaluate_skill",
+        new=AsyncMock(return_value=report),
+    ) as judge:
+        first = await run_skill_evaluate(context)
+        second = await run_skill_evaluate(context)
+
+    assert first.status == "completed"
+    assert first.reason == "evaluated"
+    assert first.detail["observed_count"] == 1
+    assert first.detail["eligible_count"] == 1
+    assert first.detail["evaluated_count"] == 1
+    assert second.status == "skipped"
+    assert second.reason == "no_changes"
+    assert second.detail["evaluated_count"] == 0
+    judge.assert_awaited_once()
+    reports = list(eval_dir.glob("web/versions/*/eval_report.json"))
+    assert len(reports) == 1

--- a/tests/e2e/test_milkie_skill_request_e2e.py
+++ b/tests/e2e/test_milkie_skill_request_e2e.py
@@ -6,7 +6,9 @@ Proves host skill-manifest injection + milkie tool handler contract:
     → hit: instructions + dir from manifest.dir/SKILL.md only
     → miss: not_found without HOME/full-disk SKILL.md search
 
-No API key required; milkie dist missing → skip.
+Skill observation / Skill Evaluate acceptance lives in
+``test_skill_observation_e2e.py`` (#187). No API key required; milkie dist
+missing → skip.
 """
 from __future__ import annotations
 
@@ -16,9 +18,7 @@ import re
 import threading
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
-from types import SimpleNamespace
 from typing import Any, Dict, List, Optional
-from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -41,6 +41,28 @@ def _milkie_cli() -> Optional[Path]:
         if candidate.exists():
             return candidate
     return None
+
+
+def _node_bin() -> str:
+    """Prefer Node 22 so milkie's better-sqlite3 native addon loads."""
+    configured = os.environ.get("MILKIE_NODE")
+    if configured:
+        p = Path(configured).expanduser()
+        if p.exists():
+            return str(p)
+    candidates = [
+        Path.home() / ".nvm/versions/node/v22.22.3/bin/node",
+        Path("/opt/homebrew/opt/node@22/bin/node"),
+        Path("/usr/local/opt/node@22/bin/node"),
+    ]
+    nvm_root = Path.home() / ".nvm/versions/node"
+    if nvm_root.is_dir():
+        for child in sorted(nvm_root.glob("v22.*/bin/node"), reverse=True):
+            candidates.append(child)
+    for candidate in candidates:
+        if candidate.exists():
+            return str(candidate)
+    return "node"
 
 
 class _SkillRequestOpenAIHandler(BaseHTTPRequestHandler):
@@ -216,7 +238,7 @@ async def test_skill_request_hit_and_miss_through_real_sidecar(tmp_path, monkeyp
             SKILL_MANIFEST_ENV: str(manifest_path),
         }
         cmd = [
-            "node", str(cli), "serve",
+            _node_bin(), str(cli), "serve",
             "--agent", str(agent_md),
             "--port", "0",
             "--state-store", "sqlite",
@@ -301,93 +323,3 @@ async def test_skill_request_hit_and_miss_through_real_sidecar(tmp_path, monkeyp
         )
         assert not re.search(r"find\s+\$HOME|find\s+/Users|find\s+/ ", cmd_blob)
     assert handler_cls.tool_calls_seen == ["skill_request", "skill_request"]
-
-    # #187 S1/S2/S3: real sidecar observation → SLM segment → report → no_changes.
-    # No Dolphin trajectory is created anywhere in this path.
-    batch = provider.get_skill_observations(handle)
-    assert batch.complete is True
-    assert batch.skill_names == ("web",)
-    assert not (tmp_path / "trajectory_job_routine_fixture.json").exists()
-
-    from src.everbot.core.slm.skill_log_recorder import SkillLogRecorder
-    from src.everbot.core.slm.segment_logger import SegmentLogger
-
-    logs_dir = tmp_path / "skill_logs"
-    eval_dir = tmp_path / "skill_eval"
-    skills_root = tmp_path / "skills"
-    recorder = SkillLogRecorder(
-        logs_dir,
-        skill_dirs=[skills_root],
-        eval_base_dir=eval_dir,
-    )
-    assert recorder.record_observation_state(
-        complete=batch.complete,
-        session_id="job_routine_e2e",
-        reason=batch.reason,
-        observed_skills=len(batch.skill_names),
-    )
-    for skill_name in batch.skill_names:
-        assert recorder.maybe_record(
-            skill_name,
-            session_id="job_routine_e2e",
-            context_before="load web skill",
-            skill_output="skill-load-done",
-        )
-
-    segments = SegmentLogger(logs_dir).load("web")
-    assert len(segments) == 1
-    assert segments[0].skill_id == "web"
-    assert segments[0].skill_version == "1.0.0"
-    assert segments[0].session_id == "job_routine_e2e"
-
-    from src.everbot.core.jobs.skill_evaluate import run as run_skill_evaluate
-    from src.everbot.core.slm.models import EvalReport, JudgeResult
-
-    context = SimpleNamespace(
-        agent_name="skillreq",
-        llm=MagicMock(),
-        mailbox=SimpleNamespace(deposit=AsyncMock(return_value=None)),
-        skill_logs_dir=logs_dir,
-        skill_eval_dir=eval_dir,
-    )
-    report = EvalReport(
-        skill_id="web",
-        skill_version="1.0.0",
-        evaluated_at="2026-08-02T00:00:00+00:00",
-        segment_count=1,
-        critical_issue_count=0,
-        critical_issue_rate=0.0,
-        mean_satisfaction=0.9,
-        results=[JudgeResult(
-            segment_index=0,
-            has_critical_issue=False,
-            satisfaction=0.9,
-            reason="e2e fixture ok",
-        )],
-    )
-    udm = MagicMock()
-    udm.skill_logs_dir = logs_dir
-    udm.skills_dir = skills_root
-    udm.repo_skills_dir = skills_root
-    udm.sessions_dir = tmp_path / "sessions"
-    udm.get_agent_writable_skills_dir.return_value = skills_root
-    udm.get_agent_read_skill_dirs.return_value = [skills_root]
-
-    with patch("src.everbot.infra.user_data.get_user_data_manager", return_value=udm), patch(
-        "src.everbot.core.jobs.skill_evaluate.evaluate_skill",
-        new=AsyncMock(return_value=report),
-    ) as judge:
-        first = await run_skill_evaluate(context)
-        second = await run_skill_evaluate(context)
-
-    assert first.status == "completed"
-    assert first.reason == "evaluated"
-    assert first.detail["observed_count"] == 1
-    assert first.detail["eligible_count"] == 1
-    assert first.detail["evaluated_count"] == 1
-    assert second.status == "skipped"
-    assert second.reason == "no_changes"
-    assert second.detail["evaluated_count"] == 0
-    judge.assert_awaited_once()
-    reports = list(eval_dir.glob("web/versions/*/eval_report.json"))
-    assert len(reports) == 1

--- a/tests/e2e/test_skill_observation_e2e.py
+++ b/tests/e2e/test_skill_observation_e2e.py
@@ -1,0 +1,566 @@
+"""E2E(#187 S1/S2/S3): Milkie skill observation → SLM segment → Skill Evaluate.
+
+Acceptance paths (no Dolphin trajectory):
+
+  S1  real milkie serve skill_request hit → complete SkillObservationBatch
+      → unique EvaluationSegment keyed by session
+  S2  Skill Evaluate consumes the new segment → completed + matching counts
+      + eval_report coverage
+  S3  second evaluate → skipped/no_changes;
+      incomplete observation state → degraded/observation_unavailable
+
+No API key required. Missing milkie dist → skip milkie-backed cases only.
+"""
+from __future__ import annotations
+
+import json
+import os
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Dict, List, Optional, Sequence
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.everbot.core.agent.provider.milkie.launcher import (
+    SKILL_MANIFEST_ENV,
+    _render_skill_manifest,
+)
+from src.everbot.core.agent.provider.milkie.pool import SidecarPool
+from src.everbot.core.agent.provider.milkie.provider import MilkieProvider
+from src.everbot.core.jobs.skill_evaluate import run as run_skill_evaluate
+from src.everbot.core.slm.models import EvalReport, JudgeResult
+from src.everbot.core.slm.segment_logger import SegmentLogger
+from src.everbot.core.slm.skill_log_recorder import SkillLogRecorder
+
+
+SESSION_ID = "job_routine_187_e2e"
+SKILL_NAME = "web"
+SKILL_VERSION = "1.0.0"
+
+
+def _milkie_cli() -> Optional[Path]:
+    configured = os.environ.get("MILKIE_CLI")
+    if configured:
+        p = Path(configured).expanduser()
+        return p if p.exists() else None
+    alfred_root = Path(__file__).resolve().parents[2]
+    for sibling in ("milkie-164", "milkie"):
+        candidate = alfred_root.parent / sibling / "dist" / "cli" / "index.js"
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def _node_bin() -> str:
+    """Prefer a Node binary whose ABI matches milkie's better-sqlite3 build.
+
+    Local milkie dist is typically built against Node 22 (NODE_MODULE_VERSION
+    127). PATH ``node`` may be 23+ and fail sidecar start; allow override via
+    ``MILKIE_NODE``.
+    """
+    configured = os.environ.get("MILKIE_NODE")
+    if configured:
+        p = Path(configured).expanduser()
+        if p.exists():
+            return str(p)
+    candidates = [
+        Path.home() / ".nvm/versions/node/v22.22.3/bin/node",
+        Path("/opt/homebrew/opt/node@22/bin/node"),
+        Path("/usr/local/opt/node@22/bin/node"),
+    ]
+    nvm_root = Path.home() / ".nvm/versions/node"
+    if nvm_root.is_dir():
+        for child in sorted(nvm_root.glob("v22.*/bin/node"), reverse=True):
+            candidates.append(child)
+    for candidate in candidates:
+        if candidate.exists():
+            return str(candidate)
+    return "node"
+
+
+def _require_milkie_cli() -> Path:
+    cli = _milkie_cli()
+    if cli is None:
+        pytest.skip("milkie dist not built (set MILKIE_CLI or build sibling milkie)")
+    return cli
+
+
+class _ScriptedSkillRequestHandler(BaseHTTPRequestHandler):
+    """Fake OpenAI that emits a fixed sequence of skill_request calls then text.
+
+    Class attrs set before the server starts:
+      skill_calls: ordered skill names to request (empty → final text only)
+      tool_results / tool_calls_seen: harvested for optional assertions
+    """
+
+    protocol_version = "HTTP/1.1"
+    skill_calls: Sequence[str] = ()
+    tool_results: List[Any] = []
+    tool_calls_seen: List[str] = []
+
+    def _send_stream(self, frames: list[dict]) -> None:
+        lines = ["data: " + json.dumps(f) for f in frames]
+        lines.append("data: [DONE]")
+        body = ("\n\n".join(lines) + "\n\n").encode("utf-8")
+        self.send_response(200)
+        self.send_header("content-type", "text/event-stream")
+        self.send_header("content-length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_POST(self):  # noqa: N802
+        length = int(self.headers.get("content-length", 0))
+        req = json.loads(self.rfile.read(length) or "{}")
+        messages = req.get("messages", [])
+
+        for m in messages:
+            if m.get("role") == "tool":
+                content = m.get("content", "")
+                try:
+                    parsed = json.loads(content) if isinstance(content, str) else content
+                except (TypeError, json.JSONDecodeError):
+                    parsed = content
+                type(self).tool_results.append(parsed)
+
+        n_tool_msgs = sum(1 for m in messages if m.get("role") == "tool")
+        calls = list(type(self).skill_calls)
+
+        if n_tool_msgs < len(calls):
+            name = calls[n_tool_msgs]
+            call_id = f"call_sr_{n_tool_msgs}"
+            type(self).tool_calls_seen.append("skill_request")
+            self._send_stream([
+                {"choices": [{"index": 0, "finish_reason": None, "delta": {
+                    "tool_calls": [{
+                        "index": 0, "id": call_id, "type": "function",
+                        "function": {
+                            "name": "skill_request",
+                            "arguments": json.dumps({"name": name}),
+                        },
+                    }],
+                }}]},
+                {"choices": [{"index": 0, "finish_reason": "tool_calls", "delta": {}}]},
+            ])
+            return
+
+        self._send_stream([
+            {"choices": [{"index": 0, "finish_reason": None, "delta": {
+                "content": "skill-observation-done",
+            }}]},
+            {"choices": [{"index": 0, "finish_reason": "stop", "delta": {}}]},
+        ])
+
+    def log_message(self, *args):
+        pass
+
+
+def _make_web_skill(root: Path) -> Dict[str, Any]:
+    skill = root / "skills" / SKILL_NAME
+    skill.mkdir(parents=True)
+    body = (
+        "---\n"
+        f"name: {SKILL_NAME}\n"
+        f'version: "{SKILL_VERSION}"\n'
+        "---\n"
+        "# Web\n\n"
+        "Closed-world e2e fixture for skill observation (#187).\n\n"
+        "Load via skill_request; use returned instructions and dir.\n"
+    )
+    (skill / "SKILL.md").write_text(body, encoding="utf-8")
+    return {
+        "name": SKILL_NAME,
+        "title": "Web",
+        "description": "web skill observation e2e fixture",
+        "abs_path": str(skill.resolve()),
+    }
+
+
+def _write_agent(tmp_path: Path, fake_port: int) -> Path:
+    md = tmp_path / "skill_obs_agent.md"
+    md.write_text(
+        "---\n"
+        "agentId: skillobs\n"
+        "version: 1.0.0\n"
+        "fsm:\n"
+        "  states:\n"
+        "    - name: react\n"
+        "      type: llm\n"
+        "      max_iterations: 8\n"
+        "      instructions: load skills via skill_request then answer\n"
+        "model:\n"
+        "  provider: openai\n"
+        "  model: fake-model\n"
+        "  adapter: openai-compatible\n"
+        f"  baseUrl: http://127.0.0.1:{fake_port}/v1\n"
+        "---\n"
+        "Prefer skill_request over shell discovery for SKILL.md.\n",
+        encoding="utf-8",
+    )
+    return md
+
+
+def _start_scripted_server(skill_calls: Sequence[str]):
+    handler_cls = type(
+        "_SkillObsHandler",
+        (_ScriptedSkillRequestHandler,),
+        {
+            "skill_calls": tuple(skill_calls),
+            "tool_results": [],
+            "tool_calls_seen": [],
+        },
+    )
+    server = HTTPServer(("127.0.0.1", 0), handler_cls)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    return server, handler_cls, server.server_address[1]
+
+
+async def _run_milkie_turn(
+    tmp_path: Path,
+    monkeypatch,
+    *,
+    skill_calls: Sequence[str],
+    include_manifest_skill: bool = True,
+):
+    """Boot real milkie serve + fake OpenAI; return (provider, handle, events, paths)."""
+    cli = _require_milkie_cli()
+    skill_meta = _make_web_skill(tmp_path)
+    skills_root = tmp_path / "skills"
+    manifest_skills = [skill_meta] if include_manifest_skill else []
+    manifest = _render_skill_manifest(manifest_skills)
+    data_dir = tmp_path / "milkie-data" / "skillobs"
+    data_dir.mkdir(parents=True)
+    manifest_path = data_dir / "skill-manifest.json"
+    manifest_path.write_text(json.dumps(manifest, ensure_ascii=False, indent=2), encoding="utf-8")
+
+    server, handler_cls, fake_port = _start_scripted_server(skill_calls)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-fake")
+    agent_md = _write_agent(tmp_path, fake_port)
+
+    def _build(_name: str):
+        env = {
+            "OPENAI_API_KEY": "sk-fake",
+            "PATH": os.environ.get("PATH", ""),
+            SKILL_MANIFEST_ENV: str(manifest_path),
+        }
+        cmd = [
+            _node_bin(), str(cli), "serve",
+            "--agent", str(agent_md),
+            "--port", "0",
+            "--state-store", "sqlite",
+            "--data-dir", str(data_dir),
+        ]
+        return cmd, env
+
+    pool = SidecarPool(build=_build)
+    provider = MilkieProvider()
+    provider._pool = pool
+    try:
+        handle = await provider.create_agent("skillobs", "/ws-skill-obs")
+        events = [e async for e in provider.run_turn(handle, "exercise skill observation")]
+    finally:
+        await provider.shutdown_sidecars()
+        server.shutdown()
+
+    return {
+        "provider": provider,
+        "handle": handle,
+        "events": events,
+        "handler_cls": handler_cls,
+        "skills_root": skills_root,
+        "skill_dir": Path(skill_meta["abs_path"]),
+        "data_dir": data_dir,
+        "tmp_path": tmp_path,
+    }
+
+
+def _assert_no_legacy_trajectory(tmp_path: Path) -> None:
+    leftovers = list(tmp_path.rglob("trajectory_*.json"))
+    assert leftovers == [], f"legacy trajectory must not exist: {leftovers}"
+
+
+def _make_recorder(tmp_path: Path, skills_root: Path) -> tuple[SkillLogRecorder, Path, Path]:
+    logs_dir = tmp_path / "skill_logs"
+    eval_dir = tmp_path / "skill_eval"
+    recorder = SkillLogRecorder(
+        logs_dir,
+        skill_dirs=[skills_root],
+        eval_base_dir=eval_dir,
+    )
+    return recorder, logs_dir, eval_dir
+
+
+def _record_complete_batch(
+    recorder: SkillLogRecorder,
+    batch,
+    *,
+    session_id: str = SESSION_ID,
+    context_before: str = "exercise skill observation",
+    skill_output: str = "skill-observation-done",
+) -> int:
+    assert recorder.record_observation_state(
+        complete=batch.complete,
+        session_id=session_id,
+        reason=batch.reason,
+        observed_skills=len(batch.skill_names),
+    )
+    recorded = 0
+    for skill_name in batch.skill_names:
+        if recorder.maybe_record(
+            skill_name,
+            session_id=session_id,
+            context_before=context_before,
+            skill_output=skill_output,
+        ):
+            recorded += 1
+    return recorded
+
+
+def _eval_context(logs_dir: Path, eval_dir: Path, skills_root: Path, tmp_path: Path):
+    context = SimpleNamespace(
+        agent_name="skillobs",
+        llm=MagicMock(),
+        mailbox=SimpleNamespace(deposit=AsyncMock(return_value=None)),
+        skill_logs_dir=logs_dir,
+        skill_eval_dir=eval_dir,
+    )
+    udm = MagicMock()
+    udm.skill_logs_dir = logs_dir
+    udm.skills_dir = skills_root
+    udm.repo_skills_dir = skills_root
+    udm.sessions_dir = tmp_path / "sessions"
+    udm.get_agent_writable_skills_dir.return_value = skills_root
+    udm.get_agent_read_skill_dirs.return_value = [skills_root]
+    return context, udm
+
+
+def _healthy_report(segment_count: int = 1) -> EvalReport:
+    return EvalReport(
+        skill_id=SKILL_NAME,
+        skill_version=SKILL_VERSION,
+        evaluated_at="2026-08-02T00:00:00+00:00",
+        segment_count=segment_count,
+        critical_issue_count=0,
+        critical_issue_rate=0.0,
+        mean_satisfaction=0.9,
+        results=[
+            JudgeResult(
+                segment_index=i,
+                has_critical_issue=False,
+                satisfaction=0.9,
+                reason="e2e fixture ok",
+            )
+            for i in range(segment_count)
+        ],
+    )
+
+
+# ---------------------------------------------------------------------------
+# S1 + S2 + S3 (happy path): hit → segment → evaluated → no_changes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_s1_s2_s3_hit_segment_evaluate_no_changes(tmp_path, monkeypatch):
+    """#187 full loop: one hit sample, evaluate once, second run is no_changes."""
+    run = await _run_milkie_turn(tmp_path, monkeypatch, skill_calls=[SKILL_NAME])
+    provider, handle = run["provider"], run["handle"]
+    skills_root = run["skills_root"]
+
+    # S1: complete batch, only the hit skill, no trajectory.
+    batch = provider.get_skill_observations(handle)
+    assert batch.complete is True
+    assert batch.reason == ""
+    assert batch.skill_names == (SKILL_NAME,)
+    _assert_no_legacy_trajectory(tmp_path)
+
+    recorder, logs_dir, eval_dir = _make_recorder(tmp_path, skills_root)
+    recorded = _record_complete_batch(recorder, batch)
+    assert recorded == 1
+
+    segments = SegmentLogger(logs_dir).load(SKILL_NAME)
+    assert len(segments) == 1
+    seg = segments[0]
+    assert seg.skill_id == SKILL_NAME
+    assert seg.skill_version == SKILL_VERSION
+    assert seg.session_id == SESSION_ID
+    assert seg.context_before
+    assert seg.skill_output
+    assert seg.triggered_at
+
+    state = SegmentLogger(logs_dir).load_observation_state()
+    assert state is not None
+    assert state["complete"] is True
+    assert state["session_id"] == SESSION_ID
+    assert state["observed_skills"] == 1
+
+    # S2: Skill Evaluate covers the new sample with matching counts.
+    context, udm = _eval_context(logs_dir, eval_dir, skills_root, tmp_path)
+    report = _healthy_report(segment_count=1)
+    with patch("src.everbot.infra.user_data.get_user_data_manager", return_value=udm), patch(
+        "src.everbot.core.jobs.skill_evaluate.evaluate_skill",
+        new=AsyncMock(return_value=report),
+    ) as judge:
+        first = await run_skill_evaluate(context)
+        second = await run_skill_evaluate(context)
+
+    assert first.status == "completed"
+    assert first.reason == "evaluated"
+    assert first.detail["observed_count"] == 1
+    assert first.detail["eligible_count"] == 1
+    assert first.detail["evaluated_count"] == 1
+    judge.assert_awaited_once()
+
+    reports = list(eval_dir.glob(f"{SKILL_NAME}/versions/*/eval_report.json"))
+    assert len(reports) == 1
+    report_body = json.loads(reports[0].read_text(encoding="utf-8"))
+    assert report_body["skill_id"] == SKILL_NAME
+    assert report_body["skill_version"] == SKILL_VERSION
+    assert report_body["segment_count"] == 1
+
+    # S3a: no new samples → skipped/no_changes, evaluated_count = 0.
+    assert second.status == "skipped"
+    assert second.reason == "no_changes"
+    assert second.detail["evaluated_count"] == 0
+    assert second.detail["eligible_count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# S1: provider-level dedupe + miss exclusion
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_s1_duplicate_hits_dedupe_to_one_observation(tmp_path, monkeypatch):
+    """Same skill loaded twice in one turn → batch carries one unique name."""
+    run = await _run_milkie_turn(
+        tmp_path, monkeypatch, skill_calls=[SKILL_NAME, SKILL_NAME],
+    )
+    batch = run["provider"].get_skill_observations(run["handle"])
+    assert batch.complete is True
+    assert batch.skill_names == (SKILL_NAME,)
+    assert run["handler_cls"].tool_calls_seen == ["skill_request", "skill_request"]
+
+    recorder, logs_dir, _eval_dir = _make_recorder(tmp_path, run["skills_root"])
+    # Cron-style recording iterates unique names only.
+    recorded = _record_complete_batch(recorder, batch)
+    assert recorded == 1
+    assert len(SegmentLogger(logs_dir).load(SKILL_NAME)) == 1
+    _assert_no_legacy_trajectory(tmp_path)
+
+
+@pytest.mark.asyncio
+async def test_s1_miss_only_yields_empty_complete_batch(tmp_path, monkeypatch):
+    """not_found skill_request must not create an evaluation sample."""
+    unknown = "no-such-skill-xyz"
+    run = await _run_milkie_turn(
+        tmp_path,
+        monkeypatch,
+        skill_calls=[unknown],
+        include_manifest_skill=True,
+    )
+    batch = run["provider"].get_skill_observations(run["handle"])
+    assert batch.complete is True
+    assert batch.skill_names == ()
+    assert run["handler_cls"].tool_results, "milkie should feed tool result back to LLM"
+    miss = run["handler_cls"].tool_results[0]
+    assert isinstance(miss, dict)
+    assert miss.get("status") == "not_found"
+
+    recorder, logs_dir, eval_dir = _make_recorder(tmp_path, run["skills_root"])
+    recorded = _record_complete_batch(recorder, batch)
+    assert recorded == 0
+    assert SegmentLogger(logs_dir).list_skills() == []
+    _assert_no_legacy_trajectory(tmp_path)
+
+    # Empty observation with healthy state → evaluate is no_changes, not success.
+    context, udm = _eval_context(logs_dir, eval_dir, run["skills_root"], tmp_path)
+    with patch("src.everbot.infra.user_data.get_user_data_manager", return_value=udm):
+        outcome = await run_skill_evaluate(context)
+    assert outcome.status == "skipped"
+    assert outcome.reason == "no_changes"
+    assert outcome.detail["evaluated_count"] == 0
+    assert outcome.detail["observed_count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# S3: observation unavailable must not look like evaluated success
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_s3_incomplete_observation_state_is_degraded(tmp_path):
+    """Persisted incomplete observation → degraded/observation_unavailable."""
+    logs_dir = tmp_path / "skill_logs"
+    eval_dir = tmp_path / "skill_eval"
+    skills_root = tmp_path / "skills"
+    skills_root.mkdir()
+
+    # Even if stale segments exist, incomplete observation wins.
+    recorder = SkillLogRecorder(logs_dir, skill_dirs=[skills_root], eval_base_dir=eval_dir)
+    # Write a decoy segment without going through a complete observation.
+    (skills_root / SKILL_NAME).mkdir()
+    (skills_root / SKILL_NAME / "SKILL.md").write_text(
+        f"---\nname: {SKILL_NAME}\nversion: \"{SKILL_VERSION}\"\n---\n# Web\n",
+        encoding="utf-8",
+    )
+    assert recorder.maybe_record(
+        SKILL_NAME,
+        session_id="stale-session",
+        context_before="stale",
+        skill_output="stale-output",
+    )
+    assert recorder.record_observation_state(
+        complete=False,
+        session_id="routine-broken",
+        reason="terminal_not_seen",
+        observed_skills=0,
+    )
+
+    context, udm = _eval_context(logs_dir, eval_dir, skills_root, tmp_path)
+    with patch("src.everbot.infra.user_data.get_user_data_manager", return_value=udm), patch(
+        "src.everbot.core.jobs.skill_evaluate.evaluate_skill",
+        new=AsyncMock(),
+    ) as judge:
+        outcome = await run_skill_evaluate(context)
+
+    assert outcome.status == "degraded"
+    assert outcome.reason == "observation_unavailable"
+    assert outcome.detail["evaluated_count"] == 0
+    assert outcome.detail["eligible_count"] == 0
+    assert outcome.detail["observed_count"] == 0
+    assert outcome.detail["observation_reason"] == "terminal_not_seen"
+    assert outcome.detail["observation_session_id"] == "routine-broken"
+    judge.assert_not_awaited()
+    assert list(eval_dir.glob(f"{SKILL_NAME}/versions/*/eval_report.json")) == []
+
+
+@pytest.mark.asyncio
+async def test_s3_empty_skill_logs_is_no_changes_not_completed(tmp_path):
+    """Healthy but empty skill_logs must be skipped/no_changes."""
+    logs_dir = tmp_path / "skill_logs"
+    logs_dir.mkdir()
+    eval_dir = tmp_path / "skill_eval"
+    skills_root = tmp_path / "skills"
+    skills_root.mkdir()
+
+    # Explicit complete/zero observation health (cron writes this after empty batch).
+    SegmentLogger(logs_dir).save_observation_state(
+        complete=True,
+        session_id="routine-empty",
+        observed_skills=0,
+    )
+
+    context, udm = _eval_context(logs_dir, eval_dir, skills_root, tmp_path)
+    with patch("src.everbot.infra.user_data.get_user_data_manager", return_value=udm):
+        outcome = await run_skill_evaluate(context)
+
+    assert outcome.status == "skipped"
+    assert outcome.reason == "no_changes"
+    assert outcome.detail == {
+        "observed_count": 0,
+        "eligible_count": 0,
+        "evaluated_count": 0,
+    }

--- a/tests/unit/test_cron_executor.py
+++ b/tests/unit/test_cron_executor.py
@@ -678,6 +678,64 @@ class TestInvokeJobLLMErrorHandling:
                 await executor._invoke_job(task, None, "test_run")
 
 
+class TestStructuredJobOutcome:
+    @pytest.mark.asyncio
+    async def test_no_changes_emits_skipped_instead_of_completed(self, tmp_path):
+        from src.everbot.core.jobs.result import JobOutcome
+
+        mgr = _seed_task(tmp_path, title="Skill Evaluate", job="skill-evaluate")
+        executor = _make_executor(tmp_path, routine_manager=mgr)
+        task = mgr.load_task_list().tasks[0]
+        executor._write_event = MagicMock()
+        executor._build_job_context = MagicMock(return_value=MagicMock())
+        outcome = JobOutcome(
+            status="skipped",
+            reason="no_changes",
+            detail={"observed_count": 4, "eligible_count": 0, "evaluated_count": 0},
+        )
+
+        with patch("importlib.import_module") as mock_import:
+            mock_module = SimpleNamespace(run=AsyncMock(return_value=outcome))
+            mock_import.return_value = mock_module
+            result = await executor._invoke_job(task, None, "test_run")
+
+        assert result is None
+        event_names = [call.args[0] for call in executor._write_event.call_args_list]
+        assert event_names == ["job_started", "job_skipped"]
+        skipped = executor._write_event.call_args_list[-1]
+        assert skipped.kwargs["reason"] == "no_changes"
+        assert skipped.kwargs["evaluated_count"] == 0
+
+    @pytest.mark.asyncio
+    async def test_evaluated_outcome_emits_completed_with_counts(self, tmp_path):
+        from src.everbot.core.jobs.result import JobOutcome
+
+        mgr = _seed_task(tmp_path, title="Skill Evaluate", job="skill-evaluate")
+        executor = _make_executor(tmp_path, routine_manager=mgr)
+        task = mgr.load_task_list().tasks[0]
+        executor._write_event = MagicMock()
+        executor._build_job_context = MagicMock(return_value=MagicMock())
+        outcome = JobOutcome(
+            status="completed",
+            reason="evaluated",
+            summary="Evaluated 2 segments across 1 skills",
+            detail={"observed_count": 2, "eligible_count": 2, "evaluated_count": 2},
+        )
+
+        with patch("importlib.import_module") as mock_import:
+            mock_module = SimpleNamespace(run=AsyncMock(return_value=outcome))
+            mock_import.return_value = mock_module
+            result = await executor._invoke_job(task, None, "test_run")
+
+        assert result is None  # bookkeeping remains silent to the user
+        event_names = [call.args[0] for call in executor._write_event.call_args_list]
+        assert event_names == ["job_started", "job_completed"]
+        completed = executor._write_event.call_args_list[-1]
+        assert completed.kwargs["reason"] == "evaluated"
+        assert completed.kwargs["eligible_count"] == 2
+        assert completed.kwargs["evaluated_count"] == 2
+
+
 class TestIsolatedAgentRetries:
     @pytest.mark.asyncio
     async def test_transient_remote_disconnect_is_not_retried_inside_agent_runner(self, tmp_path):
@@ -861,6 +919,74 @@ class TestSkillLogRecording:
             assert call.kwargs["session_id"] == "sess2"
             assert call.kwargs["skill_output"] == "report content"
             assert call.kwargs["context_before"] == "daily papers task"
+
+    def test_record_skill_log_prefers_complete_provider_observation(self, tmp_path):
+        from src.everbot.core.agent.provider.base import SkillObservationBatch
+
+        executor = _make_executor(tmp_path)
+        recorder = MagicMock()
+        recorder.maybe_record.return_value = True
+        executor._skill_log_recorder = recorder
+        provider = MagicMock()
+        provider.get_skill_observations.return_value = SkillObservationBatch(
+            skill_names=("paper-discovery", "paper-discovery"), complete=True,
+        )
+        agent = object()
+        task = MagicMock(description="daily papers task")
+
+        with patch("src.everbot.core.agent.provider.provider_for", return_value=provider), patch.object(
+            executor, "_extract_skills_from_trajectory"
+        ) as legacy:
+            recorded = executor._record_skill_log(
+                task, "report content", "sess-provider", agent=agent,
+            )
+
+        assert recorded == 1
+        legacy.assert_not_called()
+        recorder.record_observation_state.assert_called_once_with(
+            complete=True,
+            session_id="sess-provider",
+            observed_skills=1,
+        )
+        recorder.maybe_record.assert_called_once_with(
+            "paper-discovery",
+            session_id="sess-provider",
+            skill_output="report content",
+            context_before="daily papers task",
+        )
+
+    def test_record_skill_log_incomplete_observation_is_not_empty_success(self, tmp_path):
+        from src.everbot.core.agent.provider.base import SkillObservationBatch
+
+        executor = _make_executor(tmp_path)
+        recorder = MagicMock()
+        executor._skill_log_recorder = recorder
+        provider = MagicMock()
+        provider.get_skill_observations.return_value = SkillObservationBatch(
+            skill_names=("paper-discovery",),
+            complete=False,
+            reason="terminal_not_seen",
+        )
+
+        with patch("src.everbot.core.agent.provider.provider_for", return_value=provider), patch.object(
+            executor, "_write_event"
+        ) as write_event:
+            recorded = executor._record_skill_log(
+                MagicMock(description="task"), "out", "sess-incomplete", agent=object(),
+            )
+
+        assert recorded == 0
+        recorder.maybe_record.assert_not_called()
+        recorder.record_observation_state.assert_called_once_with(
+            complete=False,
+            session_id="sess-incomplete",
+            reason="terminal_not_seen",
+        )
+        write_event.assert_called_once_with(
+            "skill_observation_unavailable",
+            session_id="sess-incomplete",
+            reason="terminal_not_seen",
+        )
 
     def test_record_skill_log_no_recorder_is_noop(self, tmp_path):
         executor = _make_executor(tmp_path)

--- a/tests/unit/test_milkie_provider.py
+++ b/tests/unit/test_milkie_provider.py
@@ -99,6 +99,66 @@ async def test_run_turn_yields_llm_progress_deltas():
     ]
 
 
+async def test_run_turn_observes_only_successful_skill_request_hits():
+    sse = _sse(
+        ("tool.requested", {
+            "toolName": "skill_request", "toolCallId": "hit-1", "input": {"name": "web"},
+        }),
+        ("tool.responded", {
+            "toolCallId": "hit-1", "status": "ok",
+            "output": {"status": "ok", "instructions": "..."},
+        }),
+        ("tool.requested", {
+            "toolName": "skill_request", "toolCallId": "miss", "input": {"name": "missing"},
+        }),
+        ("tool.responded", {
+            "toolCallId": "miss", "status": "ok", "output": {"status": "not_found"},
+        }),
+        ("tool.requested", {
+            "toolName": "skill_request", "toolCallId": "hit-2",
+            "input": json.dumps({"name": "web"}),
+        }),
+        ("tool.responded", {
+            "toolCallId": "hit-2", "status": "ok",
+            "output": json.dumps({"status": "ok", "instructions": "..."}),
+        }),
+        ("agent.run.completed", {"status": "completed", "runId": "run-1"}),
+    )
+    p, client = _provider(sse)
+    handle = MilkieAgentHandle("http://sidecar", "c")
+    try:
+        _ = [e async for e in p.run_turn(handle, "load skills")]
+    finally:
+        await client.aclose()
+
+    batch = p.get_skill_observations(handle)
+    assert batch.complete is True
+    assert batch.reason == ""
+    assert batch.skill_names == ("web",)
+
+
+async def test_run_turn_without_terminal_marks_observation_incomplete():
+    sse = _sse(
+        ("tool.requested", {
+            "toolName": "skill_request", "toolCallId": "hit", "input": {"name": "web"},
+        }),
+        ("tool.responded", {
+            "toolCallId": "hit", "status": "ok", "output": {"status": "ok"},
+        }),
+    )
+    p, client = _provider(sse)
+    handle = MilkieAgentHandle("http://sidecar", "c")
+    try:
+        _ = [e async for e in p.run_turn(handle, "load skill")]
+    finally:
+        await client.aclose()
+
+    batch = p.get_skill_observations(handle)
+    assert batch.complete is False
+    assert batch.reason == "terminal_not_seen"
+    assert batch.skill_names == ("web",)
+
+
 async def test_run_turn_raises_on_error_terminal():
     """An ``agent.run.completed`` with status=error must raise (not be swallowed as
     an empty turn) — e.g. an LLM-endpoint connection error. The message carries the

--- a/tests/unit/test_skill_evaluate_drift_check.py
+++ b/tests/unit/test_skill_evaluate_drift_check.py
@@ -16,8 +16,14 @@ class _StubSegmentLogger:
     def list_skills(self):
         return ["twitter-watch", "invest"]
 
+    def load_observation_state(self):
+        return None
+
     def cleanup(self, _skill_id):
         pass
+
+    def count(self, _skill_id):
+        return 0
 
 
 class _StubVersionManager:

--- a/tests/unit/test_skill_evaluate_job.py
+++ b/tests/unit/test_skill_evaluate_job.py
@@ -101,9 +101,95 @@ async def test_run_skips_unavailable_skill_and_continues(tmp_path: Path):
         "src.everbot.core.jobs.skill_evaluate._evaluate_one",
         new=AsyncMock(side_effect=fake_evaluate_one),
     ):
-        summary = await run(context)
+        outcome = await run(context)
 
-    assert summary == "Evaluated 1/2 skills, skipped 1 due to LLM unavailability"
+    assert outcome.status == "degraded"
+    assert outcome.reason == "llm_unavailable"
+    assert outcome.detail == {
+        "observed_count": 2,
+        "eligible_count": 1,
+        "evaluated_count": 1,
+        "evaluated_skill_count": 1,
+        "skill_count": 2,
+        "unavailable_skill_count": 1,
+        "failed_skill_count": 0,
+    }
+
+
+@pytest.mark.asyncio
+async def test_run_without_skill_logs_is_explicit_no_changes(tmp_path: Path):
+    context = MagicMock()
+    context.skill_logs_dir = tmp_path / "skill_logs"
+    context.skill_eval_dir = tmp_path / "skill_eval"
+
+    fake_udm = MagicMock()
+    fake_udm.skill_logs_dir = context.skill_logs_dir
+    fake_udm.skills_dir = tmp_path / "skills"
+    fake_udm.sessions_dir = tmp_path / "sessions"
+
+    with patch("src.everbot.infra.user_data.get_user_data_manager", return_value=fake_udm):
+        outcome = await run(context)
+
+    assert outcome.status == "skipped"
+    assert outcome.reason == "no_changes"
+    assert outcome.detail == {
+        "observed_count": 0,
+        "eligible_count": 0,
+        "evaluated_count": 0,
+    }
+
+
+@pytest.mark.asyncio
+async def test_run_with_incomplete_observation_is_degraded(tmp_path: Path):
+    logs_dir = tmp_path / "skill_logs"
+    SegmentLogger(logs_dir).save_observation_state(
+        complete=False,
+        session_id="routine-42",
+        reason="terminal_not_seen",
+    )
+    context = MagicMock(skill_logs_dir=logs_dir, skill_eval_dir=tmp_path / "skill_eval")
+    fake_udm = MagicMock()
+    fake_udm.skill_logs_dir = logs_dir
+    fake_udm.skills_dir = tmp_path / "skills"
+
+    with patch("src.everbot.infra.user_data.get_user_data_manager", return_value=fake_udm):
+        outcome = await run(context)
+
+    assert outcome.status == "degraded"
+    assert outcome.reason == "observation_unavailable"
+    assert outcome.detail == {
+        "observed_count": 0,
+        "eligible_count": 0,
+        "evaluated_count": 0,
+        "observation_reason": "terminal_not_seen",
+        "observation_session_id": "routine-42",
+    }
+
+
+@pytest.mark.asyncio
+async def test_run_with_already_covered_segments_is_no_changes(tmp_path: Path):
+    logs_dir = tmp_path / "skill_logs"
+    _append_segment(logs_dir, "alpha")
+    context = MagicMock(skill_logs_dir=logs_dir, skill_eval_dir=tmp_path / "skill_eval")
+
+    fake_udm = MagicMock()
+    fake_udm.skill_logs_dir = logs_dir
+    fake_udm.skills_dir = tmp_path / "skills"
+    fake_udm.sessions_dir = tmp_path / "sessions"
+    fake_udm.get_agent_writable_skills_dir.return_value = tmp_path / "skills"
+    fake_udm.get_agent_read_skill_dirs.return_value = [tmp_path / "skills"]
+
+    with patch("src.everbot.infra.user_data.get_user_data_manager", return_value=fake_udm), patch(
+        "src.everbot.core.jobs.skill_evaluate._evaluate_one",
+        new=AsyncMock(return_value=None),
+    ):
+        outcome = await run(context)
+
+    assert outcome.status == "skipped"
+    assert outcome.reason == "no_changes"
+    assert outcome.detail["observed_count"] == 1
+    assert outcome.detail["eligible_count"] == 0
+    assert outcome.detail["evaluated_count"] == 0
 
 
 @pytest.mark.asyncio
@@ -157,6 +243,67 @@ async def test_evaluate_one_uses_bootstrapped_pointer_version(tmp_path: Path):
 
     assert result is not None
     assert "v2.0.0" in result
+
+
+@pytest.mark.asyncio
+async def test_evaluate_one_reports_incremental_coverage(tmp_path: Path):
+    skills_dir = tmp_path / "skills"
+    logs_dir = tmp_path / "skill_logs"
+    eval_dir = tmp_path / "skill_eval"
+    _write_skill_md(skills_dir, "web-search", version="1.0.0")
+    seg_logger = SegmentLogger(logs_dir)
+    for index in range(2):
+        seg_logger.append(EvaluationSegment(
+            skill_id="web-search",
+            skill_version="1.0.0",
+            triggered_at=f"2026-08-02T00:0{index}:00+00:00",
+            context_before="search",
+            skill_output=f"result {index}",
+            context_after="ok",
+            session_id=f"s-{index}",
+        ))
+
+    ver_mgr = VersionManager(skills_dir, eval_base_dir=eval_dir)
+    from src.everbot.core.slm.state_normalizer import ensure_registered
+    ensure_registered(ver_mgr, "web-search", repo_skills_dir=None)
+    existing = EvalReport(
+        skill_id="web-search",
+        skill_version="1.0.0",
+        evaluated_at="2026-08-02T00:00:00+00:00",
+        segment_count=1,
+        critical_issue_count=0,
+        critical_issue_rate=0.0,
+        mean_satisfaction=0.9,
+        results=[JudgeResult(0, False, 0.9, "ok")],
+    )
+    ver_mgr.save_eval_report("web-search", "1.0.0", existing)
+    updated = EvalReport(
+        skill_id="web-search",
+        skill_version="1.0.0",
+        evaluated_at="2026-08-02T00:01:00+00:00",
+        segment_count=2,
+        critical_issue_count=0,
+        critical_issue_rate=0.0,
+        mean_satisfaction=0.9,
+        results=[
+            JudgeResult(0, False, 0.9, "ok"),
+            JudgeResult(1, False, 0.9, "ok"),
+        ],
+    )
+    context = MagicMock(llm=MagicMock(), mailbox=AsyncMock())
+
+    with patch(
+        "src.everbot.core.jobs.skill_evaluate.evaluate_skill",
+        new=AsyncMock(return_value=updated),
+    ):
+        result = await _evaluate_one(
+            context, seg_logger, ver_mgr, "web-search", tmp_path / "sessions",
+        )
+
+    assert result is not None
+    assert result.observed_count == 2
+    assert result.eligible_count == 1
+    assert result.evaluated_count == 1
 
 
 def _mk_context(tmp_path: Path):

--- a/tests/unit/test_slm_segment_logger.py
+++ b/tests/unit/test_slm_segment_logger.py
@@ -27,6 +27,32 @@ def _make_segment(skill_id="test-skill", version="1.0", session_id="s1", **kw):
 
 
 class TestSegmentLogger:
+    def test_observation_state_round_trip(self, tmp_path):
+        logger = SegmentLogger(tmp_path)
+
+        logger.save_observation_state(
+            complete=False,
+            session_id="session-1",
+            reason="stream_ended_without_completion",
+            observed_skills=2,
+        )
+
+        state = logger.load_observation_state()
+        assert state is not None
+        assert state["complete"] is False
+        assert state["session_id"] == "session-1"
+        assert state["reason"] == "stream_ended_without_completion"
+        assert state["observed_skills"] == 2
+
+    def test_invalid_observation_state_is_unavailable(self, tmp_path):
+        (tmp_path / ".observation_state.json").write_text("not-json", encoding="utf-8")
+
+        state = SegmentLogger(tmp_path).load_observation_state()
+
+        assert state is not None
+        assert state["complete"] is False
+        assert state["reason"] == "observation_state_invalid"
+
     def test_append_and_load(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             logger = SegmentLogger(Path(tmpdir))


### PR DESCRIPTION
## 变更说明

Closes #187

生产 routine 已迁移至 Milkie，但 SLM 仍从 Dolphin trajectory 识别技能调用，导致新样本与评估报告长期停滞；无样本时任务又被统一记录为成功。

本 PR：

- 在 AgentProvider 边界新增完整性可判定的 `SkillObservationBatch`
- 从真实 Milkie `skill_request` request/response/terminal 事件记录成功技能加载
- 持久化最新观测健康状态，异常时返回 `degraded/observation_unavailable`
- 让 Skill Evaluate 返回结构化 completed/skipped/degraded 终态与 observed/eligible/evaluated 增量计数
- 保留 trajectory 兼容回退，不要求 Milkie 重建旧存储
- 新增 Approved L2 设计：`docs/design/187-skill-observation.md`

## 验收证据

- Unit：`.venv/bin/python -m pytest -q tests/unit` → `2067 passed`
- Integration/相关回归：SLM lifecycle/bootstrap/layered evolve、heartbeat watermark、cron/provider/job → `162 passed`
- 真实 Milkie E2E（Node 22 + 本地 milkie dist）：
  `test_milkie_skill_request_e2e.py test_milkie_run_command_e2e.py test_milkie_serve_smoke.py` → `9 passed`
- E2E 闭环：真实 sidecar skill_request hit/miss → provider observation → 唯一 EvaluationSegment → eval report → 再次执行 skipped/no_changes；全程无 legacy trajectory
- `git diff --check` 通过

## 风险与回滚

旧 JSONL/eval report 格式不变；新增的 `.observation_state.json` 可被旧版本忽略。回滚代码即可，但会恢复 #187 所述观测断链。