### PR TITLE
fix(paper-discovery): --with-summary 走 resolve_model（#193 P0a）

### DIFF
--- a/skills/paper-discovery/scripts/fetch_papers.py
+++ b/skills/paper-discovery/scripts/fetch_papers.py
@@ -5,73 +5,96 @@ Fetch trending AI/ML papers from HuggingFace JSON API with arXiv fallback.
 """
 
 import argparse
+import asyncio
 import json
 import logging
 import math
+import os
 import re
 import sys
 from datetime import datetime
-from typing import List, Dict, Any
+from pathlib import Path
+from typing import List, Dict, Any, Optional
 
+import httpx
 import requests
 
 logger = logging.getLogger(__name__)
 
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
 
-def generate_one_line_summary(abstract: str) -> str:
-    """Generate a one-line Chinese summary for a paper using LLM."""
+from src.everbot.core.agent.provider.model_config import resolve_model  # noqa: E402
+
+
+def generate_one_line_summary(
+    abstract: str,
+    *,
+    agent_name: Optional[str] = None,
+    model: Optional[str] = None,
+    timeout: float = 90.0,
+) -> str:
+    """Generate a one-line Chinese summary via everbot model routing (#193 P0a).
+
+    Uses ``resolve_model(tier="fast")`` (same pattern as twitter-watch/analyze.py).
+    Failures degrade to empty string so paper fetch still succeeds.
+    """
     if not abstract:
         return ""
 
+    prompt = (
+        "请用一句简洁的中文概括以下论文摘要的核心贡献或发现，不超过50个字：\n\n"
+        f"{abstract}"
+    )
+    agent = agent_name or os.environ.get("EVERBOT_AGENT") or os.environ.get("ALFRED_AGENT")
+
     try:
-        import asyncio
-        import os
-        from dolphin.core.llm.llm_client import LLMClient
-        from dolphin.core.common.enums import Messages as DolphinMessages, MessageRole
-        from dolphin.core.context import Context
-        from dolphin.core.config.global_config import GlobalConfig
-
-        # Load config from dolphin.yaml so LLMClient gets context_engineer_config
-        config_path = os.path.join(
-            os.path.dirname(__file__), "..", "..", "..", "config", "dolphin.yaml"
+        resolved = resolve_model(
+            agent_name=agent,
+            override=model,
+            tier="fast",
         )
-        config_path = os.path.normpath(config_path)
-        if os.path.exists(config_path):
-            config = GlobalConfig.from_yaml(config_path)
-        else:
-            logger.warning("dolphin.yaml not found at %s, using default GlobalConfig", config_path)
-            config = GlobalConfig()
-        context = Context(config=config)
-        llm_client = LLMClient(context)
-        msgs = DolphinMessages()
-        prompt = (
-            "请用一句简洁的中文概括以下论文摘要的核心贡献或发现，不超过50个字：\n\n"
-            f"{abstract}"
-        )
-        msgs.append_message(MessageRole.USER, prompt)
-
-        runtime_config = context.get_config()
-        model = getattr(runtime_config, "fast_llm", None) or "qwen-turbo"
-
-        async def _call():
-            result = ""
-            async for chunk in llm_client.mf_chat_stream(
-                messages=msgs,
-                model=model,
-                temperature=0.3,
-                no_cache=True,
-            ):
-                result = chunk.get("content") or ""
-            return result.strip()
-
-        loop = asyncio.new_event_loop()
-        try:
-            return loop.run_until_complete(asyncio.wait_for(_call(), timeout=90))
-        finally:
-            loop.close()
+        route = resolved.route
     except Exception as e:
         print(f"Warning: Failed to generate summary: {e}", file=sys.stderr)
         return ""
+
+    payload: Dict[str, Any] = {
+        "model": route.model,
+        "messages": [{"role": "user", "content": prompt}],
+        "temperature": 0.3,
+        "stream": False,
+        **(route.extra_body or {}),
+    }
+    headers = {
+        "Authorization": f"Bearer {route.api_key}",
+        "content-type": "application/json",
+        **(route.headers or {}),
+    }
+    base = route.base_url or ""
+    url = base if base.endswith("/chat/completions") else f"{base.rstrip('/')}/chat/completions"
+
+    async def _call() -> str:
+        async with httpx.AsyncClient(
+            timeout=httpx.Timeout(timeout),
+            trust_env=False,
+        ) as client:
+            resp = await client.post(url, json=payload, headers=headers)
+        if resp.status_code >= 400:
+            raise RuntimeError(f"LLM HTTP {resp.status_code}: {resp.text[:200]}")
+        data = resp.json()
+        content = (data["choices"][0]["message"]["content"] or "").strip()
+        if not content:
+            raise RuntimeError("LLM returned empty summary")
+        return content
+
+    try:
+        return asyncio.run(asyncio.wait_for(_call(), timeout=timeout))
+    except Exception as e:
+        print(f"Warning: Failed to generate summary: {e}", file=sys.stderr)
+        return ""
+
 
 
 def fetch_paper_by_id(paper_id: str) -> Dict[str, Any]:

--- a/tests/unit/test_fetch_papers_summary.py
+++ b/tests/unit/test_fetch_papers_summary.py
@@ -1,0 +1,116 @@
+"""#193 P0a — paper-discovery summary must use resolve_model, not dolphin/qwen-turbo."""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+
+_SCRIPTS = Path(__file__).resolve().parents[2] / "skills" / "paper-discovery" / "scripts"
+_SCRIPT = _SCRIPTS / "fetch_papers.py"
+
+
+def _load_fetch_papers():
+    name = "fetch_papers_under_test"
+    # Fresh load so patches apply to the module under test.
+    sys.modules.pop(name, None)
+    spec = importlib.util.spec_from_file_location(name, _SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_fetch_papers_source_has_no_dolphin_or_qwen_hardcode():
+    src = _SCRIPT.read_text(encoding="utf-8")
+    assert "import dolphin" not in src
+    assert "from dolphin" not in src
+    assert "dolphin.yaml" not in src
+    assert "qwen-turbo" not in src
+    assert "GlobalConfig" not in src
+    assert "mf_chat_stream" not in src
+    assert "resolve_model" in src
+
+
+def test_generate_one_line_summary_uses_resolve_model_fast_tier(monkeypatch):
+    fp = _load_fetch_papers()
+
+    route = SimpleNamespace(
+        model="doubao-seed-fake",
+        api_key="sk-test",
+        base_url="https://example.test/v1",
+        headers={},
+        extra_body={},
+    )
+    resolved = SimpleNamespace(route=route, logical_name="doubao-nothink", source="system_fast")
+
+    mock_resolve = MagicMock(return_value=resolved)
+    monkeypatch.setattr(
+        "src.everbot.core.agent.provider.model_config.resolve_model",
+        mock_resolve,
+        raising=False,
+    )
+    # Script imports resolve_model into its own namespace after load; patch both.
+    if hasattr(fp, "resolve_model"):
+        monkeypatch.setattr(fp, "resolve_model", mock_resolve)
+
+    class _Resp:
+        status_code = 200
+
+        def json(self):
+            return {"choices": [{"message": {"content": "  提出共享记忆的多智能体协调方法。  "}}]}
+
+    class _Client:
+        def __init__(self, *a, **k):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def post(self, url, json=None, headers=None):
+            self.url = url
+            self.json_payload = json
+            self.headers = headers
+            return _Resp()
+
+    with patch.object(fp, "httpx") as httpx_mod:
+        httpx_mod.AsyncClient = _Client
+        httpx_mod.Timeout = lambda *a, **k: None
+        out = fp.generate_one_line_summary(
+            "We propose multi-agent coordination via shared memory."
+        )
+
+    assert out == "提出共享记忆的多智能体协调方法。"
+    mock_resolve.assert_called()
+    kwargs = mock_resolve.call_args.kwargs
+    assert kwargs.get("tier") == "fast"
+    # Must not hardcode qwen; agent env may be None or EVERBOT_AGENT.
+    assert kwargs.get("override") in (None, "") or "qwen" not in str(kwargs.get("override"))
+
+
+def test_generate_one_line_summary_degrades_on_resolve_failure(monkeypatch, capsys):
+    fp = _load_fetch_papers()
+
+    def _boom(**kwargs):
+        raise RuntimeError("no model config")
+
+    if hasattr(fp, "resolve_model"):
+        monkeypatch.setattr(fp, "resolve_model", _boom)
+    else:
+        monkeypatch.setattr(
+            "src.everbot.core.agent.provider.model_config.resolve_model",
+            _boom,
+            raising=False,
+        )
+
+    out = fp.generate_one_line_summary("Some abstract about transformers.")
+    assert out == ""
+    err = capsys.readouterr().err
+    assert "Failed to generate summary" in err
+    assert "qwen-turbo" not in err


### PR DESCRIPTION
## Summary
- 去掉 `fetch_papers.py` 中 dolphin / `dolphin.yaml` / `qwen-turbo` 死栈
- `--with-summary` 改走 `resolve_model(tier=fast)` + httpx（对齐 twitter-watch）
- 单测覆盖：无死栈静态检查、成功路由、resolve 失败降级

## Test plan
- [x] `pytest tests/unit/test_fetch_papers_summary.py tests/unit/test_paper_discovery_provenance.py`
- [x] code review (no Critical/Important)

Closes nothing alone — tracks #193 S1/P0a