### PR TITLE
fix(#188): make memory corrections replace stale profiles

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,3 +36,15 @@ jobs:
           PYTHONPATH: ${{ github.workspace }}
         run: |
           pytest tests/unit/ -m "not integration" -x -q --tb=short
+
+      - name: Run memory review integration tests
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+        run: |
+          pytest tests/integration/test_memory_review_atomicity.py -q --tb=short
+
+      - name: Run memory correction E2E tests
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+        run: |
+          pytest tests/e2e/test_memory_correction_e2e.py -q --tb=short

--- a/docs/design/188-memory-correction.md
+++ b/docs/design/188-memory-correction.md
@@ -1,0 +1,173 @@
+# 【memory】让用户纠正可靠取代陈旧画像
+
+- Issue: #188
+- 状态: Approved
+- 最后更新: 2026-08-02
+
+## 1. 背景
+
+用户在 2026-07-29 明确说明“不再负责 kweaver-core”，但 2026-08-01 的 MEMORY.md 与长期未刷新的 USER.md 仍保留相反画像。现有 Memory Review 只允许合并、降权、强化和原地改写既有记录，无法表达“新事实取代旧事实”或把一条混合记录拆成独立事实；score 低于 0.5 时又直接保留旧 USER.md。Milkie 会话结束路径还跳过 profile extraction，因此纠正只能依赖后续 review 从 session digest 中识别。最后，WorkspaceLoader 同时注入 USER.md 和原始 MEMORY.md，即使旧条目已归档，也可能再次污染下一会话。概要设计见 Issue #188 的 Approved 评论。
+
+## 2. 名词解释
+
+| 术语 | 含义 |
+|------|------|
+| 原子画像事实 | 可独立评分、失效和投影的一项长期用户事实，不混入临时任务或故障日志 |
+| correction | 用户在会话中明确否定或更新一项既有画像事实 |
+| supersede | 新事实取代一个或多个冲突旧事实；旧事实保留溯源但不再 active |
+| split | 将一条混合画像记录替换为多个原子长期事实；不合格的临时内容不进入新画像 |
+| active projection | 从 active 且 score 达阈值的原子事实派生出的 USER.md |
+| commit boundary | MEMORY、USER 与成功 watermark 要么全部更新，要么恢复到执行前状态 |
+
+## 3. 设计目标与非目标
+
+- **目标**：明确纠正不受普通相关性分数约束，在一次成功 review 内取代冲突旧事实。
+- **目标**：旧事实保留 superseded 溯源，但不会进入 USER.md 或下一会话系统提示。
+- **目标**：无 active 事实时原子写入中性 USER.md，不保留旧画像。
+- **目标**：Memory Review 可把混合巨型记录拆成独立长期事实，并排除临时任务和故障日志。
+- **目标**：LLM/解析/文件写入/watermark 失败时不产生半更新，原输入可重试。
+- **非目标**：从用户未明确表达的内容推断新身份或删除事实。
+- **非目标**：恢复所有历史会话、重写事件记忆或改变通用模型供应商。
+- **非目标**：把 USER.md 变成新的事实源；它始终是 MEMORY 的可重建投影。
+
+## 4. 能力与功能设计
+
+Memory Review 将最近 session digest 与完整的现有画像条目交给 consolidation judge。输出在既有 merge/deprecate/reinforce/refine 之外增加两类受约束操作：
+
+- `corrections`：包含纠正后的原子事实与被取代的 active entry IDs。只有 digest 中可定位的用户明确表述才允许生成；至少命中一个既有 active ID 才应用。
+- `split_entries`：指定一个 active 混合条目及 1—8 个长期原子事实。原条目变为 superseded；临时任务、一次性状态和故障日志不得出现在 children 中。
+
+每个新原子条目有稳定 ID、来源 session、active 状态和 `supersedes` 关系；旧条目标记 `superseded` 与 `superseded_by`。重复处理同一纠正或 split 时，已 superseded 的源不再二次应用。
+
+USER.md 每次成功 review 都由 active、score ≥ 0.5 的事实重建。active 为空时写入固定中性投影，结果为 `profile_cleared`；非空时写入带派生标记的压缩投影，结果为 `profile_rebuilt`。WorkspaceLoader 识别该标记后不再把原始 MEMORY.md 注入系统提示，避免 archived/superseded 内容绕过投影门禁。
+
+### 4.1 UI / UX
+
+N/A — 无页面。job completed 结果明确包含 `profile_cleared` 或 `profile_rebuilt:N`；连接、超时、解析或提交异常沿既有 job degraded/failed 事件暴露。
+
+## 5. 设计思路与折衷
+
+选择扩展现有 MEMORY.md 条目元数据，而不是引入数据库或第二套事实仓库。现有条目 ID、分数、来源和 Markdown 运维可读性得以保留，旧格式可无损按 active 读取。superseded 条目仍留在 Archived Memories，提供最小可追踪关系。
+
+选择由 review 从 Milkie 已落盘 session digest 识别 correction，而不是等待会话结束 extraction bridge。这样直接修复当前生产路径，且 watermark 天然提供失败重试输入。未来补齐 Milkie session-end extraction 后，两者仍可通过 stable relation 与幂等门禁共存。
+
+选择先完成两次 LLM 计算，再进入短提交临界区；提交前校验 MEMORY 快照未并发变化，提交中原子替换 MEMORY、USER、watermark，任一步失败则用执行前快照恢复。放弃“先改 MEMORY 再调用压缩 LLM”，因为压缩超时会留下半更新。放弃仅降低 0.5 阈值，因为会重新注入低质量巨型记录且无法表达冲突。
+
+选择 USER.md 作为会话画像唯一投影。放弃继续同时注入原始 MEMORY.md，因为后者必须保留 superseded 溯源，两者同时注入会破坏失效语义。
+
+## 6. 架构设计
+
+### 6.1 逻辑分层
+
+```mermaid
+flowchart LR
+  S["Milkie session JSON"] --> D["SessionScanner digest"]
+  D --> J["Memory Review judge"]
+  M["MEMORY.md current facts"] --> J
+  J --> P["Pure review projection\ncorrection/split/merge"]
+  P --> C["Recoverable commit boundary"]
+  C --> M2["MEMORY.md\nactive + superseded"]
+  C --> U["USER.md\nderived active projection"]
+  C --> W["memory-review watermark"]
+  U --> L["WorkspaceLoader"]
+  M2 -. "not injected when derived marker exists" .-> L
+```
+
+### 6.2 核心业务流程
+
+```mermaid
+sequenceDiagram
+  participant R as Memory Review
+  participant J as LLM Judge
+  participant MM as MemoryManager
+  participant FS as Workspace Files
+
+  R->>FS: read sessions, MEMORY, USER, watermark snapshots
+  R->>J: analyze explicit corrections and atomic splits
+  J-->>R: validated review operations
+  R->>MM: preview_review(expected snapshot)
+  R->>J: compress projected active facts
+  J-->>R: USER projection
+  R->>MM: commit if MEMORY snapshot unchanged
+  MM->>FS: atomic replace MEMORY
+  MM->>FS: atomic replace USER
+  MM->>FS: atomic replace watermark
+  alt any commit failure
+    MM->>FS: restore all pre-run snapshots
+  end
+```
+
+失败路径：consolidation 或 compression 连接错误、超时、配置错误、JSON 解析失败均在提交前终止；并发 MEMORY 变化使本轮失败并保留 watermark；文件替换失败触发三文件回滚。下一次成功 review 使用同一 watermark 重新读取纠正。
+
+## 7. 模块设计
+
+| 模块 | 契约变化 |
+|------|----------|
+| `core/memory/models.py` | `MemoryEntry` 增加 active/superseded 状态与双向取代关系 |
+| `core/memory/profile_store.py` | 保持旧 header，兼容读取可选关系 metadata comment 并使用原子替换；active 选择排除 superseded |
+| `core/memory/manager.py` | 纯 review projection、correction/split 校验与幂等应用、快照一致性提交 |
+| `core/jobs/memory_review.py` | 从 digest 生成 correction/split，先预览和压缩再提交，返回可观察 profile 结果 |
+| `core/jobs/system_dphs/memory_review_consolidation.dph` | 约束明确纠正、原子 split 与临时内容排除 |
+| `infra/workspace.py` | 派生 USER.md 存在时只注入 USER 投影，不再注入原始 MEMORY |
+| `core/scanners/reflection_state.py` | 保存失败可被调用方检测，避免伪推进 watermark |
+
+## 8. API / CLI 设计
+
+无公共 API/CLI。内部 review JSON 增量契约：
+
+```json
+{
+  "corrections": [{
+    "content": "用户现在不负责项目 A",
+    "category": "fact",
+    "supersedes_ids": ["old123"],
+    "source_session": "session-id"
+  }],
+  "split_entries": [{
+    "id": "giant1",
+    "entries": [
+      {"content": "用户偏好简洁输出", "category": "preference", "importance": "high"}
+    ]
+  }]
+}
+```
+
+旧的 merge/deprecate/reinforce/refined 字段继续兼容。未知 ID、空 correction、无明确 supersedes、对已 superseded 源的重复操作均跳过并记录 warning。
+
+## 9. 边界考虑
+
+- correction 必须引用 digest 中用户明确说法和至少一个冲突 active ID；助手承诺或模型推断不能单独触发删除。
+- 纠正新事实初始 score 固定为高优先级，不受被纠正巨型记录的低分影响。
+- split 每个 child 必须非空、类别合法、数量有界；一次性任务/故障默认丢弃而不是迁入 profile。
+- 旧格式没有状态字段时按 active 读取；损坏关系元数据不影响其他条目加载。
+- superseded 内容保留在 MEMORY 但不进入 prompt、profile compression 或 prompt recall。
+- USER 内容和模型输出有长度上限；空画像使用固定文本，不调用 compression LLM。
+- 文件不保存密钥；失败日志只含稳定原因与 entry/session ID。
+- 提交锁覆盖 MEMORY/USER/watermark 快照校验和替换；同一 correction 重放必须幂等。
+
+## 10. 迁移 / 兼容 / 回滚
+
+首次成功写 MEMORY 时，旧 header 下方自动补可选关系 metadata comment；没有 metadata 的条目按 active 读取，无需一次性批处理。现有巨型记录只在 judge 明确输出 split/correction 时迁移，旧条目保留为 superseded。旧 USER.md 在首次成功 review 时被原子重建；没有 active 事实则写中性投影。
+
+回滚代码后，旧 parser 仍能按原 header 读取条目，关系 metadata comment 只会成为无害的附加文本；若需恢复旧失效语义则使用 `MEMORY.md.bak`。USER.md 的派生标记也是 HTML comment，旧 WorkspaceLoader 可安全注入。watermark 格式不变。
+
+## 11. 测试计划
+
+- **E2E**：用真实 session JSON 与 WorkspaceLoader 构造旧 MEMORY/USER，用户消息明确“我现在不负责项目 A”；确定性 judge 输出 correction。运行完整 Memory Review 后断言旧 entry 为 superseded、新 entry 关联来源、USER 不含仍负责表述；重新构建下一会话 system prompt 并用确定性回答器验证答案不是“仍负责”。同一 fixture 再运行一次断言幂等。第二条 E2E 构造全低分/失效事实，断言 USER 被清为中性投影且 MEMORY 不被注入。
+- **Integration**：在 consolidation、compression、MEMORY replace、USER replace、watermark replace 注入连接错误/超时/写失败，断言三个文件和 watermark 均保持执行前快照；恢复后一次成功执行收敛。提交前并发插入新事实应拒绝本轮而不丢数据。
+- **Unit**：新旧 header round-trip；active/superseded 过滤；correction/split 校验与重复处理；混合巨型记录拆分；原子 USER 写与空投影；WorkspaceLoader 单一投影门禁。
+
+## 12. 开放问题 / 决策记录
+
+- 2026-08-02：Approved L1 后采用 MEMORY 事实源 + USER 派生投影，不以降低 score 阈值修复。
+- 2026-08-02：Milkie correction 先由 review digest 路径处理；session-end extraction bridge 不阻塞本 issue。
+- 2026-08-02：旧事实保留溯源但不注入；会话行为以新 WorkspaceLoader system prompt 为最终验收事实源。
+
+## 13. 关联
+
+- Issue #188
+- 概要：Issue #188 Approved 设计评论
+- PR：待创建
+- `src/everbot/core/jobs/memory_review.py`
+- `src/everbot/core/memory/`
+- `src/everbot/infra/workspace.py`

--- a/docs/design/188-memory-correction.md
+++ b/docs/design/188-memory-correction.md
@@ -1,7 +1,7 @@
 # 【memory】让用户纠正可靠取代陈旧画像
 
 - Issue: #188
-- 状态: Approved
+- 状态: Implemented
 - 最后更新: 2026-08-02
 
 ## 1. 背景
@@ -167,7 +167,7 @@ sequenceDiagram
 
 - Issue #188
 - 概要：Issue #188 Approved 设计评论
-- PR：待创建
+- PR：[GitHub #190](https://github.com/xforce-io/alfred/pull/190)
 - `src/everbot/core/jobs/memory_review.py`
 - `src/everbot/core/memory/`
 - `src/everbot/infra/workspace.py`

--- a/docs/design/188-memory-correction.md
+++ b/docs/design/188-memory-correction.md
@@ -105,11 +105,12 @@ sequenceDiagram
 |------|----------|
 | `core/memory/models.py` | `MemoryEntry` 增加 active/superseded 状态与双向取代关系 |
 | `core/memory/profile_store.py` | 保持旧 header，兼容读取可选关系 metadata comment 并使用原子替换；active 选择排除 superseded |
-| `core/memory/manager.py` | 纯 review projection、correction/split 校验与幂等应用、快照一致性提交 |
-| `core/jobs/memory_review.py` | 从 digest 生成 correction/split，先预览和压缩再提交，返回可观察 profile 结果 |
+| `core/memory/manager.py` | 纯 review projection、correction/split 校验与幂等应用；等价 correction 合并来源关系，不产生重复 active；快照一致性提交 |
+| `core/jobs/memory_review.py` | prompt、source allowlist、watermark 共用同一个 analyzed-session batch；先预览和压缩再提交；无 session bootstrap 也使用锁与 MEMORY fingerprint |
 | `core/jobs/system_dphs/memory_review_consolidation.dph` | 约束明确纠正、原子 split 与临时内容排除 |
 | `infra/workspace.py` | 派生 USER.md 存在时只注入 USER 投影，不再注入原始 MEMORY |
 | `core/scanners/reflection_state.py` | 保存失败可被调用方检测，避免伪推进 watermark |
+| `core/tasks/execution_gate.py` | 若 job 已把 watermark 推到精确处理边界，gate 保留该值；否则维持成功后推进到当前时间的防自触发语义 |
 
 ## 8. API / CLI 设计
 
@@ -132,7 +133,7 @@ sequenceDiagram
 }
 ```
 
-旧的 merge/deprecate/reinforce/refined 字段继续兼容。未知 ID、空 correction、无明确 supersedes、对已 superseded 源的重复操作均跳过并记录 warning。
+旧的 merge/deprecate/reinforce/refined 字段继续兼容。未知 ID、空 correction、无明确 supersedes 均跳过并记录 warning。对已由同一等价 active replacement 取代的源执行重放时静默 no-op；部分重叠来源合并进既有 replacement 的关系，不新建重复 active。
 
 ## 9. 边界考虑
 
@@ -141,6 +142,7 @@ sequenceDiagram
 - split 每个 child 必须非空、类别合法、数量有界；一次性任务/故障默认丢弃而不是迁入 profile。
 - 旧格式没有状态字段时按 active 读取；损坏关系元数据不影响其他条目加载。
 - superseded 内容保留在 MEMORY 但不进入 prompt、profile compression 或 prompt recall。
+- scanner 可以发现多于单次 judge 预算的 session，但 prompt、纠正来源 allowlist 与成功 watermark 必须使用同一 analyzed batch；watermark 不得越过未送入 judge 的 session。
 - USER 内容和模型输出有长度上限；空画像使用固定文本，不调用 compression LLM。
 - 文件不保存密钥；失败日志只含稳定原因与 entry/session ID。
 - 提交锁覆盖 MEMORY/USER/watermark 快照校验和替换；同一 correction 重放必须幂等。
@@ -154,14 +156,15 @@ sequenceDiagram
 ## 11. 测试计划
 
 - **E2E**：用真实 session JSON 与 WorkspaceLoader 构造旧 MEMORY/USER，用户消息明确“我现在不负责项目 A”；确定性 judge 输出 correction。运行完整 Memory Review 后断言旧 entry 为 superseded、新 entry 关联来源、USER 不含仍负责表述；重新构建下一会话 system prompt 并用确定性回答器验证答案不是“仍负责”。同一 fixture 再运行一次断言幂等。第二条 E2E 构造全低分/失效事实，断言 USER 被清为中性投影且 MEMORY 不被注入。
-- **Integration**：在 consolidation、compression、MEMORY replace、USER replace、watermark replace 注入连接错误/超时/写失败，断言三个文件和 watermark 均保持执行前快照；恢复后一次成功执行收敛。提交前并发插入新事实应拒绝本轮而不丢数据。
-- **Unit**：新旧 header round-trip；active/superseded 过滤；correction/split 校验与重复处理；混合巨型记录拆分；原子 USER 写与空投影；WorkspaceLoader 单一投影门禁。
+- **Integration**：在 consolidation、compression、MEMORY replace、USER replace、watermark replace 注入连接错误/超时/写失败，断言三个文件和 watermark 均保持执行前快照；恢复后一次成功执行收敛。提交前并发插入新事实应拒绝本轮而不丢数据。构造 5 个 pending session 且纠正在第 5 个：首轮只分析前三个并把 watermark 停在第 3 个，次轮必须应用纠正。无 session bootstrap 渲染期间 MEMORY 变化时拒绝陈旧 USER 写入，写失败恢复原 USER。
+- **Unit**：新旧 header round-trip；active/superseded 过滤；correction/split 校验与精确/部分重叠重放；Judge 上下文排除 superseded；混合巨型记录拆分；原子 USER 写与空投影；gate 保留 job 自管 watermark 且普通路径仍推进当前时间；WorkspaceLoader 单一投影门禁。
 
 ## 12. 开放问题 / 决策记录
 
 - 2026-08-02：Approved L1 后采用 MEMORY 事实源 + USER 派生投影，不以降低 score 阈值修复。
 - 2026-08-02：Milkie correction 先由 review digest 路径处理；session-end extraction bridge 不阻塞本 issue。
 - 2026-08-02：旧事实保留溯源但不注入；会话行为以新 WorkspaceLoader system prompt 为最终验收事实源。
+- 2026-08-02：analyzed-session batch 是 prompt、source allowlist 和 watermark 的共同事实边界；TaskExecutionGate 不覆盖 job 已提交的精确边界。
 
 ## 13. 关联
 

--- a/src/everbot/core/agent/provider/base.py
+++ b/src/everbot/core/agent/provider/base.py
@@ -1,9 +1,9 @@
-"""Neutral AgentProvider port. MUST NOT import dolphin.
+"""Neutral AgentProvider port.
 
 This module defines only provider-neutral *capabilities* (the methods any
-agent runtime must offer).  Dolphin-specific storage details (e.g. the history
-variable key) intentionally do NOT live here — consumers that need them import
-from the allowlisted compat layer instead.
+agent runtime must offer). Storage details (e.g. the history variable key)
+intentionally do NOT live here — consumers that need them import from the
+compat constants module instead.
 """
 from __future__ import annotations
 
@@ -15,9 +15,8 @@ from typing import Any, AsyncIterator, Optional, Protocol, runtime_checkable
 class AgentProvider(Protocol):
     """Provider-neutral port for agent-runtime capabilities.
 
-    The active implementation (currently :class:`DolphinProvider`) hides all
-    dolphin-specific types behind this surface so that alfred's mainline code
-    never imports dolphin directly.
+    The active implementation is :class:`MilkieProvider`. Mainline alfred code
+    talks to agents only through this surface.
     """
 
     async def create_agent(
@@ -99,10 +98,10 @@ class AgentProvider(Protocol):
         ...
 
     def needs_history_restore(self) -> bool:
-        """是否需要 alfred 把存档历史灌回 agent。
+        """Whether alfred must push archived history back into the live agent.
 
-        dolphin(进程内)True;milkie(serve 自持久化,重启从 checkpoint 恢复)False。
-        ``restore_to_agent`` 据此 short-circuit。
+        milkie serve self-persists and restores from its own checkpoint, so the
+        implementation returns False and restore callers short-circuit.
         """
         ...
 
@@ -115,5 +114,5 @@ class AgentProvider(Protocol):
         ...
 
     async def shutdown_sidecars(self) -> None:
-        """Close any spawned sidecar processes. No-op for in-process providers (dolphin)."""
+        """Close any spawned sidecar processes. No-op when none are owned."""
         ...

--- a/src/everbot/core/jobs/memory_review.py
+++ b/src/everbot/core/jobs/memory_review.py
@@ -84,19 +84,21 @@ async def run(context: SkillContext) -> Optional[str]:
     memory_path = context.memory_manager.store.memory_path
     user_path = context.workspace_path / "USER.md"
     state_path = context.workspace_path / ".reflection_state.json"
-    snapshots = {
-        memory_path: _snapshot_file(memory_path),
-        user_path: _snapshot_file(user_path),
-        state_path: _snapshot_file(state_path),
-    }
     expected = context.memory_manager.entries_fingerprint(existing)
     with context.memory_manager.review_lock():
+        snapshots = {
+            memory_path: _snapshot_file(memory_path),
+            user_path: _snapshot_file(user_path),
+            state_path: _snapshot_file(state_path),
+        }
+        memory_committed = False
         try:
             context.memory_manager.commit_review(
                 projected,
                 expected_fingerprint=expected,
                 lock_already_held=True,
             )
+            memory_committed = True
             _atomic_write_profile(user_path, profile_content)
             if analyzed_sessions:
                 state.set_watermark(
@@ -105,8 +107,22 @@ async def run(context: SkillContext) -> Optional[str]:
                 if not state.save(context.workspace_path):
                     raise OSError("failed to persist memory-review watermark")
         except Exception:
-            for path, snapshot in snapshots.items():
-                _restore_file(path, snapshot)
+            # A fingerprint mismatch happens before this review writes anything.
+            # Restoring in that case would overwrite the concurrent writer that
+            # caused the mismatch.  Once MEMORY was committed, however, all
+            # three files belong to this transaction and must roll back together.
+            review_changed_memory = memory_committed
+            if not review_changed_memory:
+                current = context.memory_manager.load_entries()
+                current_fingerprint = context.memory_manager.entries_fingerprint(current)
+                projected_fingerprint = context.memory_manager.entries_fingerprint(projected)
+                review_changed_memory = (
+                    projected_fingerprint != expected
+                    and current_fingerprint == projected_fingerprint
+                )
+            if review_changed_memory:
+                for path, snapshot in snapshots.items():
+                    _restore_file(path, snapshot)
             raise
 
     logger.info("Memory review: %s, profile: %s", review_stats, profile_result)
@@ -180,18 +196,47 @@ def _review_digest_window(digest: str, limit: int = 2000) -> str:
 
 
 def _validate_review_sources(review: dict, session_ids: List[str]) -> dict:
-    """Reject corrective facts whose claimed source is outside this review batch."""
+    """Validate provenance without silently consuming an analyzed session.
+
+    A missing source is unambiguous only for a one-session batch.  Any other
+    missing or out-of-batch source fails the whole review so its watermark can
+    be retried instead of permanently skipping a correction or split.
+    """
     allowed = set(session_ids)
-    corrections = []
-    for item in review.get("corrections", []):
-        if not isinstance(item, dict):
-            continue
-        source = str(item.get("source_session", ""))
+    sole_source = session_ids[0] if len(session_ids) == 1 else None
+
+    def validate_source(item: dict, operation: str) -> None:
+        source = str(item.get("source_session", "")).strip()
+        if not source and sole_source:
+            item["source_session"] = sole_source
+            return
         if source not in allowed:
-            logger.warning("Skipping correction with untrusted source session: %s", source)
-            continue
+            raise ValueError(
+                f"{operation} has invalid source_session {source!r}; "
+                "memory review must retry"
+            )
+
+    raw_corrections = review.get("corrections", [])
+    if not isinstance(raw_corrections, list):
+        raise ValueError("corrections must be a list")
+    corrections = []
+    for item in raw_corrections:
+        if not isinstance(item, dict):
+            raise ValueError("correction must be an object with source_session")
+        validate_source(item, "correction")
         corrections.append(item)
     review["corrections"] = corrections
+
+    raw_splits = review.get("split_entries", [])
+    if not isinstance(raw_splits, list):
+        raise ValueError("split_entries must be a list")
+    for split in raw_splits:
+        if not isinstance(split, dict) or not isinstance(split.get("entries", []), list):
+            raise ValueError("split entry must contain an entries list")
+        for child in split.get("entries", []):
+            if not isinstance(child, dict):
+                raise ValueError("split child must be an object with source_session")
+            validate_source(child, "split child")
     return review
 
 

--- a/src/everbot/core/jobs/memory_review.py
+++ b/src/everbot/core/jobs/memory_review.py
@@ -13,6 +13,7 @@ from .llm_utils import parse_json_response, parse_system_dph
 logger = logging.getLogger(__name__)
 _DERIVED_PROFILE_MARKER = "<!-- derived_from_memory: true -->"
 _EMPTY_PROFILE = "（暂无活跃画像）"
+_MAX_ANALYZED_SESSIONS = 3
 
 
 async def run(context: SkillContext) -> Optional[str]:
@@ -36,22 +37,26 @@ async def run(context: SkillContext) -> Optional[str]:
         current_user = user_path.read_text(encoding="utf-8") if user_path.exists() else ""
         if _DERIVED_PROFILE_MARKER in current_user:
             return None
+        existing = context.memory_manager.load_entries()
         profile_content, profile_result = await _render_user_profile(
-            context, context.memory_manager.load_entries(),
+            context, existing,
         )
-        _atomic_write_profile(user_path, profile_content)
+        _commit_profile_if_memory_unchanged(
+            context,
+            user_path,
+            profile_content,
+            existing,
+        )
         return profile_result
 
     # 2. Extract digests, skip failed sessions
-    digests, digest_session_ids = [], []
-    last_successful_session = None
+    digests, successful_sessions = [], []
     for s in sessions:
         try:
             digests.append(
                 f"[source_session:{s.id}]\n{scanner.extract_digest(s.path)}"
             )
-            digest_session_ids.append(s.id)
-            last_successful_session = s
+            successful_sessions.append(s)
         except Exception as e:
             logger.warning("Failed to extract session %s: %s, skipping", s.id, e)
             continue
@@ -59,10 +64,17 @@ async def run(context: SkillContext) -> Optional[str]:
     if not digests:
         return None
 
-    # 3. Consolidation analysis (single LLM call)
+    # 3. Consolidation analysis (single LLM call).  Every downstream boundary
+    # uses this exact batch: prompt, correction source allowlist, and watermark.
+    analyzed_digests = digests[:_MAX_ANALYZED_SESSIONS]
+    analyzed_sessions = successful_sessions[:_MAX_ANALYZED_SESSIONS]
     existing = context.memory_manager.load_entries()
-    review = await _analyze_memory_consolidation(context.llm, digests, existing)
-    review = _validate_review_sources(review, digest_session_ids)
+    review = await _analyze_memory_consolidation(
+        context.llm, analyzed_digests, existing,
+    )
+    review = _validate_review_sources(
+        review, [session.id for session in analyzed_sessions],
+    )
 
     # 4. Project in memory and finish all LLM work before mutating any file.
     projected, review_stats = context.memory_manager.preview_review(review, existing)
@@ -86,8 +98,10 @@ async def run(context: SkillContext) -> Optional[str]:
                 lock_already_held=True,
             )
             _atomic_write_profile(user_path, profile_content)
-            if last_successful_session:
-                state.set_watermark("memory-review", last_successful_session.updated_at)
+            if analyzed_sessions:
+                state.set_watermark(
+                    "memory-review", analyzed_sessions[-1].updated_at,
+                )
                 if not state.save(context.workspace_path):
                     raise OSError("failed to persist memory-review watermark")
         except Exception:
@@ -110,13 +124,19 @@ async def _analyze_memory_consolidation(llm, digests: List[str], existing_entrie
     if not existing_entries:
         return {}
 
+    active_entries = [
+        entry for entry in existing_entries if entry.status == "active"
+    ]
+    if not active_entries:
+        return {}
+
     existing_text = "\n".join(
         f"- [{e.id}] [{e.category}] (score={e.score:.2f}, count={e.activation_count}) {e.content}"
-        for e in existing_entries
+        for e in active_entries
     )
     # Corrections often occur near the end of a long session. Preserve the
     # source header plus the recent tail instead of truncating at 500 chars.
-    context_text = "\n".join(_review_digest_window(d) for d in digests[:3])
+    context_text = "\n".join(_review_digest_window(d) for d in digests)
 
     from pathlib import Path
 
@@ -227,6 +247,28 @@ def _atomic_write_profile(path: Path, content: str) -> None:
     tmp = path.with_suffix(".md.tmp")
     tmp.write_text(content, encoding="utf-8")
     os.replace(tmp, path)
+
+
+def _commit_profile_if_memory_unchanged(
+    context: SkillContext,
+    user_path: Path,
+    profile_content: str,
+    existing_entries,
+) -> None:
+    """Commit a bootstrap USER projection against an unchanged MEMORY view."""
+    from ..memory.manager import IntegrityError
+
+    expected = context.memory_manager.entries_fingerprint(existing_entries)
+    with context.memory_manager.review_lock():
+        current = context.memory_manager.load_entries()
+        if context.memory_manager.entries_fingerprint(current) != expected:
+            raise IntegrityError("Memory changed concurrently; profile must retry")
+        user_snapshot = _snapshot_file(user_path)
+        try:
+            _atomic_write_profile(user_path, profile_content)
+        except Exception:
+            _restore_file(user_path, user_snapshot)
+            raise
 
 
 def _snapshot_file(path: Path) -> Optional[bytes]:

--- a/src/everbot/core/jobs/memory_review.py
+++ b/src/everbot/core/jobs/memory_review.py
@@ -1,10 +1,8 @@
-"""Memory review skill — consolidate and optimize agent memory.
-
-Silent execution, no user notification.
-Strategy: consolidate existing entries, then compress to USER.md profile.
-"""
+"""Memory review — consolidate facts and rebuild the USER.md projection."""
 
 import logging
+import os
+from pathlib import Path
 from typing import List, Optional
 
 from ..runtime.skill_context import SkillContext
@@ -13,15 +11,16 @@ from ..scanners.reflection_state import ReflectionState
 from .llm_utils import parse_json_response, parse_system_dph
 
 logger = logging.getLogger(__name__)
+_DERIVED_PROFILE_MARKER = "<!-- derived_from_memory: true -->"
+_EMPTY_PROFILE = "（暂无活跃画像）"
 
 
 async def run(context: SkillContext) -> Optional[str]:
     """Execute memory review: consolidate entries and compress to profile.
 
-    Returns None — this job is silent by contract; review/compression
-    stats are recorded via logger only and never surfaced to the user.
-    Integrity errors still log at ERROR but are not pushed: the next
-    review run self-heals and a persistent failure shows up in metrics.
+    Returns a concise profile terminal when a projection was cleared or
+    rebuilt, and None only for a true no-change run. Failures propagate so
+    cron records degraded/failed and the unchanged watermark permits retry.
     """
     scanner = SessionScanner(context.sessions_dir)
     state = ReflectionState.load(context.workspace_path)
@@ -33,14 +32,24 @@ async def run(context: SkillContext) -> Optional[str]:
     else:
         sessions = scanner.get_reviewable_sessions(skill_wm, agent_name=context.agent_name)
     if not sessions:
-        return None
+        user_path = context.workspace_path / "USER.md"
+        current_user = user_path.read_text(encoding="utf-8") if user_path.exists() else ""
+        if _DERIVED_PROFILE_MARKER in current_user:
+            return None
+        profile_content, profile_result = await _render_user_profile(
+            context, context.memory_manager.load_entries(),
+        )
+        _atomic_write_profile(user_path, profile_content)
+        return profile_result
 
     # 2. Extract digests, skip failed sessions
     digests, digest_session_ids = [], []
     last_successful_session = None
     for s in sessions:
         try:
-            digests.append(scanner.extract_digest(s.path))
+            digests.append(
+                f"[source_session:{s.id}]\n{scanner.extract_digest(s.path)}"
+            )
             digest_session_ids.append(s.id)
             last_successful_session = s
         except Exception as e:
@@ -53,34 +62,44 @@ async def run(context: SkillContext) -> Optional[str]:
     # 3. Consolidation analysis (single LLM call)
     existing = context.memory_manager.load_entries()
     review = await _analyze_memory_consolidation(context.llm, digests, existing)
+    review = _validate_review_sources(review, digest_session_ids)
 
-    # 4. Apply consolidation + post-validation
-    entries_before = len(existing)
-    from ..memory.manager import IntegrityError
-    try:
-        review_stats = context.memory_manager.apply_review(review)
-    except IntegrityError as e:
-        logger.error("Memory consolidation integrity violation: %s", e)
-        return None
+    # 4. Project in memory and finish all LLM work before mutating any file.
+    projected, review_stats = context.memory_manager.preview_review(review, existing)
+    profile_content, profile_result = await _render_user_profile(context, projected)
 
-    # Defense against concurrent writes: apply_review holds flock but another
-    # process_session_end could have inserted entries between our load and save.
-    entries_after = len(context.memory_manager.load_entries())
-    if entries_after > entries_before:
-        logger.warning(
-            "Entries increased after review (likely concurrent write): %d → %d",
-            entries_before, entries_after,
-        )
+    # 5. Recoverable commit boundary: MEMORY + USER + watermark.
+    memory_path = context.memory_manager.store.memory_path
+    user_path = context.workspace_path / "USER.md"
+    state_path = context.workspace_path / ".reflection_state.json"
+    snapshots = {
+        memory_path: _snapshot_file(memory_path),
+        user_path: _snapshot_file(user_path),
+        state_path: _snapshot_file(state_path),
+    }
+    expected = context.memory_manager.entries_fingerprint(existing)
+    with context.memory_manager.review_lock():
+        try:
+            context.memory_manager.commit_review(
+                projected,
+                expected_fingerprint=expected,
+                lock_already_held=True,
+            )
+            _atomic_write_profile(user_path, profile_content)
+            if last_successful_session:
+                state.set_watermark("memory-review", last_successful_session.updated_at)
+                if not state.save(context.workspace_path):
+                    raise OSError("failed to persist memory-review watermark")
+        except Exception:
+            for path, snapshot in snapshots.items():
+                _restore_file(path, snapshot)
+            raise
 
-    # 5. Compress memories → USER.md
-    compress_result = await _compress_to_user_profile(context)
-
-    # Advance watermark — if we got here, both LLM calls succeeded.
-    if last_successful_session:
-        state.set_watermark("memory-review", last_successful_session.updated_at)
-        state.save(context.workspace_path)
-    logger.info("Memory review: %s, profile: %s", review_stats, compress_result)
-    return None
+    logger.info("Memory review: %s, profile: %s", review_stats, profile_result)
+    return (
+        f"{profile_result}; corrected={review_stats['corrected']}; "
+        f"split={review_stats['split']}"
+    )
 
 
 async def _analyze_memory_consolidation(llm, digests: List[str], existing_entries) -> dict:
@@ -95,7 +114,9 @@ async def _analyze_memory_consolidation(llm, digests: List[str], existing_entrie
         f"- [{e.id}] [{e.category}] (score={e.score:.2f}, count={e.activation_count}) {e.content}"
         for e in existing_entries
     )
-    context_text = "\n".join(d[:500] for d in digests[:3])
+    # Corrections often occur near the end of a long session. Preserve the
+    # source header plus the recent tail instead of truncating at 500 chars.
+    context_text = "\n".join(_review_digest_window(d) for d in digests[:3])
 
     from pathlib import Path
 
@@ -114,6 +135,8 @@ async def _analyze_memory_consolidation(llm, digests: List[str], existing_entrie
         **dph_data["config"]
     )
     result = parse_json_response(response)
+    if not isinstance(result, dict):
+        raise ValueError("memory review response must be a JSON object")
 
     # Validate entropy constraint
     merge_count = len(result.get("merge_pairs", []))
@@ -130,26 +153,53 @@ async def _analyze_memory_consolidation(llm, digests: List[str], existing_entrie
     return result
 
 
+def _review_digest_window(digest: str, limit: int = 2000) -> str:
+    if len(digest) <= limit:
+        return digest
+    return f"{digest[:200]}\n...[earlier context truncated]...\n{digest[-(limit - 240):]}"
+
+
+def _validate_review_sources(review: dict, session_ids: List[str]) -> dict:
+    """Reject corrective facts whose claimed source is outside this review batch."""
+    allowed = set(session_ids)
+    corrections = []
+    for item in review.get("corrections", []):
+        if not isinstance(item, dict):
+            continue
+        source = str(item.get("source_session", ""))
+        if source not in allowed:
+            logger.warning("Skipping correction with untrusted source session: %s", source)
+            continue
+        corrections.append(item)
+    review["corrections"] = corrections
+    return review
+
+
 async def _compress_to_user_profile(context: SkillContext) -> str:
     """Compress all memory entries into structured tags and write to USER.md.
 
     This replaces verbose narrative memories with a compact user profile
     that is injected into the system prompt via the USER.md section.
     """
-    entries = context.memory_manager.load_entries()
-    if not entries:
-        return "no entries"
+    content, result = await _render_user_profile(
+        context, context.memory_manager.load_entries(),
+    )
+    _atomic_write_profile(context.workspace_path / "USER.md", content)
+    return result
 
-    # Only compress entries with reasonable score
-    active = [e for e in entries if e.score >= 0.5]
+
+async def _render_user_profile(context: SkillContext, entries) -> tuple[str, str]:
+    """Render a USER.md projection without writing it."""
+    active = [e for e in entries if e.status == "active" and e.score >= 0.5]
     if not active:
-        return "no active entries"
+        return (
+            f"# 用户画像\n\n{_DERIVED_PROFILE_MARKER}\n\n{_EMPTY_PROFILE}\n",
+            "profile_cleared",
+        )
 
     entries_text = "\n".join(
         f"- [{e.category}] {e.content}" for e in active
     )
-
-    from pathlib import Path
 
     dph_path = Path(__file__).parent / "system_dphs" / "memory_review_compression.dph"
     dph_data = parse_system_dph(str(dph_path), {
@@ -166,11 +216,29 @@ async def _compress_to_user_profile(context: SkillContext) -> str:
     )
     profile_content = response.strip()
 
-    # Write to USER.md
-    user_md_path = context.workspace_path / "USER.md"
-    user_md_path.write_text(
-        f"# 用户画像\n\n{profile_content}\n",
-        encoding="utf-8",
+    return (
+        f"# 用户画像\n\n{_DERIVED_PROFILE_MARKER}\n\n{profile_content}\n",
+        f"profile_rebuilt:{len(active)}",
     )
-    logger.info("Compressed %d memory entries to USER.md", len(active))
-    return f"compressed {len(active)} entries"
+
+
+def _atomic_write_profile(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".md.tmp")
+    tmp.write_text(content, encoding="utf-8")
+    os.replace(tmp, path)
+
+
+def _snapshot_file(path: Path) -> Optional[bytes]:
+    return path.read_bytes() if path.exists() else None
+
+
+def _restore_file(path: Path, snapshot: Optional[bytes]) -> None:
+    """Restore one file atomically after a failed multi-file commit."""
+    if snapshot is None:
+        path.unlink(missing_ok=True)
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".rollback")
+    tmp.write_bytes(snapshot)
+    os.replace(tmp, path)

--- a/src/everbot/core/jobs/system_dphs/memory_review_consolidation.dph
+++ b/src/everbot/core/jobs/system_dphs/memory_review_consolidation.dph
@@ -8,13 +8,17 @@ $existing_text
 $context_text
 
 ## Tasks
-1. Find pairs of entries that can be merged (similar or overlapping content)
-2. Find entries that are outdated or no longer relevant (deprecate)
-3. Find entries reinforced by recent conversations (reinforce)
-4. Find entries whose content can be refined for clarity (refine, in-place update only)
+1. Detect explicit user corrections that contradict current entries (corrections)
+2. Split any giant entry that mixes independent durable facts with temporary tasks/incidents (split_entries)
+3. Find pairs of atomic entries that can be merged (similar or overlapping content)
+4. Find entries that are outdated or no longer relevant (deprecate)
+5. Find entries reinforced by recent conversations (reinforce)
+6. Find entries whose content can be refined for clarity (refine, in-place update only)
 
 ## Constraints
 - merge: creates 1 new entry, removes 2 → net -1
+- correction: only when a [user] statement explicitly denies/updates a current fact; it must name every superseded current ID and preserve the user's corrected current state
+- split: only for one mixed source entry; emit 1-8 independent long-term user facts and omit temporary tasks, incidents, logs, and assistant claims
 - deprecate: reduces score (accelerates natural decay)
 - reinforce: boosts score of existing entry
 - refine: updates content in-place, no score change
@@ -24,6 +28,8 @@ Output format:
 ```json
 {
   "merge_pairs": [{"id_a": "...", "id_b": "...", "merged_content": "..."}],
+  "corrections": [{"content": "...", "category": "fact", "supersedes_ids": ["..."], "source_session": "session ID from context"}],
+  "split_entries": [{"id": "...", "entries": [{"content": "...", "category": "preference|fact|workflow|decision|experience", "importance": "high|medium|low", "source_session": "..."}]}],
   "deprecate_ids": ["..."],
   "reinforce_ids": ["..."],
   "refined_entries": [{"id": "...", "content": "..."}]

--- a/src/everbot/core/memory/manager.py
+++ b/src/everbot/core/memory/manager.py
@@ -409,20 +409,53 @@ class MemoryManager:
             source_ids = list(dict.fromkeys(
                 str(value) for value in item.get("supersedes_ids", []) if value
             ))
+            if not content or category not in _PROFILE_CATEGORIES or not source_ids:
+                logger.warning("Skipping invalid memory correction for IDs %s", source_ids)
+                continue
+
+            normalized_content = _normalize_fact(content)
+            replacement = next((
+                entry
+                for entry in entry_map.values()
+                if entry.status == "active"
+                and entry.id not in source_ids
+                and entry.category == category
+                and _normalize_fact(entry.content) == normalized_content
+            ), None)
             sources = [
                 entry_map[source_id]
                 for source_id in source_ids
                 if source_id in entry_map and entry_map[source_id].status == "active"
             ]
-            if not content or category not in _PROFILE_CATEGORIES or not sources:
+            if replacement is not None:
+                new_sources = [
+                    source for source in sources if source.id != replacement.id
+                ]
+                if new_sources:
+                    replacement.supersedes = list(dict.fromkeys(
+                        replacement.supersedes
+                        + [source.id for source in new_sources]
+                    ))
+                    for source in new_sources:
+                        source.status = "superseded"
+                        source.superseded_by = [replacement.id]
+                        source.score = min(source.score, 0.19)
+                    stats["corrected"] += 1
+                    continue
+
+                already_replaced = all(
+                    source_id in replacement.supersedes
+                    or (
+                        source_id in entry_map
+                        and replacement.id in entry_map[source_id].superseded_by
+                    )
+                    for source_id in source_ids
+                )
+                if already_replaced:
+                    continue
+
+            if not sources:
                 logger.warning("Skipping invalid memory correction for IDs %s", source_ids)
-                continue
-            if any(
-                entry.status == "active"
-                and _normalize_fact(entry.content) == _normalize_fact(content)
-                and set(source_ids).issubset(set(entry.supersedes))
-                for entry in entry_map.values()
-            ):
                 continue
             replacement = _new_review_entry(
                 content=content,

--- a/src/everbot/core/memory/manager.py
+++ b/src/everbot/core/memory/manager.py
@@ -166,28 +166,35 @@ class MemoryManager:
     ) -> Dict[str, Any]:
         """Profile pipeline: extract → decay → merge → save."""
         extractor = ProfileExtractor(self._context)
-        extract_result = await extractor.extract(new_messages, existing)
+        active_snapshot = [entry for entry in existing if entry.status == "active"]
+        extract_result = await extractor.extract(new_messages, active_snapshot)
 
-        superseded = [entry for entry in existing if entry.status == "superseded"]
-        active_existing = self.merger.apply_profile_decay(
-            [entry for entry in existing if entry.status == "active"]
-        )
+        expected = self.entries_fingerprint(existing)
+        with self.review_lock():
+            current = self.store.load()
+            if self.entries_fingerprint(current) != expected:
+                raise IntegrityError("Memory changed concurrently; session extraction must retry")
 
-        merge_result = self.merger.merge(
-            existing=active_existing,
-            new_extractions=extract_result.new_memories,
-            reinforcements=extract_result.reinforced_ids,
-            source_session=session_id,
-            content_filter=_is_internal_content,
-        )
+            superseded = [entry for entry in current if entry.status == "superseded"]
+            active_existing = self.merger.apply_profile_decay(
+                [entry for entry in current if entry.status == "active"]
+            )
 
-        # Save advances the watermark even when extraction produced
-        # nothing new — otherwise the same messages would be re-extracted
-        # on the next call.
-        self.store.save(
-            merge_result.entries + superseded,
-            last_processed_count=total_messages,
-        )
+            merge_result = self.merger.merge(
+                existing=active_existing,
+                new_extractions=extract_result.new_memories,
+                reinforcements=extract_result.reinforced_ids,
+                source_session=session_id,
+                content_filter=_is_internal_content,
+            )
+
+            # Save advances the watermark even when extraction produced
+            # nothing new — otherwise the same messages would be re-extracted
+            # on the next call.
+            self.store.save(
+                merge_result.entries + superseded,
+                last_processed_count=total_messages,
+            )
 
         return {
             "new_count": merge_result.new_count,
@@ -247,6 +254,10 @@ class MemoryManager:
         if event_block:
             sections.append(event_block)
         return "\n\n".join(sections)
+
+    def get_prompt_profile(self, top_k: int = 20) -> str:
+        """Return the canonical active-only profile projection for prompts."""
+        return self._format_profile_block(top_k)
 
     def _format_profile_block(self, top_k: int) -> str:
         """High-scoring profile entries, deduplicated by token similarity."""

--- a/src/everbot/core/memory/manager.py
+++ b/src/everbot/core/memory/manager.py
@@ -8,13 +8,16 @@ layer never block the other.
 
 import logging
 import re
+import json
+from contextlib import contextmanager
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 from .event_extractor import EventExtractor
 from .event_store import EventStore
 from .merger import MemoryMerger
-from .models import MemoryEntry
+from .models import MemoryEntry, new_id
 from .profile_extractor import ProfileExtractor
 from .profile_store import ProfileStore
 
@@ -165,10 +168,13 @@ class MemoryManager:
         extractor = ProfileExtractor(self._context)
         extract_result = await extractor.extract(new_messages, existing)
 
-        existing = self.merger.apply_profile_decay(existing)
+        superseded = [entry for entry in existing if entry.status == "superseded"]
+        active_existing = self.merger.apply_profile_decay(
+            [entry for entry in existing if entry.status == "active"]
+        )
 
         merge_result = self.merger.merge(
-            existing=existing,
+            existing=active_existing,
             new_extractions=extract_result.new_memories,
             reinforcements=extract_result.reinforced_ids,
             source_session=session_id,
@@ -178,12 +184,15 @@ class MemoryManager:
         # Save advances the watermark even when extraction produced
         # nothing new — otherwise the same messages would be re-extracted
         # on the next call.
-        self.store.save(merge_result.entries, last_processed_count=total_messages)
+        self.store.save(
+            merge_result.entries + superseded,
+            last_processed_count=total_messages,
+        )
 
         return {
             "new_count": merge_result.new_count,
             "updated_count": merge_result.updated_count,
-            "total": len(merge_result.entries),
+            "total": len(merge_result.entries) + len(superseded),
         }
 
     async def _process_events(
@@ -250,7 +259,8 @@ class MemoryManager:
         candidates = sorted(
             [
                 e for e in entries
-                if e.score >= _PROFILE_INJECT_THRESHOLD
+                if e.status == "active"
+                and e.score >= _PROFILE_INJECT_THRESHOLD
                 and not _is_internal_content(e.content)
             ],
             key=lambda e: e.score,
@@ -343,7 +353,7 @@ class MemoryManager:
 
         pool: List[MemoryEntry] = []
         if kind in ("profile", "both"):
-            pool.extend(self.store.load())
+            pool.extend(entry for entry in self.store.load() if entry.status == "active")
         if kind in ("event", "both"):
             if days is not None:
                 pool.extend(self._event_store.load_recent(days=days))
@@ -369,94 +379,273 @@ class MemoryManager:
         """Load all profile entries (events are queried via ``recall``)."""
         return self.store.load()
 
+    def preview_review(
+        self,
+        review: dict,
+        existing_entries: Optional[List[MemoryEntry]] = None,
+    ) -> tuple[List[MemoryEntry], dict]:
+        """Project a review without writing, including correction/split relations."""
+        entries = existing_entries if existing_entries is not None else self.store.load()
+        entry_map = {
+            entry.id: MemoryEntry.from_dict(entry.to_dict())
+            for entry in entries
+        }
+        active_before = sum(1 for entry in entry_map.values() if entry.status == "active")
+        stats = {
+            "merged": 0,
+            "deprecated": 0,
+            "reinforced": 0,
+            "refined": 0,
+            "corrected": 0,
+            "split": 0,
+        }
+
+        # Explicit corrections have priority over ordinary consolidation.
+        for item in review.get("corrections", []):
+            if not isinstance(item, dict):
+                continue
+            content = str(item.get("content", "")).strip()
+            category = str(item.get("category", "fact")).strip()
+            source_ids = list(dict.fromkeys(
+                str(value) for value in item.get("supersedes_ids", []) if value
+            ))
+            sources = [
+                entry_map[source_id]
+                for source_id in source_ids
+                if source_id in entry_map and entry_map[source_id].status == "active"
+            ]
+            if not content or category not in _PROFILE_CATEGORIES or not sources:
+                logger.warning("Skipping invalid memory correction for IDs %s", source_ids)
+                continue
+            if any(
+                entry.status == "active"
+                and _normalize_fact(entry.content) == _normalize_fact(content)
+                and set(source_ids).issubset(set(entry.supersedes))
+                for entry in entry_map.values()
+            ):
+                continue
+            replacement = _new_review_entry(
+                content=content,
+                category=category,
+                importance="high",
+                source_session=str(item.get("source_session", "")),
+                supersedes=[source.id for source in sources],
+            )
+            entry_map[replacement.id] = replacement
+            for source in sources:
+                source.status = "superseded"
+                source.superseded_by = [replacement.id]
+                source.score = min(source.score, 0.19)
+            stats["corrected"] += 1
+
+        # Split giant mixed entries into independently invalidatable facts.
+        for item in review.get("split_entries", []):
+            if not isinstance(item, dict):
+                continue
+            source_id = str(item.get("id", ""))
+            source = entry_map.get(source_id)
+            raw_children = item.get("entries", [])
+            if source is None or source.status != "active" or not isinstance(raw_children, list):
+                continue
+            children: List[MemoryEntry] = []
+            seen_content: set[str] = set()
+            for child in raw_children[:8]:
+                if not isinstance(child, dict):
+                    continue
+                content = str(child.get("content", "")).strip()
+                category = str(child.get("category", "fact")).strip()
+                normalized = _normalize_fact(content)
+                if (
+                    not content
+                    or category not in _PROFILE_CATEGORIES
+                    or normalized in seen_content
+                    or _is_internal_content(content)
+                ):
+                    continue
+                seen_content.add(normalized)
+                children.append(_new_review_entry(
+                    content=content,
+                    category=category,
+                    importance=str(child.get("importance", "medium")),
+                    source_session=str(child.get("source_session") or source.source_session),
+                    supersedes=[source.id],
+                ))
+            if not children:
+                continue
+            source.status = "superseded"
+            source.superseded_by = [child.id for child in children]
+            source.score = min(source.score, 0.19)
+            for child in children:
+                entry_map[child.id] = child
+            stats["split"] += 1
+
+        # Existing consolidation operations remain backward compatible.
+        consumed_merge_ids = set()
+        for pair in review.get("merge_pairs", []):
+            id_a = pair.get("id_a", "")
+            id_b = pair.get("id_b", "")
+            merged_content = pair.get("merged_content", "")
+            if id_a == id_b or id_a in consumed_merge_ids or id_b in consumed_merge_ids:
+                continue
+            if id_a not in entry_map or id_b not in entry_map:
+                continue
+            if entry_map[id_a].status != "active" or entry_map[id_b].status != "active":
+                continue
+            merged = self.merger.merge_entries(entry_map[id_a], entry_map[id_b], merged_content)
+            del entry_map[id_a]
+            del entry_map[id_b]
+            consumed_merge_ids.update((id_a, id_b))
+            entry_map[merged.id] = merged
+            stats["merged"] += 1
+
+        for entry_id in review.get("deprecate_ids", []):
+            entry = entry_map.get(entry_id)
+            if entry is None or entry.status != "active":
+                continue
+            entry.score *= 0.3
+            stats["deprecated"] += 1
+
+        for entry_id in review.get("reinforce_ids", []):
+            entry = entry_map.get(entry_id)
+            if entry is None or entry.status != "active":
+                continue
+            self.merger.reinforce(entry)
+            stats["reinforced"] += 1
+
+        for item in review.get("refined_entries", []):
+            entry = entry_map.get(item.get("id", "")) if isinstance(item, dict) else None
+            content = str(item.get("content", "")).strip() if isinstance(item, dict) else ""
+            if entry is None or entry.status != "active" or not content:
+                continue
+            entry.content = content
+            stats["refined"] += 1
+
+        result_entries = list(entry_map.values())
+        active_after = sum(1 for entry in result_entries if entry.status == "active")
+        allowed_growth = sum(
+            max(0, len(item.get("entries", [])) - 1)
+            for item in review.get("split_entries", [])
+            if isinstance(item, dict)
+        )
+        if active_after > active_before + allowed_growth:
+            raise IntegrityError(
+                f"Review unexpectedly increased active entries: {active_before} → {active_after}"
+            )
+        return result_entries, stats
+
+    @staticmethod
+    def entries_fingerprint(entries: List[MemoryEntry]) -> str:
+        """Stable optimistic-concurrency fingerprint for profile entries."""
+        # Fingerprint only fields persisted by ProfileStore. created_at and
+        # source_session are absent from legacy MEMORY.md and are synthesized
+        # on load, so including them would create false concurrency failures.
+        payload = [
+            {
+                "id": entry.id,
+                "content": entry.content,
+                "category": entry.category,
+                "score": round(entry.score, 2),
+                "last_activated": entry.last_activated[:10],
+                "activation_count": entry.activation_count,
+                "source_session": entry.source_session,
+                "status": entry.status,
+                "supersedes": entry.supersedes,
+                "superseded_by": entry.superseded_by,
+            }
+            for entry in sorted(entries, key=lambda item: item.id)
+        ]
+        return json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+    def commit_review(
+        self,
+        projected_entries: List[MemoryEntry],
+        *,
+        expected_fingerprint: str,
+        lock_already_held: bool = False,
+    ) -> None:
+        """Commit a precomputed review only if MEMORY has not changed."""
+        if lock_already_held:
+            self._commit_review_unlocked(projected_entries, expected_fingerprint)
+            return
+        with self.review_lock():
+            self._commit_review_unlocked(projected_entries, expected_fingerprint)
+
+    def _commit_review_unlocked(
+        self,
+        projected_entries: List[MemoryEntry],
+        expected_fingerprint: str,
+    ) -> None:
+        current = self.store.load()
+        if self.entries_fingerprint(current) != expected_fingerprint:
+            raise IntegrityError("Memory changed concurrently; review must retry")
+        self.store.save(projected_entries)
+
+    @contextmanager
+    def review_lock(self):
+        """Serialize the short MEMORY/USER/watermark review commit boundary."""
+        import fcntl
+
+        lock_path = self.store.memory_path.with_suffix(".md.lock")
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(lock_path, "w") as lock_fd:
+            fcntl.flock(lock_fd, fcntl.LOCK_EX)
+            try:
+                yield
+            finally:
+                fcntl.flock(lock_fd, fcntl.LOCK_UN)
+
     def apply_review(self, review: dict) -> dict:
         """Apply a review result from memory-review skill.
 
         The review dict may contain:
+        - corrections: replacement facts plus superseded active IDs
+        - split_entries: atomic children replacing one mixed active entry
         - merge_pairs: list of {id_a, id_b, merged_content}
         - deprecate_ids: list of entry IDs to deprecate (score *= 0.3)
         - reinforce_ids: list of entry IDs to reinforce
         - refined_entries: list of {id, content} for in-place content updates
 
-        Returns stats dict. Raises IntegrityError if entries increase.
+        Returns stats dict. Raises IntegrityError on unexpected active growth
+        or a concurrent MEMORY change.
 
         Note: review currently operates on profile entries only — event
         memory is append-only by design and is not subject to review.
         """
-        import fcntl  # Unix-only; project targets Linux/macOS
-
-        lock_path = self.store.memory_path.with_suffix(".md.lock")
-        lock_path.parent.mkdir(parents=True, exist_ok=True)
-
-        stats = {"merged": 0, "deprecated": 0, "reinforced": 0, "refined": 0}
-
-        with open(lock_path, "w") as lock_fd:
-            fcntl.flock(lock_fd, fcntl.LOCK_EX)
-            try:
-                entries = self.store.load()
-                entries_before = len(entries)
-                entry_map = {e.id: e for e in entries}
-
-                # 1. Merge pairs
-                consumed_merge_ids = set()
-                for pair in review.get("merge_pairs", []):
-                    id_a = pair.get("id_a", "")
-                    id_b = pair.get("id_b", "")
-                    merged_content = pair.get("merged_content", "")
-                    if id_a == id_b:
-                        logger.warning("Merge pair references the same ID twice: %s", id_a)
-                        continue
-                    if id_a in consumed_merge_ids or id_b in consumed_merge_ids:
-                        logger.warning("Merge pair reuses already merged ID: %s, %s", id_a, id_b)
-                        continue
-                    if id_a not in entry_map or id_b not in entry_map:
-                        logger.warning("Merge pair references missing ID: %s, %s", id_a, id_b)
-                        continue
-                    merged = self.merger.merge_entries(
-                        entry_map[id_a], entry_map[id_b], merged_content
-                    )
-                    del entry_map[id_a]
-                    del entry_map[id_b]
-                    consumed_merge_ids.update((id_a, id_b))
-                    entry_map[merged.id] = merged
-                    stats["merged"] += 1
-
-                # 2. Deprecate
-                for eid in review.get("deprecate_ids", []):
-                    if eid not in entry_map:
-                        logger.warning("Deprecate references missing ID: %s", eid)
-                        continue
-                    entry_map[eid].score *= 0.3
-                    stats["deprecated"] += 1
-
-                # 3. Reinforce
-                for eid in review.get("reinforce_ids", []):
-                    if eid not in entry_map:
-                        logger.warning("Reinforce references missing ID: %s", eid)
-                        continue
-                    self.merger.reinforce(entry_map[eid])
-                    stats["reinforced"] += 1
-
-                # 4. Refine (in-place content update)
-                for item in review.get("refined_entries", []):
-                    eid = item.get("id", "")
-                    content = item.get("content", "")
-                    if eid not in entry_map:
-                        logger.warning("Refine references missing ID: %s", eid)
-                        continue
-                    entry_map[eid].content = content
-                    stats["refined"] += 1
-
-                result_entries = list(entry_map.values())
-
-                # Integrity check: entries should not increase
-                if len(result_entries) > entries_before:
-                    raise IntegrityError(
-                        f"Review should not increase entries: {entries_before} → {len(result_entries)}"
-                    )
-
-                self.store.save(result_entries)
-            finally:
-                fcntl.flock(lock_fd, fcntl.LOCK_UN)
-
+        existing = self.store.load()
+        projected, stats = self.preview_review(review, existing)
+        self.commit_review(
+            projected,
+            expected_fingerprint=self.entries_fingerprint(existing),
+        )
         return stats
+
+
+_PROFILE_CATEGORIES = {"preference", "fact", "workflow", "decision", "experience"}
+_IMPORTANCE_SCORES = {"high": 0.9, "medium": 0.7, "low": 0.5}
+
+
+def _normalize_fact(content: str) -> str:
+    return "".join(content.lower().split())
+
+
+def _new_review_entry(
+    *,
+    content: str,
+    category: str,
+    importance: str,
+    source_session: str,
+    supersedes: List[str],
+) -> MemoryEntry:
+    now = datetime.now(timezone.utc).isoformat()
+    return MemoryEntry(
+        id=new_id(),
+        content=content,
+        category=category,
+        score=_IMPORTANCE_SCORES.get(importance, 0.7),
+        created_at=now,
+        last_activated=now,
+        activation_count=1,
+        source_session=source_session,
+        status="active",
+        supersedes=supersedes,
+    )

--- a/src/everbot/core/memory/models.py
+++ b/src/everbot/core/memory/models.py
@@ -1,6 +1,6 @@
 """Memory entry data model."""
 
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from typing import Any, Dict, Optional
 import uuid
@@ -29,6 +29,9 @@ class MemoryEntry:
     kind: str = "profile"
     event_at: Optional[str] = None
     due_at: Optional[str] = None
+    status: str = "active"
+    supersedes: list[str] = field(default_factory=list)
+    superseded_by: list[str] = field(default_factory=list)
 
     def to_dict(self) -> Dict[str, Any]:
         """Convert to JSON-serializable dictionary."""
@@ -51,9 +54,24 @@ class MemoryEntry:
             kind=str(data.get("kind", "profile")),
             event_at=str(event_at_raw) if event_at_raw else None,
             due_at=str(due_at_raw) if due_at_raw else None,
+            status=(
+                str(data.get("status", "active"))
+                if str(data.get("status", "active")) in {"active", "superseded"}
+                else "active"
+            ),
+            supersedes=_relation_list(data.get("supersedes", [])),
+            superseded_by=_relation_list(data.get("superseded_by", [])),
         )
 
 
 def new_id() -> str:
     """Generate a short uuid4 ID (6 chars)."""
     return uuid.uuid4().hex[:6]
+
+
+def _relation_list(raw: Any) -> list[str]:
+    if isinstance(raw, str):
+        return [value.strip() for value in raw.split(",") if value.strip()]
+    if isinstance(raw, (list, tuple, set)):
+        return [str(value) for value in raw if value]
+    return []

--- a/src/everbot/core/memory/profile_extractor.py
+++ b/src/everbot/core/memory/profile_extractor.py
@@ -103,8 +103,13 @@ class ProfileExtractor:
         if not messages:
             return ExtractResult()
 
-        # Build existing memories summary (top 50 by score)
-        top_existing = sorted(existing_entries, key=lambda e: e.score, reverse=True)[:50]
+        # Defense in depth: callers should pass active entries, but stale trace
+        # must never be shown to the extractor even if another caller forgets.
+        top_existing = sorted(
+            [entry for entry in existing_entries if entry.status == "active"],
+            key=lambda e: e.score,
+            reverse=True,
+        )[:50]
         if top_existing:
             existing_lines = []
             for e in top_existing:

--- a/src/everbot/core/memory/profile_store.py
+++ b/src/everbot/core/memory/profile_store.py
@@ -111,9 +111,10 @@ class ProfileStore:
 
         return entries
 
-    # Hard cap on total entries to prevent unbounded growth.
+    # Independent caps prevent provenance trace from evicting active facts.
     # Increase once consolidation logic matures.
     MAX_ENTRIES = 30
+    MAX_TRACE_ENTRIES = 5
 
     def save(self, entries: List[MemoryEntry], last_processed_count: Optional[int] = None) -> None:
         """Atomically write entries to MEMORY.md while preserving superseded trace."""
@@ -123,21 +124,22 @@ class ProfileStore:
         # for provenance even though they are never injected.
         entries = [e for e in entries if e.status == "superseded" or e.score >= 0.05]
 
-        # Enforce hard cap: keep top entries by score
-        if len(entries) > self.MAX_ENTRIES:
-            active_ranked = sorted(
-                [e for e in entries if e.status == "active"],
-                key=lambda e: e.score,
-                reverse=True,
-            )
-            trace_ranked = sorted(
-                [e for e in entries if e.status == "superseded"],
-                key=lambda e: e.last_activated,
-                reverse=True,
-            )
-            trace_budget = min(len(trace_ranked), 5)
-            active_budget = self.MAX_ENTRIES - trace_budget
-            entries = active_ranked[:active_budget] + trace_ranked[:trace_budget]
+        # Active facts and superseded provenance have independent budgets.
+        # Trace retention must never evict a still-valid active fact.
+        active_ranked = sorted(
+            [e for e in entries if e.status == "active"],
+            key=lambda e: e.score,
+            reverse=True,
+        )
+        trace_ranked = sorted(
+            [e for e in entries if e.status == "superseded"],
+            key=lambda e: e.last_activated,
+            reverse=True,
+        )
+        entries = (
+            active_ranked[:self.MAX_ENTRIES]
+            + trace_ranked[:self.MAX_TRACE_ENTRIES]
+        )
 
         # Partition
         active = sorted(

--- a/src/everbot/core/memory/profile_store.py
+++ b/src/everbot/core/memory/profile_store.py
@@ -8,7 +8,9 @@ Event memories live in a separate ``event_store`` module — they are
 time-anchored, append-only, and stored under ``events/YYYY-MM.md``.
 """
 
+import json
 import logging
+import os
 import re
 from datetime import datetime, timezone
 from pathlib import Path
@@ -18,10 +20,12 @@ from .models import MemoryEntry
 
 logger = logging.getLogger(__name__)
 
-# Header pattern: ### [id] category | score | last_activated_date | activation_count
+# Keep the legacy header stable. New relation fields live in an optional
+# HTML metadata comment on the following line so old readers still see entries.
 _HEADER_RE = re.compile(
     r"^###\s+\[(\w+)\]\s+(\w+)\s*\|\s*([\d.]+)\s*\|\s*([\d-]+)\s*\|\s*(\d+)\s*$"
 )
+_ENTRY_META_RE = re.compile(r"^<!--\s*memory_meta:\s*(\{.*\})\s*-->$")
 _META_PROCESSED_RE = re.compile(r"<!--\s*last_processed_count:\s*(\d+)\s*-->")
 
 
@@ -78,6 +82,19 @@ class ProfileStore:
                 content_lines = []
             elif current_entry is not None:
                 stripped = line.strip()
+                meta_match = _ENTRY_META_RE.match(stripped)
+                if meta_match:
+                    try:
+                        metadata = json.loads(meta_match.group(1))
+                        current_entry.update({
+                            "status": metadata.get("status", "active"),
+                            "supersedes": metadata.get("supersedes", []),
+                            "superseded_by": metadata.get("superseded_by", []),
+                            "source_session": metadata.get("source_session", ""),
+                        })
+                    except (json.JSONDecodeError, TypeError):
+                        logger.warning("Skipping malformed memory relation metadata")
+                    continue
                 # Skip section headers (# or ##) — they're structural, not content
                 if stripped.startswith("## ") or stripped.startswith("# "):
                     continue
@@ -99,19 +116,40 @@ class ProfileStore:
     MAX_ENTRIES = 30
 
     def save(self, entries: List[MemoryEntry], last_processed_count: Optional[int] = None) -> None:
-        """Write entries to MEMORY.md with backup. Discards score < 0.05."""
+        """Atomically write entries to MEMORY.md while preserving superseded trace."""
         if last_processed_count is not None:
             self.last_processed_count = last_processed_count
-        # Filter out near-zero entries
-        entries = [e for e in entries if e.score >= 0.05]
+        # Drop only near-zero active entries. Superseded entries are retained
+        # for provenance even though they are never injected.
+        entries = [e for e in entries if e.status == "superseded" or e.score >= 0.05]
 
         # Enforce hard cap: keep top entries by score
         if len(entries) > self.MAX_ENTRIES:
-            entries = sorted(entries, key=lambda e: e.score, reverse=True)[:self.MAX_ENTRIES]
+            active_ranked = sorted(
+                [e for e in entries if e.status == "active"],
+                key=lambda e: e.score,
+                reverse=True,
+            )
+            trace_ranked = sorted(
+                [e for e in entries if e.status == "superseded"],
+                key=lambda e: e.last_activated,
+                reverse=True,
+            )
+            trace_budget = min(len(trace_ranked), 5)
+            active_budget = self.MAX_ENTRIES - trace_budget
+            entries = active_ranked[:active_budget] + trace_ranked[:trace_budget]
 
         # Partition
-        active = sorted([e for e in entries if e.score >= 0.2], key=lambda e: e.score, reverse=True)
-        archived = sorted([e for e in entries if e.score < 0.2], key=lambda e: e.score, reverse=True)
+        active = sorted(
+            [e for e in entries if e.status == "active" and e.score >= 0.2],
+            key=lambda e: e.score,
+            reverse=True,
+        )
+        archived = sorted(
+            [e for e in entries if e.status == "superseded" or e.score < 0.2],
+            key=lambda e: e.score,
+            reverse=True,
+        )
 
         now_str = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S")
         total = len(active) + len(archived)
@@ -150,11 +188,22 @@ class ProfileStore:
             except Exception:
                 logger.debug("Backup failed", exc_info=True)
 
-        self.memory_path.write_text(content, encoding="utf-8")
+        tmp = self.memory_path.with_suffix(".md.tmp")
+        tmp.write_text(content, encoding="utf-8")
+        os.replace(tmp, self.memory_path)
 
 
 def _format_entry(entry: MemoryEntry) -> str:
     """Format a single entry as markdown block."""
     date_str = entry.last_activated[:10] if len(entry.last_activated) >= 10 else entry.last_activated
-    header = f"### [{entry.id}] {entry.category} | {entry.score:.2f} | {date_str} | {entry.activation_count}"
-    return f"{header}\n{entry.content}\n"
+    header = (
+        f"### [{entry.id}] {entry.category} | {entry.score:.2f} | "
+        f"{date_str} | {entry.activation_count}"
+    )
+    metadata = json.dumps({
+        "status": entry.status,
+        "supersedes": entry.supersedes,
+        "superseded_by": entry.superseded_by,
+        "source_session": entry.source_session,
+    }, ensure_ascii=False, separators=(",", ":"))
+    return f"{header}\n<!-- memory_meta: {metadata} -->\n{entry.content}\n"

--- a/src/everbot/core/runtime/heartbeat.py
+++ b/src/everbot/core/runtime/heartbeat.py
@@ -355,12 +355,12 @@ If not, reply with `HEARTBEAT_OK`.
         return self._file_mgr.read_heartbeat_md()
 
     def _read_memory_md(self) -> Optional[str]:
-        """Read MEMORY.md from workspace, returning content or None."""
+        """Read the canonical active profile projection for reflection."""
         memory_path = self.workspace_path / "MEMORY.md"
         try:
-            return memory_path.read_text(encoding="utf-8")
-        except FileNotFoundError:
-            return None
+            from ..memory.manager import MemoryManager
+
+            return MemoryManager(memory_path).get_prompt_profile() or None
         except OSError as e:
             logger.warning("Failed to read MEMORY.md: %s", e)
             return None

--- a/src/everbot/core/runtime/inspector.py
+++ b/src/everbot/core/runtime/inspector.py
@@ -305,7 +305,9 @@ class Inspector:
         memory_content = None
         if memory_path.exists():
             try:
-                memory_content = memory_path.read_text(encoding="utf-8")
+                from ..memory.manager import MemoryManager
+
+                memory_content = MemoryManager(memory_path).get_prompt_profile() or None
             except Exception as exc:
                 logger.debug("Failed to read MEMORY.md: %s", exc)
                 gather_errors.append(f"MEMORY.md: {exc}")

--- a/src/everbot/core/scanners/reflection_state.py
+++ b/src/everbot/core/scanners/reflection_state.py
@@ -43,7 +43,7 @@ class ReflectionState:
             logger.warning("Failed to load reflection state, starting fresh: %s", e)
             return cls()
 
-    def save(self, workspace_path: Path) -> None:
+    def save(self, workspace_path: Path) -> bool:
         """Atomically save state to disk."""
         state_file = Path(workspace_path) / _STATE_FILENAME
         state_file.parent.mkdir(parents=True, exist_ok=True)
@@ -52,6 +52,7 @@ class ReflectionState:
         try:
             tmp.write_text(data, encoding="utf-8")
             os.replace(tmp, state_file)
+            return True
         except Exception as e:
             logger.error("Failed to save reflection state: %s", e)
             # Clean up tmp on failure
@@ -59,3 +60,4 @@ class ReflectionState:
                 tmp.unlink(missing_ok=True)
             except Exception:
                 pass
+            return False

--- a/src/everbot/core/session/session.py
+++ b/src/everbot/core/session/session.py
@@ -45,7 +45,6 @@ class SessionManager:
 
     MAX_TIMELINE_EVENTS = 500  # 防止内存泄漏，限制每个 session 的 timeline 事件数
     _MAX_CACHED_LOCKS = 200
-    MEMORY_EXTRACTION_TIMEOUT = 120  # seconds; LLM-based memory extraction after session save
 
     # --- Delegated ID helpers (canonical implementations in session_ids.py) ---
 
@@ -592,35 +591,9 @@ class SessionManager:
         timeline = self.get_timeline(session_id)
         context_trace = self._extract_context_trace(agent)
 
-        # Extract structured memories for primary / channel sessions.
-        # Fire-and-forget with timeout so it never blocks session persistence.
-        session_type = SessionManager.infer_session_type(session_id)
-        from ..agent.provider import provider_for  # local: avoid import cycle
-        provider = provider_for(agent)
-        if session_type in ("primary", "channel") and provider.needs_history_restore():
-            # dolphin: 进程内 context 驱动 session-end 记忆抽取。
-            # milkie: in-process memory extraction needs #87 bridge; skip for now
-            try:
-                agent_name = getattr(agent, "name", "")
-                if agent_name:
-                    context = agent.executor.context
-                    from ..memory.manager import MemoryManager
-                    from ...infra.user_data import get_user_data_manager
-                    memory_path = get_user_data_manager().get_agent_dir(agent_name) / "MEMORY.md"
-                    mm = MemoryManager(memory_path, context)
-                    portable = provider.export_session(agent)
-                    history = portable.get("history_messages", [])
-                    await asyncio.wait_for(
-                        mm.process_session_end(history, session_id),
-                        timeout=self.MEMORY_EXTRACTION_TIMEOUT,
-                    )
-            except asyncio.TimeoutError:
-                logger.warning(
-                    "Memory extraction timed out (%ds); skipping",
-                    self.MEMORY_EXTRACTION_TIMEOUT,
-                )
-            except Exception:
-                logger.warning("Memory extraction failed; skipping", exc_info=True)
+        # Profile memory is maintained by the memory-review job (session digests),
+        # not at save_session time. milkie is the only runtime and does not restore
+        # in-process history for extraction here.
 
         if lock_already_held:
             await self.persistence.save(
@@ -635,12 +608,13 @@ class SessionManager:
             logger.debug("Session persisted.")
             return
 
+        from ..agent.provider import provider_for  # local: avoid import cycle
         provider = provider_for(agent)
         portable = provider.export_session(agent)
         serializable_history = portable.get("history_messages", [])
         exported_variables = portable.get("variables", {})
         exported_variables.pop("_history", None)  # avoid duplicating history_messages
-        # session_created_at: dolphin 读 context;milkie 走 serve(可能为 None,容忍)。
+        # session_created_at may be absent on milkie serve paths; tolerate None.
         created_at_hint = provider.get_variable(agent, "session_created_at")
 
         # Compress history for long-lived sessions before entering the lock.

--- a/src/everbot/core/tasks/execution_gate.py
+++ b/src/everbot/core/tasks/execution_gate.py
@@ -22,6 +22,7 @@ class GateVerdict:
     allowed: bool
     skip_reason: Optional[str] = None  # "no_changes" | "interval_not_met" | "scanner_error"
     scan_result: Any = None
+    watermark_before: Optional[str] = None
 
 
 class TaskExecutionGate:
@@ -52,6 +53,7 @@ class TaskExecutionGate:
         scanner_type = getattr(task, "scanner", None)
         scanner = self._scanner_factory(scanner_type)
         scan_result = None
+        watermark_before = None
 
         # 1. Scanner gate
         if scanner:
@@ -59,26 +61,46 @@ class TaskExecutionGate:
 
             skill_name = getattr(task, "job", None) or ""
             state = ReflectionState.load(self._workspace_path)
+            watermark_before = state.get_watermark(skill_name)
             try:
-                scan_result = scanner.check(state.get_watermark(skill_name), self._agent_name)
+                scan_result = scanner.check(watermark_before, self._agent_name)
             except Exception as exc:
                 logger.warning("Scanner %s error: %s", scanner_type, exc)
-                return GateVerdict(allowed=False, skip_reason="scanner_error", scan_result=None)
+                return GateVerdict(
+                    allowed=False,
+                    skip_reason="scanner_error",
+                    scan_result=None,
+                    watermark_before=watermark_before,
+                )
             if not scan_result.has_changes:
-                return GateVerdict(allowed=False, skip_reason="no_changes", scan_result=scan_result)
+                return GateVerdict(
+                    allowed=False,
+                    skip_reason="no_changes",
+                    scan_result=scan_result,
+                    watermark_before=watermark_before,
+                )
 
         # 2. Min execution interval
         if not self._check_min_execution_interval(task):
-            return GateVerdict(allowed=False, skip_reason="interval_not_met", scan_result=scan_result)
+            return GateVerdict(
+                allowed=False,
+                skip_reason="interval_not_met",
+                scan_result=scan_result,
+                watermark_before=watermark_before,
+            )
 
-        return GateVerdict(allowed=True, scan_result=scan_result)
+        return GateVerdict(
+            allowed=True,
+            scan_result=scan_result,
+            watermark_before=watermark_before,
+        )
 
     def commit(self, task: Any, verdict: GateVerdict) -> None:
         """Advance watermark after successful execution.
 
-        Uses ``datetime.now(UTC)`` – **not** scan-time ``updated_at`` – to
-        prevent self-triggering loops when skill execution itself mutates the
-        monitored data source.
+        Preserve a watermark advanced by the job itself (for example a partial
+        analyzed-session boundary). Otherwise use ``datetime.now(UTC)`` to
+        prevent self-triggering loops when execution mutates the data source.
         """
         from ..scanners.reflection_state import ReflectionState
 
@@ -86,6 +108,17 @@ class TaskExecutionGate:
         if not job_name:
             return
         state = ReflectionState.load(self._workspace_path)
+        current = state.get_watermark(job_name)
+        if (
+            verdict.watermark_before is not None
+            and current != verdict.watermark_before
+        ):
+            logger.debug(
+                "Preserving job-managed watermark for %s: %s",
+                job_name,
+                current,
+            )
+            return
         state.set_watermark(job_name, datetime.now(timezone.utc).isoformat())
         state.save(self._workspace_path)
 

--- a/src/everbot/infra/workspace.py
+++ b/src/everbot/infra/workspace.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass
 import logging
 
 logger = logging.getLogger(__name__)
+_DERIVED_MEMORY_PROFILE_MARKER = "<!-- derived_from_memory: true -->"
 
 
 @dataclass
@@ -147,7 +148,10 @@ class WorkspaceLoader:
 
         # Inject memory when available and within budget.
         # Once memory-review populates USER.md, this becomes redundant.
-        if instructions.memory_md:
+        if instructions.memory_md and not (
+            instructions.user_md
+            and _DERIVED_MEMORY_PROFILE_MARKER in instructions.user_md
+        ):
             memory_text = instructions.memory_md.strip()
             if len(memory_text) <= self.MAX_MEMORY_PROMPT_CHARS:
                 parts.append(f"# 记忆\n\n{memory_text}")

--- a/tests/e2e/test_memory_correction_e2e.py
+++ b/tests/e2e/test_memory_correction_e2e.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import json
-from unittest.mock import AsyncMock
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import patch
 
 import pytest
 
@@ -11,6 +14,10 @@ from src.everbot.core.jobs.memory_review import run
 from src.everbot.core.memory.manager import MemoryManager
 from src.everbot.core.memory.models import MemoryEntry
 from src.everbot.core.runtime.skill_context import SkillContext
+from src.everbot.core.runtime.cron import CronExecutor
+from src.everbot.core.runtime.cron_delivery import CronDelivery
+from src.everbot.core.scanners.reflection_state import ReflectionState
+from src.everbot.core.tasks.routine_manager import RoutineManager
 from src.everbot.infra.workspace import WorkspaceLoader
 
 
@@ -132,3 +139,105 @@ async def test_no_active_memory_clears_stale_profile_and_prompt(tmp_path):
     prompt = WorkspaceLoader(tmp_path).build_system_prompt()
     assert "项目 A 核心研发" not in prompt
     assert "用户是项目 A" not in prompt
+
+
+class _E2EUserData:
+    def __init__(self, root: Path):
+        self.sessions_dir = root / "sessions"
+        self.heartbeat_events_file = root / "heartbeat-events.jsonl"
+
+    def get_agent_skill_logs_dir(self, _agent_name: str) -> Path:
+        return self.heartbeat_events_file.parent / "skill-logs"
+
+    def get_agent_skill_eval_dir(self, _agent_name: str) -> Path:
+        return self.heartbeat_events_file.parent / "skill-eval"
+
+    def get_skill_log_recorder(self, **_kwargs):
+        return None
+
+
+@pytest.mark.asyncio
+async def test_cron_gate_runs_correction_to_next_session_prompt(tmp_path):
+    """Production cron/gate/job wiring, with only the LLM boundary stubbed."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    user_data = _E2EUserData(tmp_path)
+    manager = MemoryManager(workspace / "MEMORY.md")
+    manager.store.save([_old_assignment()])
+    (workspace / "USER.md").write_text(
+        "# 用户画像\n\n- 项目: 项目 A 核心研发\n", encoding="utf-8",
+    )
+    session_id = "web_session_demo_cron_e2e"
+    _write_session(
+        user_data.sessions_dir / f"{session_id}.json",
+        content="我现在不负责项目 A 啦，请更新记忆。",
+    )
+
+    routine_manager = RoutineManager(workspace)
+    routine_manager.add_routine(
+        title="Memory Review",
+        schedule="2h",
+        job="memory-review",
+        scanner="session",
+        execution_mode="inline",
+        next_run_at=(datetime.now(timezone.utc) - timedelta(minutes=1)).isoformat(),
+    )
+    tasks = routine_manager.load_task_list()
+    session_manager = MagicMock()
+    session_manager.get_primary_session_id.return_value = "web_session_demo_primary"
+    session_manager.get_heartbeat_session_id.return_value = "heartbeat_session_demo"
+    delivery = CronDelivery(
+        session_manager=session_manager,
+        primary_session_id="web_session_demo_primary",
+        heartbeat_session_id="heartbeat_session_demo",
+        agent_name="demo",
+        realtime_push=False,
+    )
+
+    responses = [
+        json.dumps({
+            "corrections": [{
+                "content": "用户现在不负责项目 A",
+                "category": "fact",
+                "supersedes_ids": ["old001"],
+                "source_session": session_id,
+            }],
+        }, ensure_ascii=False),
+        "- 项目状态: 不再负责项目 A",
+    ]
+
+    async def complete(_self, _prompt, **_kwargs):
+        return responses.pop(0)
+
+    with patch(
+        "src.everbot.infra.user_data.get_user_data_manager",
+        return_value=user_data,
+    ), patch(
+        "src.everbot.core.runtime.cron._SkillLLMClient.complete",
+        new=complete,
+    ):
+        executor = CronExecutor(
+            agent_name="demo",
+            workspace_path=workspace,
+            session_manager=session_manager,
+            agent_factory=AsyncMock(),
+            routine_manager=routine_manager,
+            delivery=delivery,
+        )
+        executor._resolve_skill_model = lambda: "test-model"
+        result = await executor.tick(
+            tasks,
+            run_agent=AsyncMock(),
+            inject_context=AsyncMock(),
+            run_id="memory-review-e2e",
+        )
+
+    assert result.executed == 1
+    assert result.failed == 0
+    assert result.results[0].status == "done"
+    assert ReflectionState.load(workspace).get_watermark("memory-review")
+    prompt = WorkspaceLoader(workspace).build_system_prompt()
+    assert "不再负责项目 A" in prompt
+    assert "核心研发者并负责该项目" not in prompt
+    events = user_data.heartbeat_events_file.read_text(encoding="utf-8")
+    assert '"event": "job_completed"' in events

--- a/tests/e2e/test_memory_correction_e2e.py
+++ b/tests/e2e/test_memory_correction_e2e.py
@@ -1,0 +1,134 @@
+"""E2E(#188): session correction → review → MEMORY/USER → next-session prompt."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.everbot.core.jobs.memory_review import run
+from src.everbot.core.memory.manager import MemoryManager
+from src.everbot.core.memory.models import MemoryEntry
+from src.everbot.core.runtime.skill_context import SkillContext
+from src.everbot.infra.workspace import WorkspaceLoader
+
+
+def _old_assignment() -> MemoryEntry:
+    return MemoryEntry(
+        id="old001",
+        content="用户是项目 A 的核心研发者并负责该项目",
+        category="fact",
+        score=0.8,
+        created_at="2026-06-01T00:00:00+00:00",
+        last_activated="2026-07-01T00:00:00+00:00",
+        activation_count=3,
+        source_session="old-session",
+    )
+
+
+def _write_session(path, *, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({
+        "session_id": path.stem,
+        "updated_at": "2026-08-02T08:00:00+00:00",
+        "session_type": "primary",
+        "agent_name": "demo",
+        "history_messages": [
+            {"role": "user", "content": content},
+            {"role": "assistant", "content": "我会更新记忆。"},
+        ],
+    }, ensure_ascii=False), encoding="utf-8")
+
+
+def _context(tmp_path, manager, llm) -> SkillContext:
+    return SkillContext(
+        sessions_dir=tmp_path / "sessions",
+        workspace_path=tmp_path,
+        agent_name="demo",
+        memory_manager=manager,
+        mailbox=AsyncMock(),
+        llm=llm,
+        scan_result=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_explicit_correction_reaches_next_session_prompt(tmp_path):
+    manager = MemoryManager(tmp_path / "MEMORY.md")
+    manager.store.save([_old_assignment()])
+    (tmp_path / "USER.md").write_text(
+        "# 用户画像\n\n- 项目: 项目 A 核心研发\n",
+        encoding="utf-8",
+    )
+    session_id = "web_session_demo_20260802"
+    _write_session(
+        tmp_path / "sessions" / f"{session_id}.json",
+        content="我现在不负责项目 A 啦，请不要再把我当作该项目研发。",
+    )
+    llm = AsyncMock()
+    llm.complete.side_effect = [
+        json.dumps({
+            "corrections": [{
+                "content": "用户现在不负责项目 A",
+                "category": "fact",
+                "supersedes_ids": ["old001"],
+                "source_session": session_id,
+            }],
+            "split_entries": [],
+            "merge_pairs": [],
+            "deprecate_ids": [],
+            "reinforce_ids": [],
+            "refined_entries": [],
+        }, ensure_ascii=False),
+        "- 项目状态: 不再负责项目 A",
+    ]
+
+    result = await run(_context(tmp_path, manager, llm))
+
+    assert result == "profile_rebuilt:1; corrected=1; split=0"
+    entries = {entry.id: entry for entry in manager.load_entries()}
+    assert entries["old001"].status == "superseded"
+    replacement = next(entry for entry in entries.values() if entry.status == "active")
+    assert replacement.content == "用户现在不负责项目 A"
+    assert replacement.supersedes == ["old001"]
+    assert replacement.source_session == session_id
+
+    user_profile = (tmp_path / "USER.md").read_text(encoding="utf-8")
+    assert "不再负责项目 A" in user_profile
+    assert "核心研发" not in user_profile
+
+    # The next session sees only the derived USER projection; superseded raw
+    # MEMORY content is retained for traceability but is not injected.
+    next_session_prompt = WorkspaceLoader(tmp_path).build_system_prompt()
+    assert "不再负责项目 A" in next_session_prompt
+    assert "核心研发者并负责该项目" not in next_session_prompt
+
+    # A deterministic next-session answer check: the injected facts cannot
+    # support an affirmative answer to “do I still own project A?”.
+    answer = "不再负责" if "不再负责项目 A" in next_session_prompt else "仍负责"
+    assert answer == "不再负责"
+
+    # Re-running with the same already-watermarked session is a no-op.
+    assert await run(_context(tmp_path, manager, AsyncMock())) is None
+    assert len(manager.load_entries()) == 2
+
+
+@pytest.mark.asyncio
+async def test_no_active_memory_clears_stale_profile_and_prompt(tmp_path):
+    manager = MemoryManager(tmp_path / "MEMORY.md")
+    stale = _old_assignment()
+    stale.score = 0.22
+    manager.store.save([stale])
+    (tmp_path / "USER.md").write_text(
+        "# 用户画像\n\n- 项目: 项目 A 核心研发\n",
+        encoding="utf-8",
+    )
+
+    result = await run(_context(tmp_path, manager, AsyncMock()))
+
+    assert result == "profile_cleared"
+    assert "（暂无活跃画像）" in (tmp_path / "USER.md").read_text(encoding="utf-8")
+    prompt = WorkspaceLoader(tmp_path).build_system_prompt()
+    assert "项目 A 核心研发" not in prompt
+    assert "用户是项目 A" not in prompt

--- a/tests/integration/test_heartbeat_token_optimizations.py
+++ b/tests/integration/test_heartbeat_token_optimizations.py
@@ -16,6 +16,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from src.everbot.core.runtime.heartbeat import HeartbeatRunner
+from src.everbot.core.memory.manager import MemoryManager
+from src.everbot.core.memory.models import MemoryEntry
 
 
 class _StubUserDataManager:
@@ -424,11 +426,20 @@ class TestReflectPromptInlinesMemory:
     so the agent does not need to call _read_file with a bare path."""
 
     @pytest.mark.asyncio
-    async def test_reflect_prompt_contains_memory_content(self, tmp_path: Path):
-        """Reflect prompt should inline MEMORY.md content."""
+    async def test_reflect_prompt_contains_only_active_memory_projection(self, tmp_path: Path):
+        """Reflect prompt must not re-inject superseded MEMORY trace."""
         runner = _make_runner(workspace_path=tmp_path)
         _write_heartbeat_md(tmp_path)
-        (tmp_path / "MEMORY.md").write_text("important-memory-payload", encoding="utf-8")
+        MemoryManager(tmp_path / "MEMORY.md").store.save([
+            MemoryEntry.from_dict({
+                "id": "active1", "content": "用户现在不负责项目 A",
+                "category": "fact", "score": 0.9, "status": "active",
+            }),
+            MemoryEntry.from_dict({
+                "id": "old001", "content": "用户负责项目 A",
+                "category": "fact", "score": 0.19, "status": "superseded",
+            }),
+        ])
 
         fake_agent = SimpleNamespace(
             executor=SimpleNamespace(
@@ -446,8 +457,8 @@ class TestReflectPromptInlinesMemory:
             fake_agent, heartbeat_content, mode="reflect"
         )
 
-        assert "important-memory-payload" in prompt
-        assert "MEMORY.md" in prompt
+        assert "用户现在不负责项目 A" in prompt
+        assert "用户负责项目 A" not in prompt
 
     @pytest.mark.asyncio
     async def test_reflect_prompt_works_without_memory_file(self, tmp_path: Path):
@@ -476,11 +487,18 @@ class TestReflectPromptInlinesMemory:
         assert "routine 反思阶段" in prompt
         assert "HEARTBEAT.md" in prompt or heartbeat_content in prompt
 
-    def test_read_memory_md_returns_content(self, tmp_path: Path):
-        """_read_memory_md should return file content when file exists."""
+    def test_read_memory_md_returns_active_projection(self, tmp_path: Path):
+        """_read_memory_md should parse rather than return raw file content."""
         runner = _make_runner(workspace_path=tmp_path)
-        (tmp_path / "MEMORY.md").write_text("test-content", encoding="utf-8")
-        assert runner._read_memory_md() == "test-content"
+        MemoryManager(tmp_path / "MEMORY.md").store.save([
+            MemoryEntry.from_dict({
+                "id": "active1", "content": "用户偏好简洁输出",
+                "category": "preference", "score": 0.9, "status": "active",
+            }),
+        ])
+        projection = runner._read_memory_md()
+        assert "用户偏好简洁输出" in projection
+        assert "memory_meta" not in projection
 
     def test_read_memory_md_returns_none_when_missing(self, tmp_path: Path):
         """_read_memory_md should return None when file doesn't exist."""

--- a/tests/integration/test_memory_review_atomicity.py
+++ b/tests/integration/test_memory_review_atomicity.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from src.everbot.core.jobs.memory_review import run
-from src.everbot.core.memory.manager import MemoryManager
+from src.everbot.core.memory.manager import IntegrityError, MemoryManager
 from src.everbot.core.memory.models import MemoryEntry
 from src.everbot.core.runtime.skill_context import SkillContext
 from src.everbot.core.scanners.reflection_state import ReflectionState
@@ -153,7 +153,6 @@ async def test_concurrent_memory_insert_is_preserved_and_review_retries(tmp_path
 
     context.llm.complete.side_effect = complete
 
-    from src.everbot.core.memory.manager import IntegrityError
     with pytest.raises(IntegrityError, match="concurrently"):
         await run(context)
 
@@ -162,3 +161,179 @@ async def test_concurrent_memory_insert_is_preserved_and_review_retries(tmp_path
     assert entries["old001"].status == "active"
     assert not ReflectionState.load(tmp_path).get_watermark("memory-review")
     assert "负责 A" in (tmp_path / "USER.md").read_text(encoding="utf-8")
+
+
+@pytest.mark.asyncio
+async def test_watermark_never_advances_past_sessions_sent_to_judge(tmp_path):
+    sessions_dir = tmp_path / "sessions"
+    sessions_dir.mkdir()
+    timestamps = [f"2026-08-02T08:0{i}:00+00:00" for i in range(1, 6)]
+    session_ids = [f"web_session_demo_backlog_{i}" for i in range(1, 6)]
+    for index, (session_id, updated_at) in enumerate(
+        zip(session_ids, timestamps), start=1,
+    ):
+        user_text = (
+            "我现在不负责项目 A"
+            if index == 5
+            else f"普通对话 {index}"
+        )
+        (sessions_dir / f"{session_id}.json").write_text(json.dumps({
+            "session_id": session_id,
+            "updated_at": updated_at,
+            "session_type": "primary",
+            "agent_name": "demo",
+            "history_messages": [{"role": "user", "content": user_text}],
+        }, ensure_ascii=False), encoding="utf-8")
+
+    manager = MemoryManager(tmp_path / "MEMORY.md")
+    manager.store.save([MemoryEntry(
+        id="old001",
+        content="用户负责项目 A",
+        category="fact",
+        score=0.8,
+        created_at="2026-06-01T00:00:00+00:00",
+        last_activated="2026-07-01T00:00:00+00:00",
+        activation_count=1,
+        source_session="old",
+    )])
+    (tmp_path / "USER.md").write_text(
+        "# 用户画像\n\n- 项目: 负责 A\n", encoding="utf-8",
+    )
+    context = SkillContext(
+        sessions_dir=sessions_dir,
+        workspace_path=tmp_path,
+        agent_name="demo",
+        memory_manager=manager,
+        mailbox=AsyncMock(),
+        llm=AsyncMock(),
+        scan_result=None,
+    )
+    analysis_prompts = []
+
+    async def complete(prompt, **_kwargs):
+        if "## Recent Conversation Context" in prompt:
+            analysis_prompts.append(prompt)
+            if "我现在不负责项目 A" in prompt:
+                return json.dumps({
+                    "corrections": [{
+                        "content": "用户现在不负责项目 A",
+                        "category": "fact",
+                        "supersedes_ids": ["old001"],
+                        "source_session": session_ids[4],
+                    }],
+                }, ensure_ascii=False)
+            return "{}"
+        return "- 项目状态: 不再负责项目 A"
+
+    context.llm.complete.side_effect = complete
+
+    await run(context)
+
+    first_watermark = ReflectionState.load(tmp_path).get_watermark("memory-review")
+    assert first_watermark == timestamps[2]
+    assert session_ids[3] not in analysis_prompts[0]
+    assert session_ids[4] not in analysis_prompts[0]
+    assert manager.load_entries()[0].status == "active"
+
+    await run(context)
+
+    assert ReflectionState.load(tmp_path).get_watermark("memory-review") == timestamps[4]
+    entries = manager.load_entries()
+    assert next(entry for entry in entries if entry.id == "old001").status == "superseded"
+    active = [entry for entry in entries if entry.status == "active"]
+    assert [entry.content for entry in active] == ["用户现在不负责项目 A"]
+
+
+@pytest.mark.asyncio
+async def test_no_session_bootstrap_rejects_stale_profile_after_memory_change(tmp_path):
+    sessions_dir = tmp_path / "sessions"
+    sessions_dir.mkdir()
+    manager = MemoryManager(tmp_path / "MEMORY.md")
+    manager.store.save([MemoryEntry(
+        id="old001",
+        content="用户负责项目 A",
+        category="fact",
+        score=0.8,
+        created_at="2026-06-01T00:00:00+00:00",
+        last_activated="2026-07-01T00:00:00+00:00",
+        activation_count=1,
+        source_session="old",
+    )])
+    user_path = tmp_path / "USER.md"
+    user_path.write_text("# 用户画像\n\nlegacy profile\n", encoding="utf-8")
+    context = SkillContext(
+        sessions_dir=sessions_dir,
+        workspace_path=tmp_path,
+        agent_name="demo",
+        memory_manager=manager,
+        mailbox=AsyncMock(),
+        llm=AsyncMock(),
+        scan_result=None,
+    )
+
+    async def mutate_memory_then_render(*_args, **_kwargs):
+        entries = manager.load_entries()
+        entries.append(MemoryEntry(
+            id="newcon",
+            content="用户偏好简洁输出",
+            category="preference",
+            score=0.8,
+            created_at="2026-08-02T08:00:00+00:00",
+            last_activated="2026-08-02T08:00:00+00:00",
+            activation_count=1,
+            source_session="concurrent-session",
+        ))
+        manager.store.save(entries)
+        return "- 项目状态: 负责项目 A"
+
+    context.llm.complete.side_effect = mutate_memory_then_render
+
+    with pytest.raises(IntegrityError, match="concurrently"):
+        await run(context)
+
+    assert user_path.read_text(encoding="utf-8") == "# 用户画像\n\nlegacy profile\n"
+    assert {entry.id for entry in manager.load_entries()} == {"old001", "newcon"}
+
+
+@pytest.mark.asyncio
+async def test_no_session_bootstrap_write_failure_restores_user_profile(tmp_path):
+    sessions_dir = tmp_path / "sessions"
+    sessions_dir.mkdir()
+    manager = MemoryManager(tmp_path / "MEMORY.md")
+    manager.store.save([MemoryEntry(
+        id="old001",
+        content="用户负责项目 A",
+        category="fact",
+        score=0.8,
+        created_at="2026-06-01T00:00:00+00:00",
+        last_activated="2026-07-01T00:00:00+00:00",
+        activation_count=1,
+        source_session="old",
+    )])
+    user_path = tmp_path / "USER.md"
+    original_user = "# 用户画像\n\nlegacy profile\n"
+    user_path.write_text(original_user, encoding="utf-8")
+    context = SkillContext(
+        sessions_dir=sessions_dir,
+        workspace_path=tmp_path,
+        agent_name="demo",
+        memory_manager=manager,
+        mailbox=AsyncMock(),
+        llm=AsyncMock(),
+        scan_result=None,
+    )
+    context.llm.complete.return_value = "- 项目状态: 负责项目 A"
+
+    def partial_write_then_fail(_path, _content):
+        user_path.write_text("partial profile", encoding="utf-8")
+        raise OSError("disk full after replace")
+
+    with patch(
+        "src.everbot.core.jobs.memory_review._atomic_write_profile",
+        side_effect=partial_write_then_fail,
+    ):
+        with pytest.raises(OSError, match="disk full"):
+            await run(context)
+
+    assert user_path.read_text(encoding="utf-8") == original_user
+    assert manager.load_entries()[0].status == "active"

--- a/tests/integration/test_memory_review_atomicity.py
+++ b/tests/integration/test_memory_review_atomicity.py
@@ -1,0 +1,164 @@
+"""Integration tests for Memory Review's recoverable commit boundary (#188)."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from src.everbot.core.jobs.memory_review import run
+from src.everbot.core.memory.manager import MemoryManager
+from src.everbot.core.memory.models import MemoryEntry
+from src.everbot.core.runtime.skill_context import SkillContext
+from src.everbot.core.scanners.reflection_state import ReflectionState
+
+
+def _seed(tmp_path):
+    sessions = tmp_path / "sessions"
+    sessions.mkdir()
+    session_id = "web_session_demo_atomic"
+    (sessions / f"{session_id}.json").write_text(json.dumps({
+        "session_id": session_id,
+        "updated_at": "2026-08-02T08:00:00+00:00",
+        "session_type": "primary",
+        "agent_name": "demo",
+        "history_messages": [{"role": "user", "content": "我现在不负责项目 A"}],
+    }, ensure_ascii=False), encoding="utf-8")
+    manager = MemoryManager(tmp_path / "MEMORY.md")
+    manager.store.save([MemoryEntry(
+        id="old001",
+        content="用户负责项目 A",
+        category="fact",
+        score=0.8,
+        created_at="2026-06-01T00:00:00+00:00",
+        last_activated="2026-07-01T00:00:00+00:00",
+        activation_count=1,
+        source_session="old",
+    )])
+    (tmp_path / "USER.md").write_text("# 用户画像\n\n- 项目: 负责 A\n", encoding="utf-8")
+    context = SkillContext(
+        sessions_dir=sessions,
+        workspace_path=tmp_path,
+        agent_name="demo",
+        memory_manager=manager,
+        mailbox=AsyncMock(),
+        llm=AsyncMock(),
+        scan_result=None,
+    )
+    review = json.dumps({
+        "corrections": [{
+            "content": "用户现在不负责项目 A",
+            "category": "fact",
+            "supersedes_ids": ["old001"],
+            "source_session": session_id,
+        }],
+    }, ensure_ascii=False)
+    return context, review
+
+
+def _snapshots(tmp_path):
+    paths = [tmp_path / "MEMORY.md", tmp_path / "USER.md", tmp_path / ".reflection_state.json"]
+    return {path: path.read_bytes() if path.exists() else None for path in paths}
+
+
+def _assert_snapshots(tmp_path, expected):
+    assert _snapshots(tmp_path) == expected
+    assert not ReflectionState.load(tmp_path).get_watermark("memory-review")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("error", [ConnectionError("offline"), TimeoutError("timeout")])
+async def test_llm_failure_does_not_mutate_memory_profile_or_watermark(tmp_path, error):
+    context, _review = _seed(tmp_path)
+    before = _snapshots(tmp_path)
+    context.llm.complete.side_effect = error
+
+    with pytest.raises(type(error)):
+        await run(context)
+
+    _assert_snapshots(tmp_path, before)
+
+
+@pytest.mark.asyncio
+async def test_compression_timeout_does_not_apply_completed_analysis(tmp_path):
+    context, review = _seed(tmp_path)
+    before = _snapshots(tmp_path)
+    context.llm.complete.side_effect = [review, TimeoutError("compression timeout")]
+
+    with pytest.raises(TimeoutError, match="compression timeout"):
+        await run(context)
+
+    _assert_snapshots(tmp_path, before)
+
+
+@pytest.mark.asyncio
+async def test_profile_write_failure_rolls_back_memory_and_retries_successfully(tmp_path):
+    context, review = _seed(tmp_path)
+    before = _snapshots(tmp_path)
+    context.llm.complete.side_effect = [review, "- 项目状态: 不再负责项目 A"]
+
+    with patch(
+        "src.everbot.core.jobs.memory_review._atomic_write_profile",
+        side_effect=OSError("disk full"),
+    ):
+        with pytest.raises(OSError, match="disk full"):
+            await run(context)
+
+    _assert_snapshots(tmp_path, before)
+
+    context.llm = AsyncMock()
+    context.llm.complete.side_effect = [review, "- 项目状态: 不再负责项目 A"]
+    result = await run(context)
+    assert result == "profile_rebuilt:1; corrected=1; split=0"
+    assert ReflectionState.load(tmp_path).get_watermark("memory-review")
+
+
+@pytest.mark.asyncio
+async def test_watermark_failure_rolls_back_memory_and_user(tmp_path):
+    context, review = _seed(tmp_path)
+    before = _snapshots(tmp_path)
+    context.llm.complete.side_effect = [review, "- 项目状态: 不再负责项目 A"]
+
+    with patch.object(ReflectionState, "save", return_value=False):
+        with pytest.raises(OSError, match="watermark"):
+            await run(context)
+
+    _assert_snapshots(tmp_path, before)
+
+
+@pytest.mark.asyncio
+async def test_concurrent_memory_insert_is_preserved_and_review_retries(tmp_path):
+    context, review = _seed(tmp_path)
+    calls = 0
+
+    async def complete(*_args, **_kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            entries = context.memory_manager.load_entries()
+            entries.append(MemoryEntry(
+                id="newcon",
+                content="用户偏好简洁输出",
+                category="preference",
+                score=0.8,
+                created_at="2026-08-02T08:00:00+00:00",
+                last_activated="2026-08-02T08:00:00+00:00",
+                activation_count=1,
+                source_session="concurrent-session",
+            ))
+            context.memory_manager.store.save(entries)
+            return review
+        return "- 项目状态: 不再负责项目 A"
+
+    context.llm.complete.side_effect = complete
+
+    from src.everbot.core.memory.manager import IntegrityError
+    with pytest.raises(IntegrityError, match="concurrently"):
+        await run(context)
+
+    entries = {entry.id: entry for entry in context.memory_manager.load_entries()}
+    assert "newcon" in entries
+    assert entries["old001"].status == "active"
+    assert not ReflectionState.load(tmp_path).get_watermark("memory-review")
+    assert "负责 A" in (tmp_path / "USER.md").read_text(encoding="utf-8")

--- a/tests/integration/test_memory_review_atomicity.py
+++ b/tests/integration/test_memory_review_atomicity.py
@@ -164,6 +164,134 @@ async def test_concurrent_memory_insert_is_preserved_and_review_retries(tmp_path
 
 
 @pytest.mark.asyncio
+async def test_integrity_error_before_review_write_does_not_restore_over_concurrent_insert(
+    tmp_path,
+):
+    """A pre-write CAS failure must not restore snapshots over another writer."""
+    context, review = _seed(tmp_path)
+    context.llm.complete.side_effect = [review, "- 项目状态: 不再负责项目 A"]
+    original_commit = context.memory_manager.commit_review
+
+    def insert_then_reject(*args, **kwargs):
+        entries = context.memory_manager.load_entries()
+        entries.append(MemoryEntry(
+            id="latecon",
+            content="用户偏好简洁输出",
+            category="preference",
+            score=0.8,
+            created_at="2026-08-02T08:00:00+00:00",
+            last_activated="2026-08-02T08:00:00+00:00",
+            activation_count=1,
+            source_session="late-session",
+        ))
+        context.memory_manager.store.save(entries)
+        raise IntegrityError("Memory changed concurrently; review must retry")
+
+    context.memory_manager.commit_review = insert_then_reject
+    try:
+        with pytest.raises(IntegrityError, match="concurrently"):
+            await run(context)
+    finally:
+        context.memory_manager.commit_review = original_commit
+
+    entries = {entry.id: entry for entry in context.memory_manager.load_entries()}
+    assert "latecon" in entries
+    assert entries["old001"].status == "active"
+    assert not ReflectionState.load(tmp_path).get_watermark("memory-review")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "corrections",
+    [
+        [{
+            "content": "用户现在不负责项目 A",
+            "category": "fact",
+            "supersedes_ids": ["old001"],
+            "source_session": "outside-review-batch",
+        }],
+        [
+            {
+                "content": "用户现在不负责项目 A",
+                "category": "fact",
+                "supersedes_ids": ["old001"],
+                "source_session": "web_session_demo_atomic",
+            },
+            {
+                "content": "用户偏好简洁输出",
+                "category": "preference",
+                "supersedes_ids": ["old001"],
+                "source_session": "outside-review-batch",
+            },
+        ],
+    ],
+)
+async def test_untrusted_correction_source_fails_without_advancing_watermark(
+    tmp_path, corrections,
+):
+    context, _review = _seed(tmp_path)
+    before = _snapshots(tmp_path)
+    context.llm.complete.return_value = json.dumps(
+        {"corrections": corrections}, ensure_ascii=False,
+    )
+
+    with pytest.raises(ValueError, match="source_session"):
+        await run(context)
+
+    _assert_snapshots(tmp_path, before)
+
+
+@pytest.mark.asyncio
+async def test_single_session_missing_source_is_backfilled(tmp_path):
+    context, _review = _seed(tmp_path)
+    context.llm.complete.side_effect = [
+        json.dumps({
+            "corrections": [{
+                "content": "用户现在不负责项目 A",
+                "category": "fact",
+                "supersedes_ids": ["old001"],
+            }],
+        }, ensure_ascii=False),
+        "- 项目状态: 不再负责项目 A",
+    ]
+
+    result = await run(context)
+
+    assert result == "profile_rebuilt:1; corrected=1; split=0"
+    replacement = next(
+        entry for entry in context.memory_manager.load_entries()
+        if entry.status == "active"
+    )
+    assert replacement.source_session == "web_session_demo_atomic"
+
+
+@pytest.mark.asyncio
+async def test_multi_session_missing_source_fails_without_advancing_watermark(tmp_path):
+    context, _review = _seed(tmp_path)
+    second_id = "web_session_demo_second"
+    (context.sessions_dir / f"{second_id}.json").write_text(json.dumps({
+        "session_id": second_id,
+        "updated_at": "2026-08-02T08:01:00+00:00",
+        "session_type": "primary",
+        "agent_name": "demo",
+        "history_messages": [{"role": "user", "content": "补充说明"}],
+    }, ensure_ascii=False), encoding="utf-8")
+    before = _snapshots(tmp_path)
+    context.llm.complete.return_value = json.dumps({
+        "corrections": [{
+            "content": "用户现在不负责项目 A",
+            "category": "fact",
+            "supersedes_ids": ["old001"],
+        }],
+    }, ensure_ascii=False)
+
+    with pytest.raises(ValueError, match="source_session"):
+        await run(context)
+
+    _assert_snapshots(tmp_path, before)
+
+
+@pytest.mark.asyncio
 async def test_watermark_never_advances_past_sessions_sent_to_judge(tmp_path):
     sessions_dir = tmp_path / "sessions"
     sessions_dir.mkdir()

--- a/tests/unit/test_execution_gate.py
+++ b/tests/unit/test_execution_gate.py
@@ -152,3 +152,42 @@ class TestGateCommit:
 
         state = ReflectionState.load(tmp_path)
         assert state.get_watermark("") == ""
+
+    def test_commit_preserves_watermark_advanced_by_job(self, tmp_path: Path):
+        """A partial-batch job owns its exact analyzed-session boundary."""
+        task = _make_task(job="memory-review")
+        scanner = MagicMock()
+        scanner.check.return_value = ScanResult(
+            has_changes=True, change_summary="5 new sessions",
+        )
+        gate = TaskExecutionGate(tmp_path, "agent", lambda _type: scanner)
+        verdict = gate.check(task)
+
+        job_watermark = "2026-08-02T08:03:00+00:00"
+        state = ReflectionState.load(tmp_path)
+        state.set_watermark("memory-review", job_watermark)
+        assert state.save(tmp_path)
+
+        gate.commit(task, verdict)
+
+        assert (
+            ReflectionState.load(tmp_path).get_watermark("memory-review")
+            == job_watermark
+        )
+
+    def test_commit_advances_when_job_left_watermark_unchanged(self, tmp_path: Path):
+        task = _make_task(job="test-skill")
+        initial = "2026-08-01T00:00:00+00:00"
+        state = ReflectionState.load(tmp_path)
+        state.set_watermark("test-skill", initial)
+        assert state.save(tmp_path)
+        scanner = MagicMock()
+        scanner.check.return_value = ScanResult(
+            has_changes=True, change_summary="new session",
+        )
+        gate = TaskExecutionGate(tmp_path, "agent", lambda _type: scanner)
+        verdict = gate.check(task)
+
+        gate.commit(task, verdict)
+
+        assert ReflectionState.load(tmp_path).get_watermark("test-skill") > initial

--- a/tests/unit/test_inspector.py
+++ b/tests/unit/test_inspector.py
@@ -17,6 +17,8 @@ from src.everbot.core.runtime.inspector import (
 )
 from src.everbot.core.runtime.reflection import ReflectionManager
 from src.everbot.core.tasks.routine_manager import RoutineManager
+from src.everbot.core.memory.manager import MemoryManager
+from src.everbot.core.memory.models import MemoryEntry
 
 
 class _StubUserDataManager:
@@ -48,6 +50,27 @@ def _make_inspector(tmp_path: Path, **overrides) -> Inspector:
         return_value=_StubUserDataManager(tmp_path / ".alfred"),
     ):
         return Inspector(**defaults)
+
+
+def test_reflect_prompt_uses_active_memory_projection_only(tmp_path):
+    manager = MemoryManager(tmp_path / "MEMORY.md")
+    manager.store.save([
+        MemoryEntry.from_dict({
+            "id": "active1", "content": "用户现在不负责项目 A",
+            "category": "fact", "score": 0.9, "status": "active",
+        }),
+        MemoryEntry.from_dict({
+            "id": "old001", "content": "用户负责项目 A",
+            "category": "fact", "score": 0.19, "status": "superseded",
+        }),
+    ])
+    inspector = _make_inspector(tmp_path)
+
+    context = inspector._gather_context(heartbeat_content="heartbeat")
+    prompt = inspector._build_reflect_prompt(context)
+
+    assert "用户现在不负责项目 A" in prompt
+    assert "用户负责项目 A" not in prompt
 
 
 def _make_reflection_response_with_proposals(proposals: list[dict]) -> str:

--- a/tests/unit/test_memory_correction.py
+++ b/tests/unit/test_memory_correction.py
@@ -53,6 +53,48 @@ def test_explicit_correction_supersedes_old_fact_and_is_idempotent(tmp_path):
     assert len(replayed) == len(projected)
 
 
+def test_partially_overlapping_corrections_coalesce_one_active_replacement(tmp_path):
+    manager = MemoryManager(tmp_path / "MEMORY.md")
+    existing = [
+        _entry("old001", "用户负责项目 A 的研发"),
+        _entry("old002", "用户负责项目 A 的发布"),
+    ]
+    review = {
+        "corrections": [
+            {
+                "content": "用户现在不负责项目 A",
+                "category": "fact",
+                "supersedes_ids": ["old001"],
+                "source_session": "web_session_demo_42",
+            },
+            {
+                "content": "用户现在不负责项目 A",
+                "category": "fact",
+                "supersedes_ids": ["old001", "old002"],
+                "source_session": "web_session_demo_42",
+            },
+        ],
+    }
+
+    projected, stats = manager.preview_review(review, existing)
+
+    active = [entry for entry in projected if entry.status == "active"]
+    assert len(active) == 1
+    assert active[0].content == "用户现在不负责项目 A"
+    assert set(active[0].supersedes) == {"old001", "old002"}
+    for source_id in ("old001", "old002"):
+        source = next(entry for entry in projected if entry.id == source_id)
+        assert source.status == "superseded"
+        assert source.superseded_by == [active[0].id]
+    assert stats["corrected"] == 2
+
+    replayed, replay_stats = manager.preview_review(review, projected)
+    assert replay_stats["corrected"] == 0
+    assert [entry.to_dict() for entry in replayed] == [
+        entry.to_dict() for entry in projected
+    ]
+
+
 def test_correction_without_active_conflict_is_rejected(tmp_path):
     manager = MemoryManager(tmp_path / "MEMORY.md")
     existing = [_entry("other1", "用户喜欢 Python")]
@@ -135,3 +177,25 @@ async def test_review_prompt_keeps_recent_correction_from_long_digest():
     prompt = llm.complete.await_args.args[0]
     assert "source_session:web_session_demo_long" in prompt
     assert "我现在不负责项目 A 啦" in prompt
+
+
+@pytest.mark.asyncio
+async def test_review_prompt_excludes_superseded_entries():
+    llm = AsyncMock()
+    llm.complete.return_value = "{}"
+    old = _entry("old001", "用户负责项目 A")
+    old.status = "superseded"
+    old.superseded_by = ["new001"]
+    new = _entry("new001", "用户现在不负责项目 A")
+    new.supersedes = ["old001"]
+
+    await _analyze_memory_consolidation(
+        llm,
+        ["[source_session:web_session_demo_new]\n[user] 普通对话"],
+        [old, new],
+    )
+
+    prompt = llm.complete.await_args.args[0]
+    assert "用户现在不负责项目 A" in prompt
+    assert "用户负责项目 A" not in prompt
+    assert "[old001]" not in prompt

--- a/tests/unit/test_memory_correction.py
+++ b/tests/unit/test_memory_correction.py
@@ -1,0 +1,137 @@
+"""Unit tests for explicit memory correction and atomic fact boundaries (#188)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.everbot.core.jobs.memory_review import _analyze_memory_consolidation
+from src.everbot.core.memory.manager import MemoryManager
+from src.everbot.core.memory.models import MemoryEntry
+
+
+def _entry(entry_id: str, content: str, *, score: float = 0.8) -> MemoryEntry:
+    return MemoryEntry(
+        id=entry_id,
+        content=content,
+        category="fact",
+        score=score,
+        created_at="2026-07-01T00:00:00+00:00",
+        last_activated="2026-07-01T00:00:00+00:00",
+        activation_count=1,
+        source_session="old-session",
+    )
+
+
+def test_explicit_correction_supersedes_old_fact_and_is_idempotent(tmp_path):
+    manager = MemoryManager(tmp_path / "MEMORY.md")
+    existing = [_entry("old001", "用户负责项目 A")]
+    review = {
+        "corrections": [{
+            "content": "用户现在不负责项目 A",
+            "category": "fact",
+            "supersedes_ids": ["old001"],
+            "source_session": "web_session_demo_42",
+        }],
+    }
+
+    projected, stats = manager.preview_review(review, existing)
+    active = [entry for entry in projected if entry.status == "active"]
+    old = next(entry for entry in projected if entry.id == "old001")
+
+    assert stats["corrected"] == 1
+    assert len(active) == 1
+    assert active[0].content == "用户现在不负责项目 A"
+    assert active[0].supersedes == ["old001"]
+    assert active[0].source_session == "web_session_demo_42"
+    assert old.status == "superseded"
+    assert old.superseded_by == [active[0].id]
+
+    replayed, replay_stats = manager.preview_review(review, projected)
+    assert replay_stats["corrected"] == 0
+    assert len(replayed) == len(projected)
+
+
+def test_correction_without_active_conflict_is_rejected(tmp_path):
+    manager = MemoryManager(tmp_path / "MEMORY.md")
+    existing = [_entry("other1", "用户喜欢 Python")]
+
+    projected, stats = manager.preview_review({
+        "corrections": [{
+            "content": "用户现在不负责项目 A",
+            "category": "fact",
+            "supersedes_ids": ["missing"],
+        }],
+    }, existing)
+
+    assert stats["corrected"] == 0
+    assert [entry.to_dict() for entry in projected] == [entry.to_dict() for entry in existing]
+
+
+def test_split_giant_record_creates_independent_durable_facts(tmp_path):
+    manager = MemoryManager(tmp_path / "MEMORY.md")
+    giant = _entry(
+        "giant1",
+        "用户偏好简洁输出；负责项目A；昨天连接超时；临时排查任务进行中",
+        score=0.22,
+    )
+    review = {
+        "split_entries": [{
+            "id": "giant1",
+            "entries": [
+                {"content": "用户偏好简洁输出", "category": "preference", "importance": "high"},
+                {"content": "用户负责项目 A", "category": "fact", "importance": "medium"},
+                {"content": "昨天连接超时", "category": "incident", "importance": "low"},
+            ],
+        }],
+    }
+
+    projected, stats = manager.preview_review(review, [giant])
+    active = [entry for entry in projected if entry.status == "active"]
+    source = next(entry for entry in projected if entry.id == "giant1")
+
+    assert stats["split"] == 1
+    assert {entry.content for entry in active} == {"用户偏好简洁输出", "用户负责项目 A"}
+    assert all(entry.supersedes == ["giant1"] for entry in active)
+    assert source.status == "superseded"
+    assert set(source.superseded_by) == {entry.id for entry in active}
+
+
+def test_prompt_memory_excludes_superseded_entries(tmp_path):
+    manager = MemoryManager(tmp_path / "MEMORY.md")
+    old = _entry("old001", "用户负责项目 A")
+    old.status = "superseded"
+    old.superseded_by = ["new001"]
+    new = _entry("new001", "用户现在不负责项目 A")
+    new.supersedes = ["old001"]
+    manager.store.save([old, new])
+
+    prompt = manager.get_prompt_memories()
+
+    assert "用户现在不负责项目 A" in prompt
+    assert "用户负责项目 A" not in prompt
+
+    recalled = manager.recall("项目 A", kind="profile", top_k=10)
+    assert [item["id"] for item in recalled] == ["new001"]
+
+
+@pytest.mark.asyncio
+async def test_review_prompt_keeps_recent_correction_from_long_digest():
+    llm = AsyncMock()
+    llm.complete.return_value = "{}"
+    digest = (
+        "[source_session:web_session_demo_long]\n"
+        + ("[assistant] earlier context\n" * 100)
+        + "[user] 我现在不负责项目 A 啦"
+    )
+
+    await _analyze_memory_consolidation(
+        llm,
+        [digest],
+        [_entry("old001", "用户负责项目 A")],
+    )
+
+    prompt = llm.complete.await_args.args[0]
+    assert "source_session:web_session_demo_long" in prompt
+    assert "我现在不负责项目 A 啦" in prompt

--- a/tests/unit/test_memory_manager.py
+++ b/tests/unit/test_memory_manager.py
@@ -10,7 +10,7 @@ import pytest
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from src.everbot.core.memory.manager import MemoryManager
+from src.everbot.core.memory.manager import IntegrityError, MemoryManager
 from src.everbot.core.memory.models import MemoryEntry
 from src.everbot.core.memory.profile_store import ProfileStore
 
@@ -113,6 +113,79 @@ class TestProcessSessionEnd:
             [{"role": "user", "content": "hello"}], "s1"
         )
         assert stats["profile"]["new_count"] == 0
+
+    @pytest.mark.asyncio
+    async def test_extractor_prompt_excludes_superseded_entries(self, tmp_path: Path):
+        md = tmp_path / "MEMORY.md"
+        old = MemoryEntry.from_dict({
+            "id": "old001", "content": "用户负责项目 A", "category": "fact",
+            "score": 0.19, "status": "superseded", "superseded_by": ["new001"],
+        })
+        new = MemoryEntry.from_dict({
+            "id": "new001", "content": "用户现在不负责项目 A", "category": "fact",
+            "score": 0.9, "status": "active", "supersedes": ["old001"],
+        })
+        ProfileStore(md).save([old, new])
+        captured = []
+
+        async def capture(_self, prompt):
+            captured.append(prompt)
+            return _mock_llm_response([], [])
+
+        with patch(
+            "src.everbot.core.memory.profile_extractor.ProfileExtractor._call_llm",
+            new=capture,
+        ):
+            await MemoryManager(md, MagicMock()).process_session_end(
+                [{"role": "user", "content": "普通对话"}], "session-new",
+            )
+
+        assert "用户现在不负责项目 A" in captured[0]
+        assert "用户负责项目 A" not in captured[0]
+        assert "old001" not in captured[0]
+
+    @pytest.mark.asyncio
+    async def test_session_end_does_not_overwrite_concurrent_review_commit(self, tmp_path: Path):
+        md = tmp_path / "MEMORY.md"
+        original = MemoryEntry.from_dict({
+            "id": "old001", "content": "用户负责项目 A", "category": "fact",
+            "score": 0.8, "status": "active",
+        })
+        ProfileStore(md).save([original])
+        manager = MemoryManager(md, MagicMock())
+
+        async def commit_correction_during_extract(_self, _prompt):
+            current = manager.load_entries()
+            corrected, _ = manager.preview_review({
+                "corrections": [{
+                    "content": "用户现在不负责项目 A",
+                    "category": "fact",
+                    "supersedes_ids": ["old001"],
+                    "source_session": "review-session",
+                }],
+            }, current)
+            manager.commit_review(
+                corrected,
+                expected_fingerprint=manager.entries_fingerprint(current),
+            )
+            return _mock_llm_response(
+                [{"content": "用户喜欢 Python", "category": "preference", "importance": "high"}],
+                [],
+            )
+
+        with patch(
+            "src.everbot.core.memory.profile_extractor.ProfileExtractor._call_llm",
+            new=commit_correction_during_extract,
+        ):
+            with pytest.raises(IntegrityError, match="concurrently"):
+                await manager.process_session_end(
+                    [{"role": "user", "content": "我喜欢 Python"}], "session-new",
+                )
+
+        entries = manager.load_entries()
+        assert next(entry for entry in entries if entry.id == "old001").status == "superseded"
+        assert any(entry.content == "用户现在不负责项目 A" for entry in entries)
+        assert all(entry.content != "用户喜欢 Python" for entry in entries)
 
 
 class TestIncrementalExtraction:

--- a/tests/unit/test_profile_store.py
+++ b/tests/unit/test_profile_store.py
@@ -145,6 +145,29 @@ class TestProfileStoreSave:
         content = md.read_text(encoding="utf-8")
         assert content.index("[high]") < content.index("[mid]") < content.index("[low]")
 
+    def test_superseded_trace_does_not_consume_active_capacity(self, tmp_path: Path):
+        md = tmp_path / "MEMORY.md"
+        store = ProfileStore(md)
+        active = [
+            _make_entry(id=f"active{i:02d}", score=0.9 - i / 1000)
+            for i in range(store.MAX_ENTRIES)
+        ]
+        traces = [
+            _make_entry(
+                id=f"trace{i:02d}", status="superseded", score=0.01,
+                last_activated=f"2026-08-{i + 1:02d}T00:00:00+00:00",
+            )
+            for i in range(7)
+        ]
+
+        store.save(active + traces)
+        loaded = store.load()
+
+        assert {entry.id for entry in loaded if entry.status == "active"} == {
+            entry.id for entry in active
+        }
+        assert len([entry for entry in loaded if entry.status == "superseded"]) == 5
+
 
 class TestProfileStoreRoundTrip:
     """Save then load should preserve data."""

--- a/tests/unit/test_profile_store.py
+++ b/tests/unit/test_profile_store.py
@@ -167,6 +167,33 @@ class TestProfileStoreRoundTrip:
             assert entry.content == orig.content
             assert abs(entry.score - orig.score) < 0.01
 
+    def test_round_trip_preserves_supersede_relations_and_source(self, tmp_path: Path):
+        md = tmp_path / "MEMORY.md"
+        store = ProfileStore(md)
+        replacement = _make_entry(
+            id="new123",
+            content="用户现在不负责项目 A",
+            source_session="web_session_demo_42",
+            supersedes=["old123"],
+        )
+        obsolete = _make_entry(
+            id="old123",
+            content="用户负责项目 A",
+            status="superseded",
+            superseded_by=["new123"],
+            score=0.01,
+        )
+
+        store.save([replacement, obsolete])
+        loaded = {entry.id: entry for entry in store.load()}
+
+        assert loaded["new123"].status == "active"
+        assert loaded["new123"].supersedes == ["old123"]
+        assert loaded["new123"].source_session == "web_session_demo_42"
+        assert loaded["old123"].status == "superseded"
+        assert loaded["old123"].superseded_by == ["new123"]
+        assert "## Archived Memories" in md.read_text(encoding="utf-8")
+
 
 class TestMemoryEntryKind:
     """MEMORY.md is profile-only — all entries loaded from it carry kind='profile'."""

--- a/tests/unit/test_self_reflection.py
+++ b/tests/unit/test_self_reflection.py
@@ -541,10 +541,9 @@ class TestSkillWithoutScanner:
         )
 
         result = await run(ctx)
-        # Silent job — None always; verify processing actually ran by
-        # checking the watermark advanced (only set on successful completion).
+        # Review reports the projection terminal and advances the watermark.
         from src.everbot.core.scanners.reflection_state import ReflectionState
-        assert result is None
+        assert result == "profile_cleared; corrected=0; split=0"
         assert ReflectionState.load(tmp_path).get_watermark("memory-review")
 
     @pytest.mark.asyncio
@@ -567,7 +566,7 @@ class TestSkillWithoutScanner:
         )
 
         result = await run(ctx)
-        assert result is None
+        assert result == "profile_cleared"
         assert not mock_llm.complete.called
 
     @pytest.mark.asyncio
@@ -594,7 +593,7 @@ class TestSkillWithoutScanner:
         )
 
         result = await run(ctx)
-        # Silent job — verify watermark advanced (proves completion).
+        # Silent task-discover job — watermark proves completion.
         from src.everbot.core.scanners.reflection_state import ReflectionState
         assert result is None
         assert ReflectionState.load(tmp_path).get_watermark("task-discover")
@@ -638,9 +637,9 @@ class TestSkillWithoutScanner:
         )
 
         result = await run(ctx)
-        # Silent job — verify watermark advanced (proves completion).
+        # Projection terminal plus watermark prove completion.
         from src.everbot.core.scanners.reflection_state import ReflectionState
-        assert result is None
+        assert result == "profile_cleared; corrected=0; split=0"
         assert ReflectionState.load(tmp_path).get_watermark("memory-review")
 
     @pytest.mark.asyncio

--- a/tests/unit/test_session_manager_core.py
+++ b/tests/unit/test_session_manager_core.py
@@ -1443,8 +1443,8 @@ class TestFailureMemoryPersistence:
 class TestSaveSessionMilkieSafe:
     """save_session must NOT crash on a milkie handle (no .executor/.snapshot).
 
-    - memory extraction (MemoryManager) is dolphin-only → skipped for milkie.
-    - history compression (SessionCompressor) is dolphin-only → skipped.
+    - session-end MemoryManager extraction is gone; save_session must not build it.
+    - history compression remains provider-neutral shared policy.
     - export_session / session_created_at route through provider.
     """
 
@@ -1493,7 +1493,7 @@ class TestSaveSessionMilkieSafe:
 
         manager.update_atomic = fake_update_atomic
 
-        # primary session_type triggers both memory-extraction + compression guards.
+        # primary session_type still runs shared history compression guards.
         await manager.save_session("web_session_test_agent", handle)
 
         # No crash; export routed through provider; history persisted.
@@ -1501,8 +1501,8 @@ class TestSaveSessionMilkieSafe:
         assert captured["data"].history_messages == [{"role": "user", "content": "hi"}]
 
     @pytest.mark.asyncio
-    async def test_milkie_skips_memory_extraction(self, tmp_path: Path, monkeypatch):
-        """MemoryManager (in-process) must NOT be constructed for milkie."""
+    async def test_save_session_does_not_construct_memory_manager(self, tmp_path: Path, monkeypatch):
+        """save_session must not run in-process profile extraction."""
         import importlib
         from types import SimpleNamespace
         mm_mod = importlib.import_module(
@@ -1541,7 +1541,7 @@ class TestSaveSessionMilkieSafe:
 
         await manager.save_session("web_session_test_agent", handle)
 
-        assert mm_built["n"] == 0, "MemoryManager must be skipped for milkie"
+        assert mm_built["n"] == 0, "MemoryManager must not be constructed in save_session"
 
 
 # ===========================================================================

--- a/tests/unit/test_workspace_loader.py
+++ b/tests/unit/test_workspace_loader.py
@@ -83,3 +83,20 @@ def test_build_system_prompt_no_memory_when_empty(tmp_path: Path):
     prompt = loader.build_system_prompt()
 
     assert "记忆" not in prompt
+
+
+def test_derived_user_profile_is_only_memory_projection(tmp_path: Path):
+    (tmp_path / "USER.md").write_text(
+        "# 用户画像\n\n<!-- derived_from_memory: true -->\n\n- 项目: 不再负责 A\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "MEMORY.md").write_text(
+        "## Archived Memories\n\n用户负责项目 A\n",
+        encoding="utf-8",
+    )
+
+    prompt = WorkspaceLoader(tmp_path).build_system_prompt()
+
+    assert "不再负责 A" in prompt
+    assert "用户负责项目 A" not in prompt
+    assert "# 记忆" not in prompt


### PR DESCRIPTION
## 变更说明

Closes #188

明确用户纠正此前无法可靠进入记忆：Milkie 会话结束跳过画像提取，Memory Review 不能表达 supersede/split，低分集合又会保留旧 USER.md；下一会话还同时注入原始 MEMORY 与 USER 投影。

本 PR：

- 为画像事实增加 active/superseded 状态、supersedes/superseded_by 关系和来源 session
- 扩展 Memory Review judge 契约，支持明确 correction 与巨型混合记录 split
- 保持 legacy MEMORY header，关系存为可选 metadata comment；旧文件无需迁移
- 每次成功 review 原子重建 USER.md；无活跃事实写中性画像
- consolidation、compression 完成后才进入 MEMORY/USER/watermark 可恢复提交边界
- 写入或 watermark 失败回滚全部活动文件；并发 MEMORY 变化拒绝提交且不推进 watermark
- USER 派生标记生效后，下一会话只注入 USER 投影，不再注入含 superseded 溯源的原始 MEMORY
- 新增 Approved L2：`docs/design/188-memory-correction.md`

## 验收证据

- Unit：`.venv/bin/python -m pytest -q tests/unit` → `2066 passed`
- Integration + E2E（排除需真实 LLM 密钥和本机 daemon preflight 的套件）→ `92 passed`
- #188 专项：
  - 明确否定 → old fact superseded → replacement 带 source session
  - USER profile_rebuilt/profile_cleared 终态
  - 下一会话 WorkspaceLoader prompt 不含旧画像
  - 同一纠正重放幂等
  - 巨型混合记录拆为独立长期事实，incident/临时内容不进入画像
  - connection/analysis timeout、compression timeout、USER 写失败、watermark 写失败均不前移 watermark、不留半更新
  - 并发新增事实被保留，本轮 review 安全重试
- 生产现有 MEMORY/USER 做只读兼容验证：1 条 score=0.22 的 legacy giant entry 可解析，MEMORY/USER 均确实包含 kweaver-core 陈旧画像
- `git diff --check` 与 `compileall` 通过

## 测试环境说明

完整 integration 中 daemon lifecycle 的若干既有用例受本机模型环境变量与 Milkie preflight 影响；`test_slm_real_llm.py` 需要真实模型凭证，均未作为本 PR 成功证据。其余 integration/workflow 与本 PR E2E 已通过。

## 风险与回滚

MEMORY 旧 header 保持不变；新 metadata comment 对旧 reader 可读但旧代码不理解失效关系。ProfileStore 保留 MEMORY.md.bak，回滚时可恢复备份。USER 派生标记是无害 HTML comment，watermark 格式未变。

## 合并前 review 修复（0b42cad）

- watermark：prompt、correction source allowlist、成功 watermark 统一使用同一 analyzed-session batch；5 个 backlog 时首轮停在第 3 个，次轮处理第 5 个纠正
- execution gate：job 已提交精确 watermark 时不再被 gate 的 current-time commit 覆盖；普通 job 保持原防自触发语义
- bootstrap：无 session 重建 USER 时使用 MEMORY fingerprint + review lock；并发变化拒绝陈旧投影，写失败恢复旧 USER
- correction：相同 category/content 的部分重叠纠正合并 supersedes 关系；已完成重放静默 no-op，不产生重复 active
- judge context：只传 active entries，superseded 事实不再挤占或误导 consolidation prompt

新增测试先稳定复现 5 个失败边界，再实现转绿。专项/相关回归 `108 passed`；全量 Unit `2066 passed`；GitHub Python 3.10/3.11/3.12 CI 全绿。