### PR TITLE
fix(#191): enforce evolved skill version consistency

### DIFF
--- a/docs/design/191-evolve-version-consistency.md
+++ b/docs/design/191-evolve-version-consistency.md
@@ -137,6 +137,7 @@ frontmatter 解析只认可位于首个分隔块内、行首无空白的 `versio
 
 - Issue #191
 - 概要设计：Issue #191 评论
+- 实现：PR #192
 - 发现来源：Issue #187
 - 相关实现：PR #189
 - `src/everbot/core/jobs/skill_evaluate.py`

--- a/docs/design/191-evolve-version-consistency.md
+++ b/docs/design/191-evolve-version-consistency.md
@@ -1,0 +1,144 @@
+# 【SLM】保证 evolve 发布版本与技能 frontmatter 一致
+
+- Issue: #191
+- 状态: Approved
+- 最后更新: 2026-08-02
+
+## 1. 背景
+
+SLM 在评估失败后生成系统目标版本 `new_version`，再让 LLM 返回完整 `SKILL.md`。现有链路只在 prompt 中要求 LLM 同步 frontmatter 版本，结构校验却只确认存在 `version:`；`VersionManager.publish()` 又把内容原样写入 live 文件和候选快照，同时用函数参数更新 pointer。当模型保留旧版本号时，三个版本标识立即分叉，下一轮 `ensure_registered()` 将其识别为 `CONFLICT_DETECTED`，候选无法继续评估或激活。该问题在扩展 #187 的完整 SLM lifecycle E2E 时被稳定复现。概要设计经用户于 2026-08-02 明确批准。
+
+## 2. 名词解释
+
+| 术语 | 含义 |
+|------|------|
+| target version | SLM 根据当前版本和时间生成、用于本次 evolve 发布的系统版本号 |
+| content version | `SKILL.md` 首个 frontmatter 内唯一顶层 `version` 字段的值 |
+| publish invariant | publish 开始任何写入前必须满足 `content version == target version` |
+| version triplet | live `SKILL.md`、候选 snapshot 和 current pointer 中的三个版本标识 |
+
+## 3. 设计目标与非目标
+
+- **目标**：模型输出携带旧版本号时，由系统确定性改写为 target version，而不是发布冲突状态。
+- **目标**：`VersionManager.publish()` 对所有调用方实施写前版本一致性保护。
+- **目标**：非法或歧义 frontmatter 在任何 live、snapshot、metadata 或 pointer 写入前被拒绝。
+- **目标**：完整 E2E 证明候选从 TESTING 进入 ACTIVE，随后无新增样本时返回 skipped/no_changes。
+- **非目标**：改变 Judge、evolve 触发条件、连续 evolve 限制或激活阈值。
+- **非目标**：修改模型生成的技能正文、name 或其它 frontmatter 字段。
+- **非目标**：扫描或自动修复已存在的 `CONFLICT_DETECTED` 历史状态。
+
+## 4. 能力与功能设计
+
+evolve 仍要求 LLM 返回完整技能文件，但 target version 不再属于模型自由输出。模型结果完成现有装饰清洗后，系统只在首个合法 frontmatter 中定位唯一的顶层 `version` 行，并把其标量值替换成 target version；正文及其它字段保持原字节顺序和格式。缺少版本行、出现多个顶层版本行或 frontmatter 无法闭合时，结果不可安全规范化，evolve 返回失败且不调用 publish。
+
+规范化后的内容进入 `VersionManager.publish()`。publish 独立解析 content version 并与参数 version 比较；缺失、歧义或不相等均在创建技能目录、写 live 文件或版本材料之前以 `ValueError` 拒绝。调用方规范化提升自动改进成功率，发布边界校验则保证未来 CLI、管理接口或测试调用方也不能绕过持久化不变量。
+
+### 4.1 UI / UX
+
+N/A — 无页面或用户交互变化。失败仍沿现有 evolve-failed 邮箱消息和日志呈现；本设计只消除可确定修复的旧版本号失败。
+
+## 5. 设计思路与折衷
+
+选择“调用方确定性规范化 + 发布边界写前验证”的双层方案。版本号由系统命名和状态机引用，本质上是控制面元数据，不应依赖概率模型正确复制。仅在 `_maybe_evolve` 校验相等会避免冲突，但会把一次可安全修正的漏改变成自动改进失败；仅在 `publish()` 内静默改写则会让底层存储层承担内容生成策略，并掩盖其它调用方传错版本。因此规范化属于 evolve 适配层，强制不变量属于 version manager。
+
+放弃继续强化 prompt，因为提示词不能提供确定性契约。放弃引入 YAML 库重序列化整个 frontmatter，因为这可能改变引号、注释、键顺序和多行标量，扩大技能内容 diff。选择受限文本变换：只接受首个 frontmatter 中唯一、无缩进的 `version:` 行；正文中的同名文本和嵌套字段不参与判断。缺失或重复字段不自动猜测，直接拒绝。
+
+## 6. 架构设计
+
+### 6.1 逻辑分层
+
+```mermaid
+flowchart LR
+  J["Judge: unhealthy report"] --> E["_maybe_evolve"]
+  E --> L["LLM generated SKILL.md"]
+  L --> S["sanitize decorations"]
+  S --> N{"normalize unique frontmatter version"}
+  N -->|invalid or ambiguous| F["evolve failed; no publish"]
+  N -->|target version injected| P{"VersionManager.publish preflight"}
+  P -->|version mismatch| F
+  P -->|invariant holds| W["write live + snapshot + metadata + pointer"]
+  W --> R["ensure_registered: NOOP"]
+  R --> A["candidate evaluate and activate"]
+```
+
+### 6.2 核心业务流程
+
+```mermaid
+sequenceDiagram
+  participant E as Skill Evaluate
+  participant L as Evolve LLM
+  participant N as Version Normalizer
+  participant V as VersionManager
+  participant S as State Normalizer
+
+  E->>E: generate target version
+  E->>L: request improved SKILL.md
+  L-->>E: valid content with stale version
+  E->>N: normalize(content, target)
+  N-->>E: content with target version
+  E->>V: publish(skill, target, content)
+  V->>V: preflight content version == target
+  V->>V: persist version triplet
+  E->>S: next evaluation registration check
+  S-->>E: NOOP, candidate remains evaluable
+  E->>V: activate after promotable report
+```
+
+失败路径在 normalizer 或 publish preflight 结束，不发生任何存储变更。既有 symlink-managed 检查继续拒绝可能覆盖上游的发布；其错误语义不变。
+
+## 7. 模块设计
+
+| 模块 | 契约 |
+|------|------|
+| `core/jobs/skill_evaluate.py` | 清洗 LLM 输出后，将首个 frontmatter 的唯一顶层版本字段规范化为 target version；无法安全规范化时不调用 publish |
+| `core/slm/version_manager.py` | 提供一致的 frontmatter version 解析语义；`publish()` 在任何写操作前强制 content/target 相等 |
+| `core/slm/state_normalizer.py` | 不改变；继续把人工篡改或历史不一致识别为 `CONFLICT_DETECTED`，作为下游防线 |
+| lifecycle E2E | LLM stub 故意保留 baseline 版本，验证生产代码完成规范化并走通 activate |
+
+frontmatter 解析只认可位于首个分隔块内、行首无空白的 `version:`。唯一性判断基于顶层候选行数量；值允许既有单引号、双引号或无引号格式，规范化输出统一为 `version: "{target}"`，不改其它行。
+
+## 8. API / CLI 设计
+
+无公共 API 或 CLI 变化。内部 Python 契约调整如下：
+
+- evolve 版本规范化函数接收完整技能文本和 target version，成功返回规范化文本，非法/歧义输入返回不可发布结果。
+- `_validate_skill_md` 支持校验 expected version，使调用方可以同时证明结构有效和版本正确。
+- `VersionManager.publish(skill_id, version, skill_content)` 签名保持不变，但新增前置条件：content version 必须唯一且等于 `version`；违反时抛出 `ValueError`，且不得产生写入。
+
+## 9. 边界考虑
+
+- 版本字段中的 `#`、多行标量、空值或额外尾随内容不做猜测；无法得到唯一标量时拒绝。
+- 正文代码块或示例中的 `version:` 不参与规范化和 publish 校验。
+- target version 沿用现有系统生成格式，不接收 LLM 提供的替代值。
+- publish preflight 位于 `mkdir`、live 写入、asset symlink、snapshot、metadata 和 pointer 写入之前，保证 S2 的零部分写入。
+- 调用方仍须遵守既有 per-skill 文件锁；本设计不改变并发模型。
+- symlink-managed 技能仍在写入前拒绝；版本检查与 symlink 检查均不得造成磁盘变化。
+- 不新增依赖、不处理权限或多租户边界，也不记录任何凭证。
+
+## 10. 迁移 / 兼容 / 回滚
+
+无需数据迁移，版本目录和 pointer JSON 格式不变。所有现有合法 `publish()` 调用内容版本本就与参数一致，行为保持不变；依赖不一致内容被接受的调用会改为写前 `ValueError`，这是有意收紧。历史冲突不会自动修复，仍由现有诊断路径暴露。
+
+回滚代码不会影响已发布的一致候选，但会重新允许未来不一致写入。若回滚，必须同时撤销 lifecycle 回归断言，并接受 #191 风险重新出现；不需要清理新数据格式。
+
+## 11. 测试计划
+
+- **E2E（S1/S3）**：LLM stub 返回结构合法但保持 baseline version；执行 baseline 三条失败样本 → Skill Evaluate 产生 TESTING candidate，断言 live、snapshot、pointer 都是 target version且注册为 NOOP；为 candidate 写入三条健康样本 → 再次评估并激活 ACTIVE；第三次执行断言 skipped/no_changes，整个流程无 `CONFLICT_DETECTED`。
+- **Integration（S2）**：分别用缺少 frontmatter version、重复顶层 version 和 content/target 不一致直接调用 publish；断言抛出 `ValueError`，且 live 内容、已有 pointer、已有版本列表均保持调用前状态。
+- **Unit（S1/S2）**：覆盖旧版本替换、单双引号/无引号、正文 `version:` 不误判、缺失字段、重复字段、未闭合 frontmatter、expected version 校验；覆盖 publish preflight 在首次发布和已有稳定版本两种状态下零写入拒绝。
+
+## 12. 开放问题 / 决策记录
+
+- 2026-08-02：用户明确批准 L1，选择系统维护 target version，不依赖 LLM 正确复制。
+- 2026-08-02：选择受限文本规范化，不引入 YAML 重序列化依赖。
+- 2026-08-02：publish 保持签名不变并新增写前不变量；历史冲突修复不在本 issue。
+
+## 13. 关联
+
+- Issue #191
+- 概要设计：Issue #191 评论
+- 发现来源：Issue #187
+- 相关实现：PR #189
+- `src/everbot/core/jobs/skill_evaluate.py`
+- `src/everbot/core/slm/version_manager.py`
+- `src/everbot/core/slm/state_normalizer.py`

--- a/src/everbot/core/jobs/skill_evaluate.py
+++ b/src/everbot/core/jobs/skill_evaluate.py
@@ -20,7 +20,7 @@ from ..runtime.skill_context import SkillContext
 from ..slm.judge import evaluate_skill
 from ..slm.models import EvaluationSegment, EvalReport, VersionStatus
 from ..slm.segment_logger import SegmentLogger
-from ..slm.version_manager import VersionManager
+from ..slm.version_manager import VersionManager, extract_frontmatter_version
 from ..slm._atomic_io import skill_lock
 
 logger = logging.getLogger(__name__)
@@ -429,10 +429,15 @@ async def _maybe_evolve(
         return None
 
     new_content = _sanitize_llm_skill_md(new_content)
-    if not _validate_skill_md(new_content):
-        preview = (new_content or "")[:200].replace("\n", "\\n")
+    validation_preview = (new_content or "")[:200].replace("\n", "\\n")
+    new_content = _normalize_skill_md_version(new_content, new_version)
+    if new_content is None or not _validate_skill_md(
+        new_content, expected_version=new_version,
+    ):
         logger.warning(
-            "Evolve output for %s failed validation. Preview: %r", skill_id, preview
+            "Evolve output for %s failed validation. Preview: %r",
+            skill_id,
+            validation_preview,
         )
         return None
 
@@ -495,15 +500,58 @@ def _sanitize_llm_skill_md(content: str) -> str:
     return text
 
 
-def _validate_skill_md(content: str) -> bool:
+def _normalize_skill_md_version(content: str, target_version: str) -> str | None:
+    """Replace the unique valid frontmatter version with a system target.
+
+    Only the first frontmatter block is touched.  Invalid or ambiguous input
+    returns ``None`` so evolve can fail without reaching the persistence layer.
+    """
+    if extract_frontmatter_version(content) is None:
+        return None
+    if (
+        not target_version
+        or any(char in target_version for char in ('"', "\r", "\n"))
+    ):
+        return None
+
+    frontmatter = re.match(
+        r"\A---[ \t]*\r?\n(?P<body>.*?)(?P<closing>\r?\n---[ \t]*(?=\r?\n|\Z))",
+        content,
+        re.DOTALL,
+    )
+    if frontmatter is None:
+        return None
+    body = frontmatter.group("body")
+    version_lines = list(re.finditer(r"(?m)^version:[^\r\n]*$", body))
+    if len(version_lines) != 1:
+        return None
+
+    version_line = version_lines[0]
+    body = (
+        body[:version_line.start()]
+        + f'version: "{target_version}"'
+        + body[version_line.end():]
+    )
+    normalized = (
+        content[:frontmatter.start("body")]
+        + body
+        + content[frontmatter.end("body"):]
+    )
+    return (
+        normalized
+        if extract_frontmatter_version(normalized) == target_version
+        else None
+    )
+
+
+def _validate_skill_md(
+    content: str,
+    *,
+    expected_version: str | None = None,
+) -> bool:
     if not content or not content.strip():
         return False
-    if not re.search(r"^---\s*\n", content):
+    version = extract_frontmatter_version(content)
+    if version is None:
         return False
-    match = re.search(r"^---\s*\n(.*?)\n---", content, re.DOTALL)
-    if not match:
-        return False
-    frontmatter = match.group(1)
-    if "version:" not in frontmatter:
-        return False
-    return True
+    return expected_version is None or version == expected_version

--- a/src/everbot/core/slm/version_manager.py
+++ b/src/everbot/core/slm/version_manager.py
@@ -18,6 +18,50 @@ from .models import CurrentPointer, EvalReport, VersionMetadata, VersionStatus
 logger = logging.getLogger(__name__)
 
 
+_FRONTMATTER_RE = re.compile(
+    r"\A---[ \t]*\r?\n(?P<body>.*?)(?P<closing>\r?\n---[ \t]*(?=\r?\n|\Z))",
+    re.DOTALL,
+)
+_VERSION_LINE_RE = re.compile(
+    r"^version:[ \t]*(?:"
+    r'"(?P<double>[^"\r\n]+)"'
+    r"|'(?P<single>[^'\r\n]+)'"
+    r"|(?P<plain>[A-Za-z0-9][A-Za-z0-9._+\-]*))"
+    r"[ \t]*(?:#[^\r\n]*)?$"
+)
+
+
+def extract_frontmatter_version(skill_content: str) -> Optional[str]:
+    """Return the unique top-level frontmatter version, or ``None``.
+
+    The parser is deliberately strict because callers use it as a persistence
+    invariant: missing, duplicate, indented, or ambiguous version fields must
+    not be guessed.  ``version:`` text outside the first frontmatter block is
+    ignored.
+    """
+    if not isinstance(skill_content, str):
+        return None
+    frontmatter = _FRONTMATTER_RE.match(skill_content)
+    if frontmatter is None:
+        return None
+
+    values: list[str] = []
+    for line in frontmatter.group("body").splitlines():
+        if not line.startswith("version:"):
+            continue
+        match = _VERSION_LINE_RE.fullmatch(line)
+        if match is None:
+            return None
+        value = next(
+            group for group in match.group("double", "single", "plain")
+            if group is not None
+        ).strip()
+        if not value:
+            return None
+        values.append(value)
+    return values[0] if len(values) == 1 else None
+
+
 def read_frontmatter_version(skill_md_path: Path) -> str:
     """Extract version from SKILL.md frontmatter. Returns 'baseline' if absent.
 
@@ -30,14 +74,7 @@ def read_frontmatter_version(skill_md_path: Path) -> str:
         text = skill_md_path.read_text(encoding="utf-8")
     except (UnicodeDecodeError, OSError):
         return "baseline"
-    match = re.search(r"^---\s*\n(.*?)\n---", text, re.DOTALL)
-    if not match:
-        return "baseline"
-    for line in match.group(1).splitlines():
-        m = re.match(r'version:\s*["\']?([^"\']+)["\']?', line.strip())
-        if m:
-            return m.group(1).strip()
-    return "baseline"
+    return extract_frontmatter_version(text) or "baseline"
 
 
 class VersionManager:
@@ -237,11 +274,22 @@ class VersionManager:
         2. Snapshot to .eval/versions/v{version}/
         3. Update current.json while preserving the existing stable target
 
+        Before any write, the unique SKILL.md frontmatter version must equal
+        ``version``. Missing, ambiguous, or mismatched content is rejected.
+
         Refuses to operate on symlink-managed skills: writing to the live
         SKILL.md would resolve through the symlink and overwrite the
         upstream repo file. Caller (typically _maybe_evolve) must treat
         this as evolve-failed.
         """
+        content_version = extract_frontmatter_version(skill_content)
+        if content_version != version:
+            actual = content_version if content_version is not None else "missing/ambiguous"
+            raise ValueError(
+                f"SKILL.md frontmatter version={actual!r} does not match "
+                f"publish version={version!r}"
+            )
+
         if self.is_symlink_managed(skill_id):
             raise ValueError(
                 f"{skill_id} is symlink-managed; publish would overwrite upstream. "

--- a/tests/e2e/test_slm_lifecycle_e2e.py
+++ b/tests/e2e/test_slm_lifecycle_e2e.py
@@ -1,0 +1,359 @@
+"""E2E: full SLM lifecycle through the real skill_evaluate job entry.
+
+Endpoint is not "wrote an eval report" — it is live skill replacement / iteration:
+
+  baseline SKILL.md
+    → accumulate samples
+    → Skill Evaluate (unhealthy)
+    → rollback stable target + evolve + publish TESTING candidate
+    → live SKILL.md replaced by evolved content
+    → accumulate samples on evolved version
+    → Skill Evaluate (healthy + promotable)
+    → activate: TESTING → ACTIVE, stable pointer advances
+    → third evaluate is skipped/no_changes
+
+Judge scoring is deterministic (mocked ``evaluate_skill``). Evolve content comes
+from a deliberately faulty ``context.llm.complete`` stub that keeps the baseline
+frontmatter version, proving production code owns target-version normalization.
+No network.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import List
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.everbot.core.jobs.skill_evaluate import run as run_skill_evaluate
+from src.everbot.core.slm.models import (
+    EvalReport,
+    EvaluationSegment,
+    JudgeResult,
+    VersionStatus,
+)
+from src.everbot.core.slm.segment_logger import SegmentLogger
+from src.everbot.core.slm.state_normalizer import (
+    RegistrationAction,
+    ensure_registered,
+)
+from src.everbot.core.slm.version_manager import VersionManager
+
+
+SKILL_ID = "lifecycle-skill"
+BASE_VERSION = "1.0.0"
+
+BASELINE_SKILL_MD = f"""\
+---
+name: {SKILL_ID}
+version: "{BASE_VERSION}"
+---
+# Lifecycle Skill
+
+You are the baseline skill body used by the lifecycle e2e.
+"""
+
+# Deliberately stale: the LLM ignores the prompt's target version (#191).
+EVOLVED_SKILL_MD = f"""\
+---
+name: {SKILL_ID}
+version: "{BASE_VERSION}"
+---
+# Lifecycle Skill
+
+You are an improved skill body produced by the evolve step.
+"""
+
+
+async def _evolve_complete(prompt: str, system: str = "") -> str:
+    """Mimic an LLM that improves content but forgets the version update."""
+    assert "Update the `version` field" in prompt
+    return EVOLVED_SKILL_MD
+
+
+def _write_baseline_skill(skills_dir: Path) -> Path:
+    skill_dir = skills_dir / SKILL_ID
+    skill_dir.mkdir(parents=True)
+    path = skill_dir / "SKILL.md"
+    path.write_text(BASELINE_SKILL_MD, encoding="utf-8")
+    return path
+
+
+def _append_segments(
+    logs_dir: Path,
+    *,
+    version: str,
+    count: int,
+    session_prefix: str,
+    output_prefix: str = "output",
+) -> None:
+    logger = SegmentLogger(logs_dir)
+    for i in range(count):
+        logger.append(
+            EvaluationSegment(
+                skill_id=SKILL_ID,
+                skill_version=version,
+                triggered_at=f"2026-08-02T{10 + i:02d}:00:00+00:00",
+                context_before=f"user: request {session_prefix}-{i}",
+                skill_output=f"{output_prefix} {i}",
+                context_after="user: noted",
+                session_id=f"{session_prefix}-{i}",
+            )
+        )
+
+
+def _report(
+    *,
+    version: str,
+    segment_count: int,
+    unhealthy: bool,
+) -> EvalReport:
+    if unhealthy:
+        results = [
+            JudgeResult(
+                segment_index=i,
+                has_critical_issue=True,
+                satisfaction=0.2,
+                reason="critical regression in lifecycle e2e",
+            )
+            for i in range(segment_count)
+        ]
+        critical = segment_count
+        mean = 0.2
+    else:
+        results = [
+            JudgeResult(
+                segment_index=i,
+                has_critical_issue=False,
+                satisfaction=0.9,
+                reason="accepted in lifecycle e2e",
+            )
+            for i in range(segment_count)
+        ]
+        critical = 0
+        mean = 0.9
+    return EvalReport(
+        skill_id=SKILL_ID,
+        skill_version=version,
+        evaluated_at="2026-08-02T12:00:00+00:00",
+        segment_count=segment_count,
+        critical_issue_count=critical,
+        critical_issue_rate=(critical / segment_count) if segment_count else 0.0,
+        mean_satisfaction=mean,
+        results=results,
+    )
+
+
+def _mk_context(*, logs_dir: Path, eval_dir: Path) -> SimpleNamespace:
+    mailbox = SimpleNamespace(deposit=AsyncMock(return_value=None))
+    llm = SimpleNamespace(complete=AsyncMock(side_effect=_evolve_complete))
+    return SimpleNamespace(
+        agent_name="lifecycle-agent",
+        llm=llm,
+        mailbox=mailbox,
+        skill_logs_dir=logs_dir,
+        skill_eval_dir=eval_dir,
+    )
+
+
+def _mk_udm(
+    *,
+    workspace_skills: Path,
+    logs_dir: Path,
+    sessions_dir: Path,
+    repo_skills: Path,
+) -> MagicMock:
+    udm = MagicMock()
+    udm.skill_logs_dir = logs_dir
+    udm.skills_dir = workspace_skills
+    # Keep repo_skills empty so bootstrap does NOT mark repo_baseline=True
+    # (repo_baseline rollback would unlink the live SKILL.md).
+    udm.repo_skills_dir = repo_skills
+    udm.sessions_dir = sessions_dir
+    udm.get_agent_writable_skills_dir.return_value = workspace_skills
+    udm.get_agent_read_skill_dirs.return_value = [workspace_skills]
+    udm.check_skill_override_drift.return_value = None
+    return udm
+
+
+def _mailbox_summaries(context: SimpleNamespace) -> List[str]:
+    out: List[str] = []
+    for call in context.mailbox.deposit.await_args_list:
+        if "summary" in call.kwargs:
+            out.append(str(call.kwargs["summary"]))
+        elif call.args:
+            out.append(str(call.args[0]))
+    return out
+
+
+@pytest.mark.asyncio
+async def test_full_skill_lifecycle_evaluate_evolve_activate(tmp_path: Path):
+    """baseline → unhealthy evolve/replace → healthy activate → no_changes."""
+    workspace_skills = tmp_path / "agents" / "lifecycle-agent" / "skills"
+    logs_dir = tmp_path / "skill_logs"
+    eval_dir = tmp_path / "skill_eval"
+    sessions_dir = tmp_path / "sessions"
+    repo_skills = tmp_path / "repo_skills"
+    for d in (workspace_skills, logs_dir, eval_dir, sessions_dir, repo_skills):
+        d.mkdir(parents=True)
+
+    skill_md = _write_baseline_skill(workspace_skills)
+    baseline_body = skill_md.read_text(encoding="utf-8")
+    assert "baseline skill body" in baseline_body
+
+    # Phase 0 — enough baseline samples for a decisive unhealthy report.
+    _append_segments(
+        logs_dir,
+        version=BASE_VERSION,
+        count=3,
+        session_prefix="base",
+        output_prefix="bad-baseline",
+    )
+
+    context = _mk_context(logs_dir=logs_dir, eval_dir=eval_dir)
+    udm = _mk_udm(
+        workspace_skills=workspace_skills,
+        logs_dir=logs_dir,
+        sessions_dir=sessions_dir,
+        repo_skills=repo_skills,
+    )
+
+    judge_calls: list[tuple[str, int]] = []
+
+    async def _fake_evaluate_skill(_llm, skill_id, version, segments):
+        assert skill_id == SKILL_ID
+        judge_calls.append((version, len(segments)))
+        # baseline → unhealthy → evolve; evolved → healthy + promotable → activate
+        unhealthy = "evolve" not in version
+        return _report(
+            version=version,
+            segment_count=len(segments),
+            unhealthy=unhealthy,
+        )
+
+    # ── Phase A: unhealthy baseline → rollback + evolve + publish ──
+    with patch("src.everbot.infra.user_data.get_user_data_manager", return_value=udm), patch(
+        "src.everbot.core.jobs.skill_evaluate.evaluate_skill",
+        new=AsyncMock(side_effect=_fake_evaluate_skill),
+    ):
+        first = await run_skill_evaluate(context)
+
+    assert first.status == "completed"
+    assert first.reason == "evaluated"
+    assert first.detail["evaluated_count"] >= 1
+    assert judge_calls and judge_calls[0][0] == BASE_VERSION
+
+    ver_mgr = VersionManager(
+        workspace_skills,
+        eval_base_dir=eval_dir,
+        read_skill_dirs=[workspace_skills],
+    )
+    pointer = ver_mgr.get_pointer(SKILL_ID)
+    assert pointer is not None
+    evolve_version = pointer.current_version
+    assert "evolve" in evolve_version, f"expected evolve candidate, got {evolve_version}"
+    assert pointer.stable_version == BASE_VERSION
+    assert pointer.consecutive_evolve_count == 1
+
+    # Live skill file must be replaced by the evolved body (the real endpoint).
+    live_after_evolve = skill_md.read_text(encoding="utf-8")
+    assert "improved skill body" in live_after_evolve
+    assert "baseline skill body" not in live_after_evolve
+    assert f'version: "{evolve_version}"' in live_after_evolve
+
+    evolve_snap = eval_dir / SKILL_ID / "versions" / f"v{evolve_version}" / "skill.md"
+    assert evolve_snap.exists()
+    assert f'version: "{evolve_version}"' in evolve_snap.read_text(encoding="utf-8")
+
+    registration = ensure_registered(ver_mgr, SKILL_ID, repo_skills_dir=None)
+    assert registration.action == RegistrationAction.NOOP
+
+    evolve_meta = ver_mgr.get_metadata(SKILL_ID, evolve_version)
+    assert evolve_meta is not None
+    assert evolve_meta.status == VersionStatus.TESTING
+
+    baseline_meta = ver_mgr.get_metadata(SKILL_ID, BASE_VERSION)
+    assert baseline_meta is not None
+    assert baseline_meta.status == VersionStatus.ACTIVE  # stable target stays active
+
+    baseline_report = ver_mgr.get_eval_report(SKILL_ID, BASE_VERSION)
+    assert baseline_report is not None
+    assert baseline_report.segment_count == 3
+    assert not baseline_report.is_healthy
+
+    baseline_snap = eval_dir / SKILL_ID / "versions" / f"v{BASE_VERSION}" / "skill.md"
+    assert baseline_snap.exists()
+    assert "baseline skill body" in baseline_snap.read_text(encoding="utf-8")
+
+    summaries_a = _mailbox_summaries(context)
+    assert any("不达标" in s or "改进" in s for s in summaries_a), summaries_a
+
+    # ── Phase B: healthy samples on evolved version → activate ──
+    _append_segments(
+        logs_dir,
+        version=evolve_version,
+        count=3,
+        session_prefix="evolved",
+        output_prefix="good-evolved",
+    )
+    context.mailbox.deposit.reset_mock()
+
+    with patch("src.everbot.infra.user_data.get_user_data_manager", return_value=udm), patch(
+        "src.everbot.core.jobs.skill_evaluate.evaluate_skill",
+        new=AsyncMock(side_effect=_fake_evaluate_skill),
+    ):
+        second = await run_skill_evaluate(context)
+
+    assert second.status == "completed"
+    assert second.reason == "evaluated"
+    assert second.detail["evaluated_count"] == 3
+    assert any(v == evolve_version for v, _ in judge_calls)
+
+    pointer = ver_mgr.get_pointer(SKILL_ID)
+    assert pointer.current_version == evolve_version
+    assert pointer.stable_version == evolve_version, "activate must advance stable"
+    assert pointer.consecutive_evolve_count == 0
+    assert pointer.repo_baseline is False
+
+    evolve_meta = ver_mgr.get_metadata(SKILL_ID, evolve_version)
+    assert evolve_meta.status == VersionStatus.ACTIVE
+
+    # Live file remains the evolved body after activation (no further rewrite).
+    live_after_activate = skill_md.read_text(encoding="utf-8")
+    assert "improved skill body" in live_after_activate
+    assert f'version: "{evolve_version}"' in live_after_activate
+
+    evolve_report = ver_mgr.get_eval_report(SKILL_ID, evolve_version)
+    assert evolve_report is not None
+    assert evolve_report.segment_count == 3
+    assert evolve_report.is_healthy
+    assert evolve_report.is_promotable
+
+    summaries_b = _mailbox_summaries(context)
+    assert any("验证通过" in s or "已生效" in s for s in summaries_b), summaries_b
+
+    # ── Phase C: no new samples → skipped/no_changes, no further mutation ──
+    context.mailbox.deposit.reset_mock()
+    live_before_third = skill_md.read_text(encoding="utf-8")
+    pointer_before = ver_mgr.get_pointer(SKILL_ID)
+    assert pointer_before is not None
+    stable_before = pointer_before.stable_version
+    current_before = pointer_before.current_version
+
+    with patch("src.everbot.infra.user_data.get_user_data_manager", return_value=udm), patch(
+        "src.everbot.core.jobs.skill_evaluate.evaluate_skill",
+        new=AsyncMock(side_effect=_fake_evaluate_skill),
+    ) as judge:
+        third = await run_skill_evaluate(context)
+
+    assert third.status == "skipped"
+    assert third.reason == "no_changes"
+    assert third.detail["evaluated_count"] == 0
+    judge.assert_not_awaited()
+    context.mailbox.deposit.assert_not_awaited()
+
+    pointer = ver_mgr.get_pointer(SKILL_ID)
+    assert pointer.current_version == current_before
+    assert pointer.stable_version == stable_before
+    assert skill_md.read_text(encoding="utf-8") == live_before_third

--- a/tests/integration/test_slm_lifecycle.py
+++ b/tests/integration/test_slm_lifecycle.py
@@ -376,3 +376,35 @@ class TestSLMHumanOverrideFlow:
         ver_mgr.save_eval_report("test-skill", "1.0", report)
         loaded = ver_mgr.get_eval_report("test-skill", "1.0")
         assert loaded.critical_issue_rate == 0.0
+
+
+class TestPublishVersionInvariant:
+    @pytest.mark.parametrize(
+        "invalid_content",
+        [
+            '---\nname: example-skill\nversion: "stale"\n---\nbody\n',
+            "---\nname: example-skill\n---\nbody\n",
+            '---\nname: example-skill\nversion: "2.0"\nversion: "3.0"\n---\nbody\n',
+        ],
+    )
+    def test_invalid_candidate_is_rejected_without_partial_state(
+        self, tmp_path: Path, invalid_content: str,
+    ):
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir()
+        ver_mgr = VersionManager(skills_dir)
+        ver_mgr.publish("example-skill", "1.0", SKILL_V1)
+        ver_mgr.activate("example-skill", "1.0")
+
+        skill_md = skills_dir / "example-skill" / "SKILL.md"
+        live_before = skill_md.read_text()
+        pointer_before = ver_mgr.get_pointer("example-skill").to_json()
+        versions_before = ver_mgr.list_versions("example-skill")
+
+        with pytest.raises(ValueError, match="frontmatter version"):
+            ver_mgr.publish("example-skill", "2.0", invalid_content)
+
+        assert skill_md.read_text() == live_before
+        assert ver_mgr.get_pointer("example-skill").to_json() == pointer_before
+        assert ver_mgr.list_versions("example-skill") == versions_before
+        assert not ver_mgr._version_dir("example-skill", "2.0").exists()

--- a/tests/unit/test_skill_evaluate_job.py
+++ b/tests/unit/test_skill_evaluate_job.py
@@ -758,6 +758,47 @@ class TestSanitizeLLMSkillMd:
         assert not _validate_skill_md(result)
 
 
+class TestNormalizeSkillMdVersion:
+    def test_replaces_only_unique_frontmatter_version(self):
+        from src.everbot.core.jobs.skill_evaluate import (
+            _normalize_skill_md_version,
+            _validate_skill_md,
+        )
+
+        stale = (
+            '---\nname: foo\nversion: "1.0"\ndescription: keep\n---\n'
+            '# Body\n\nExample text: version: "do-not-touch"\n'
+        )
+        target = "1.0-evolve-20260802"
+
+        normalized = _normalize_skill_md_version(stale, target)
+
+        assert normalized is not None
+        assert f'version: "{target}"' in normalized
+        assert 'Example text: version: "do-not-touch"' in normalized
+        assert _validate_skill_md(normalized, expected_version=target)
+
+    @pytest.mark.parametrize(
+        "content",
+        [
+            "---\nname: foo\n---\nbody\n",
+            '---\nname: foo\nversion: "1.0"\nversion: "2.0"\n---\nbody\n',
+            '---\nname: foo\n  version: "1.0"\n---\nbody\n',
+            '---\nname: foo\nversion: "1.0\n---\nbody\n',
+        ],
+    )
+    def test_rejects_missing_ambiguous_or_invalid_version(self, content):
+        from src.everbot.core.jobs.skill_evaluate import _normalize_skill_md_version
+
+        assert _normalize_skill_md_version(content, "2.0") is None
+
+    def test_validate_rejects_unexpected_version(self):
+        from src.everbot.core.jobs.skill_evaluate import _validate_skill_md
+
+        content = '---\nname: foo\nversion: "1.0"\n---\nbody\n'
+        assert not _validate_skill_md(content, expected_version="2.0")
+
+
 @pytest.mark.asyncio
 async def test_testing_healthy_but_not_promotable_does_not_activate(tmp_path: Path):
     """Healthy with too few segments (< 3) is NOT enough to promote.

--- a/tests/unit/test_slm_version_manager.py
+++ b/tests/unit/test_slm_version_manager.py
@@ -53,6 +53,20 @@ class TestReadFrontmatterVersion:
     def test_nonexistent(self, tmp_path):
         assert read_frontmatter_version(tmp_path / "nope.md") == "baseline"
 
+    def test_duplicate_version_is_ambiguous(self, tmp_path):
+        p = tmp_path / "SKILL.md"
+        p.write_text(
+            '---\nname: foo\nversion: "1.0"\nversion: "2.0"\n---\nbody\n'
+        )
+        assert read_frontmatter_version(p) == "baseline"
+
+    def test_body_version_text_is_ignored(self, tmp_path):
+        p = tmp_path / "SKILL.md"
+        p.write_text(
+            '---\nname: foo\nversion: "1.0"\n---\nbody version: "9.9"\n'
+        )
+        assert read_frontmatter_version(p) == "1.0"
+
 
 class TestVersionManager:
     def _make_mgr(self, tmp_path) -> VersionManager:
@@ -83,6 +97,43 @@ class TestVersionManager:
         assert ptr is not None
         assert ptr.current_version == "1.0"
         assert ptr.repo_baseline is True  # first version, no prior stable
+
+    @pytest.mark.parametrize(
+        "invalid_content",
+        [
+            SKILL_CONTENT_V1,
+            "---\nname: test-skill\n---\nbody\n",
+            '---\nname: test-skill\nversion: "2.0"\nversion: "3.0"\n---\nbody\n',
+        ],
+    )
+    def test_publish_rejects_invalid_version_before_first_write(
+        self, tmp_path, invalid_content,
+    ):
+        mgr = self._make_mgr(tmp_path)
+
+        with pytest.raises(ValueError, match="frontmatter version"):
+            mgr.publish("test-skill", "2.0", invalid_content)
+
+        assert not (tmp_path / "skills" / "test-skill").exists()
+        assert mgr.list_versions("test-skill") == []
+        assert mgr.get_pointer("test-skill") is None
+
+    def test_publish_mismatch_preserves_existing_state(self, tmp_path):
+        mgr = self._make_mgr(tmp_path)
+        mgr.publish("test-skill", "1.0", SKILL_CONTENT_V1)
+        mgr.activate("test-skill", "1.0")
+        skill_md = tmp_path / "skills" / "test-skill" / "SKILL.md"
+        live_before = skill_md.read_text()
+        pointer_before = mgr.get_pointer("test-skill").to_json()
+        versions_before = mgr.list_versions("test-skill")
+
+        with pytest.raises(ValueError, match="frontmatter version"):
+            mgr.publish("test-skill", "2.0", SKILL_CONTENT_V1)
+
+        assert skill_md.read_text() == live_before
+        assert mgr.get_pointer("test-skill").to_json() == pointer_before
+        assert mgr.list_versions("test-skill") == versions_before
+        assert not mgr._version_dir("test-skill", "2.0").exists()
 
     def test_publish_second_testing_version_does_not_promote_previous_testing(self, tmp_path):
         """Publishing a new TESTING version must not bless the previous one.


### PR DESCRIPTION
## 变更说明

Closes #191

SLM evolve 过去只通过 prompt 要求 LLM 更新 `SKILL.md` frontmatter version。模型漏改时，`publish()` 会把旧 content version 写入 live/snapshot，却把系统 `new_version` 写入 pointer；下一轮 `ensure_registered()` 因 `CONFLICT_DETECTED` 跳过评估，候选永远无法激活。

本 PR：

- 将 target version 明确为系统维护元数据，evolve 清洗后只规范化首个合法 frontmatter 内唯一的顶层 `version` 行
- 统一严格 frontmatter version 解析，缺失、重复、缩进或歧义字段不做猜测
- 在 `VersionManager.publish()` 的第一次写入前强制 content version 与发布参数一致
- 新增完整 lifecycle E2E：故障 LLM stub 保留旧版本，生产代码仍走通 TESTING → ACTIVE → skipped/no_changes
- 新增非法候选零部分写入的 Integration/Unit 回归
- 新增 Approved L2：`docs/design/191-evolve-version-consistency.md`

## TDD 与验收证据

- Red：修改 lifecycle stub 固定返回 baseline version，测试在 live 文件仍为 `1.0.0`、pointer 已为 `1.0.0-evolve-*` 处失败
- Green 核心：规范化、publish 不变量、零部分写入、完整 lifecycle 共 `14 passed`
- 相关回归：Skill Evaluate、VersionManager、State Normalizer、SLM Integration/Bootstrap、lifecycle E2E 共 `94 passed`
- 全量 Unit：`.venv/bin/python -m pytest tests/unit/ -m "not integration" -x -q --tb=short` → `2077 passed`，3 条既存 AsyncMock warning
- `.venv/bin/python -m compileall` 与 `git diff --check` 通过

## Review 结论

本地 review 无阻断项：S1 的版本三元组一致、S2 的写前拒绝与零部分写入、S3 的 activate 闭环均有直接测试。严格解析会有意拒绝此前可被宽松读取的重复/歧义 version；合法的单双引号或无引号版本保持兼容。无数据格式迁移，不修复历史冲突。

## 设计

- Issue #191 Approved L1
- L2：`docs/design/191-evolve-version-consistency.md`
