### PR TITLE
fix(oneshot): 压缩/抽取透传 agent_name（#193 P0d）

### DIFF
--- a/src/everbot/core/agent/provider/oneshot_llm.py
+++ b/src/everbot/core/agent/provider/oneshot_llm.py
@@ -40,10 +40,13 @@ class OneshotLLMProvider:
         temperature: float = 0.3,
         fast: bool = False,
         raise_on_error: bool = True,
+        agent_name: str | None = None,
     ) -> str:
+        # Per-call agent intent wins over constructor default (#193 P0d).
+        effective_agent = agent_name if agent_name is not None else self._agent_name
         try:
             route = resolve_model(
-                agent_name=self._agent_name,
+                agent_name=effective_agent,
                 tier="fast" if fast else "default",
             ).route
         except Exception as exc:  # 配置缺失/模型名不存在

--- a/src/everbot/core/memory/_extractor_helpers.py
+++ b/src/everbot/core/memory/_extractor_helpers.py
@@ -59,7 +59,13 @@ def extract_json_object(raw: str) -> Optional[dict]:
     return None
 
 
-async def call_dolphin_llm(context: Any, prompt: str, temperature: float = 0.3) -> str:
+async def call_dolphin_llm(
+    context: Any,
+    prompt: str,
+    temperature: float = 0.3,
+    *,
+    agent_name: str | None = None,
+) -> str:
     """Call the LLM via the active provider with a single user-message prompt.
 
     Raises ``RuntimeError`` if the provider surfaced an error message.
@@ -67,5 +73,10 @@ async def call_dolphin_llm(context: Any, prompt: str, temperature: float = 0.3) 
     from ..agent.provider import oneshot_llm_provider
 
     return await oneshot_llm_provider().call_llm(
-        context, prompt, temperature=temperature, fast=False
+        context,
+        prompt,
+        temperature=temperature,
+        fast=False,
+        agent_name=agent_name,
     )
+

--- a/src/everbot/core/memory/event_extractor.py
+++ b/src/everbot/core/memory/event_extractor.py
@@ -89,8 +89,10 @@ class EventExtractResult:
 class EventExtractor:
     """Extract time-anchored event memories from conversation using LLM."""
 
-    def __init__(self, context: Any):
+    def __init__(self, context: Any, *, agent_name: str | None = None):
         self._context = context
+        self._agent_name = agent_name
+
 
     async def extract(
         self,
@@ -130,8 +132,11 @@ class EventExtractor:
         return self._parse_response(raw, session_id=session_id, fallback_event_at=anchor)
 
     async def _call_llm(self, prompt: str) -> str:
-        """Call Dolphin LLM. Kept as a method to preserve test patch surface."""
-        return await _helpers.call_dolphin_llm(self._context, prompt)
+        """Call oneshot LLM. Kept as a method to preserve test patch surface."""
+        return await _helpers.call_dolphin_llm(
+            self._context, prompt, agent_name=self._agent_name
+        )
+
 
     def _parse_response(
         self,

--- a/src/everbot/core/memory/manager.py
+++ b/src/everbot/core/memory/manager.py
@@ -90,6 +90,8 @@ class MemoryManager:
         memory_path: Path,
         context: Any = None,
         events_dir: Optional[Path] = None,
+        *,
+        agent_name: Optional[str] = None,
     ):
         memory_path = Path(memory_path)
         self.store = ProfileStore(memory_path)
@@ -98,6 +100,8 @@ class MemoryManager:
         )
         self.merger = MemoryMerger()
         self._context = context
+        self._agent_name = agent_name
+
 
     # =================================================================
     # Session-end pipeline
@@ -165,7 +169,8 @@ class MemoryManager:
         total_messages: int,
     ) -> Dict[str, Any]:
         """Profile pipeline: extract → decay → merge → save."""
-        extractor = ProfileExtractor(self._context)
+        extractor = ProfileExtractor(self._context, agent_name=self._agent_name)
+
         active_snapshot = [entry for entry in existing if entry.status == "active"]
         extract_result = await extractor.extract(new_messages, active_snapshot)
 
@@ -208,7 +213,8 @@ class MemoryManager:
         session_id: str,
     ) -> Dict[str, Any]:
         """Event pipeline: extract → append. Failures degrade gracefully."""
-        extractor = EventExtractor(self._context)
+        extractor = EventExtractor(self._context, agent_name=self._agent_name)
+
         try:
             result = await extractor.extract(new_messages, session_id=session_id)
         except Exception:

--- a/src/everbot/core/memory/profile_extractor.py
+++ b/src/everbot/core/memory/profile_extractor.py
@@ -83,8 +83,10 @@ class ExtractResult:
 class ProfileExtractor:
     """Extract user-portrait memories from conversation using LLM."""
 
-    def __init__(self, context: Any):
+    def __init__(self, context: Any, *, agent_name: str | None = None):
         self._context = context
+        self._agent_name = agent_name
+
 
     async def extract(
         self,
@@ -132,8 +134,11 @@ class ProfileExtractor:
             return ExtractResult()
 
     async def _call_llm(self, prompt: str) -> str:
-        """Call Dolphin LLM. Kept as a method to preserve test patch surface."""
-        return await _helpers.call_dolphin_llm(self._context, prompt)
+        """Call oneshot LLM. Kept as a method to preserve test patch surface."""
+        return await _helpers.call_dolphin_llm(
+            self._context, prompt, agent_name=self._agent_name
+        )
+
 
     def _parse_response(self, raw: str) -> ExtractResult:
         """Parse LLM JSON response with fallback strategies."""

--- a/src/everbot/core/session/compressor.py
+++ b/src/everbot/core/session/compressor.py
@@ -48,15 +48,24 @@ _SUMMARY_PROMPT_TEMPLATE = """\
 class SessionCompressor:
     """Compress old history messages into an LLM-generated summary."""
 
-    def __init__(self, context: Any = None, *, max_summary_tokens: int = 2000):
+    def __init__(
+        self,
+        context: Any = None,
+        *,
+        max_summary_tokens: int = 2000,
+        agent_name: Optional[str] = None,
+    ):
         """
         Args:
             context: Optional opaque context for oneshot LLM (unused by
                      OneshotLLMProvider but kept for call-site compatibility).
             max_summary_tokens: Cap on generated summary body (tokens ≈ chars/3).
+            agent_name: Optional agent for model intent (#193 P0d / #155).
         """
         self._context = context
         self._max_summary_tokens = max_summary_tokens
+        self._agent_name = agent_name
+
 
     # ── Public API ────────────────────────────────────────────────────
 
@@ -272,8 +281,14 @@ class SessionCompressor:
         # raise_on_error=True so error strings are not silently stored as
         # summary text; callers catch and degrade to safe window / keep original.
         return await oneshot_llm_provider().call_llm(
-            self._context, prompt, temperature=0.3, fast=True, raise_on_error=True
+            self._context,
+            prompt,
+            temperature=0.3,
+            fast=True,
+            raise_on_error=True,
+            agent_name=self._agent_name,
         )
+
 
 
 def _expand_legacy_window_start(

--- a/src/everbot/core/session/persistence.py
+++ b/src/everbot/core/session/persistence.py
@@ -331,7 +331,9 @@ class SessionPersistence:
                         compressor = SessionCompressor(
                             getattr(getattr(agent, "executor", None), "context", None),
                             max_summary_tokens=cfg.max_summary_tokens,
+                            agent_name=agent_name or None,
                         )
+
                         policy = HistoryCompactionPolicy()
                         result = await policy.ensure_within_budget(
                             data.history_messages, cfg, summarize=compressor

--- a/src/everbot/core/session/session.py
+++ b/src/everbot/core/session/session.py
@@ -636,7 +636,9 @@ class SessionManager:
                     compressor = SessionCompressor(
                         getattr(getattr(agent, "executor", None), "context", None),
                         max_summary_tokens=cfg.max_summary_tokens,
+                        agent_name=agent_name or None,
                     )
+
                     policy = HistoryCompactionPolicy()
                     result = await policy.ensure_within_budget(
                         serializable_history, cfg, summarize=compressor
@@ -1036,7 +1038,9 @@ class SessionManager:
             compressor = SessionCompressor(
                 getattr(getattr(agent, "executor", None), "context", None),
                 max_summary_tokens=cfg.max_summary_tokens,
+                agent_name=(getattr(agent, "name", "") or None) or None,
             )
+
             policy = HistoryCompactionPolicy()
             result = await policy.ensure_within_budget(
                 history, cfg, summarize=compressor

--- a/tests/unit/test_oneshot_llm.py
+++ b/tests/unit/test_oneshot_llm.py
@@ -55,3 +55,51 @@ async def test_bad_config_raises_when_raise_on_error(monkeypatch):
     p = OneshotLLMProvider()
     with pytest.raises(RuntimeError):
         await p.call_llm(None, "x", raise_on_error=True)
+
+async def test_call_llm_forwards_agent_name_to_resolve_model(monkeypatch):
+    """#193 P0d: per-call agent_name must reach resolve_model (not stuck at None)."""
+    captured = {}
+
+    def _resolve(**kwargs):
+        captured.update(kwargs)
+        return ResolvedModel(
+            logical_name="agent-model",
+            route=ModelRoute(base_url="http://fake/v1", api_key="k", model="mm"),
+            source="agent",
+        )
+
+    monkeypatch.setattr(os_mod, "resolve_model", _resolve)
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"choices": [{"message": {"content": "ok"}}]})
+
+    p = OneshotLLMProvider(client=httpx.AsyncClient(transport=httpx.MockTransport(handler)))
+    out = await p.call_llm(None, "hi", agent_name="demo_agent", fast=True)
+    assert out == "ok"
+    assert captured.get("agent_name") == "demo_agent"
+    assert captured.get("tier") == "fast"
+
+
+async def test_call_llm_uses_constructor_agent_name_when_kwarg_omitted(monkeypatch):
+    captured = {}
+
+    def _resolve(**kwargs):
+        captured.update(kwargs)
+        return ResolvedModel(
+            logical_name="ctor",
+            route=ModelRoute(base_url="http://fake/v1", api_key="k", model="mm"),
+            source="agent",
+        )
+
+    monkeypatch.setattr(os_mod, "resolve_model", _resolve)
+    p = OneshotLLMProvider(
+        client=httpx.AsyncClient(
+            transport=httpx.MockTransport(
+                lambda r: httpx.Response(200, json={"choices": [{"message": {"content": "x"}}]})
+            )
+        ),
+        agent_name="from-ctor",
+    )
+    await p.call_llm(None, "hi")
+    assert captured.get("agent_name") == "from-ctor"
+


### PR DESCRIPTION
## Summary
- `OneshotLLMProvider.call_llm(..., agent_name=)` 透传至 `resolve_model`
- `SessionCompressor` / 三处构造点带上 agent
- MemoryManager → Profile/EventExtractor → call_dolphin_llm 透传 agent_name
- 单测：per-call 与 constructor agent_name

## Test plan
- [x] `pytest tests/unit/test_oneshot_llm.py tests/unit/test_session_compressor.py tests/unit/test_memory_manager_events.py tests/unit/test_event_extractor.py tests/unit/test_history_compaction.py`

Tracks #193 S4/P0d