### PR TITLE
fix(heartbeat): SkillLLMClient 空 model 走 resolve fast（#193 P0c）

### DIFF
--- a/src/everbot/core/runtime/heartbeat.py
+++ b/src/everbot/core/runtime/heartbeat.py
@@ -1746,7 +1746,7 @@ class _SkillLLMClient:
         self._model = model
 
     async def complete(self, prompt: str, system: str = "", model_override: str = "", **kwargs) -> str:
-        """Single-turn LLM completion via Dolphin-configured OpenAI endpoint."""
+        """Single-turn LLM completion via models.yaml OpenAI-compatible route."""
         messages = []
         if system:
             messages.append({"role": "system", "content": system})
@@ -1755,10 +1755,26 @@ class _SkillLLMClient:
         model = model_override or self._model
         if not model:
             import os
-            model = os.environ.get("ALFRED_SKILL_MODEL", "deepseek-chat")
 
-        # 解析模型 endpoint/凭证(dolphin-free,读 config/models.yaml)
+            # Explicit ops override still wins; otherwise #155 resolve fast tier
+            # (no hard-coded deepseek-chat — that key is often expired).
+            model = (os.environ.get("ALFRED_SKILL_MODEL") or "").strip()
+            if not model:
+                from ..agent.provider.model_config import resolve_logical_model_name
+
+                agent_name = (
+                    os.environ.get("EVERBOT_AGENT")
+                    or os.environ.get("ALFRED_AGENT")
+                    or None
+                )
+                model, _source = resolve_logical_model_name(
+                    agent_name=agent_name,
+                    tier="fast",
+                )
+
+        # Resolve endpoint/credentials from config/models.yaml
         route = _resolve_skill_model_route(model)
+
 
         base_url = route.base_url
         # AsyncOpenAI appends /chat/completions; strip it if already present

--- a/tests/unit/test_self_reflection.py
+++ b/tests/unit/test_self_reflection.py
@@ -857,7 +857,45 @@ class TestSkillLLMClient:
             result = await client.complete("test")
 
         assert result == "ok"
-        mock_route.assert_called_once_with("deepseek-chat")  # 空 model → 回退 env
+        mock_route.assert_called_once_with("deepseek-chat")  # 空 model → env override
+
+    @pytest.mark.asyncio
+    async def test_empty_model_uses_resolve_logical_fast_not_deepseek_hardcode(self):
+        """#193 P0c: empty model must not hardcode deepseek-chat; use resolve fast."""
+        from src.everbot.core.runtime.heartbeat import _SkillLLMClient
+        import unittest.mock as um
+        import os
+        from pathlib import Path
+
+        client = _SkillLLMClient(model="")
+        fake_response = MagicMock()
+        fake_response.choices = [MagicMock()]
+        fake_response.choices[0].message.content = "ok"
+
+        env = {k: v for k, v in os.environ.items() if k != "ALFRED_SKILL_MODEL"}
+        with um.patch.dict(os.environ, env, clear=True), \
+             um.patch(
+                 "src.everbot.core.agent.provider.model_config.resolve_logical_model_name",
+                 return_value=("doubao-nothink", "system_fast"),
+             ) as mock_logical, \
+             um.patch(
+                 "src.everbot.core.runtime.heartbeat._resolve_skill_model_route",
+                 return_value=self._route(model="doubao-seed-fake"),
+             ) as mock_route, um.patch(
+                 "src.everbot.core.runtime.heartbeat.AsyncOpenAI",
+             ) as mock_openai_cls:
+            mock_client = AsyncMock()
+            mock_client.chat.completions.create.return_value = fake_response
+            mock_openai_cls.return_value = mock_client
+            result = await client.complete("test")
+
+        assert result == "ok"
+        mock_logical.assert_called_once()
+        assert mock_logical.call_args.kwargs.get("tier") == "fast"
+        mock_route.assert_called_once_with("doubao-nothink")
+        src = Path("src/everbot/core/runtime/heartbeat.py").read_text(encoding="utf-8")
+        assert 'os.environ.get("ALFRED_SKILL_MODEL", "deepseek-chat")' not in src
+
 
     def _client(self):
         from src.everbot.core.runtime.heartbeat import _SkillLLMClient


### PR DESCRIPTION
## Summary
- 删除 `_SkillLLMClient` 空 model 时的 `"deepseek-chat"` 硬编码
- 优先 `ALFRED_SKILL_MODEL`，否则 `resolve_logical_model_name(tier=fast)`
- 单测覆盖 env override + resolve fast 路径

## Test plan
- [x] `pytest tests/unit/test_self_reflection.py::TestSkillLLMClient`

Tracks #193 S3/P0c