### PR TITLE
fix(agent): 去掉 agent.dph 身份门闩（#193 P0e）

### DIFF
--- a/src/everbot/cli/doctor.py
+++ b/src/everbot/cli/doctor.py
@@ -206,58 +206,29 @@ def collect_doctor_report(
 
     for agent_dir in agent_dirs:
         agent_name = agent_dir.name
-        agent_dph = agent_dir / "agent.dph"
-        if not agent_dph.exists():
+        if agent_name.startswith("."):
+            continue
+        # milkie workspace markers (agent.dph is legacy dolphin; not required).
+        markers = [name for name in ("AGENTS.md", "SOUL.md", "HEARTBEAT.md") if (agent_dir / name).exists()]
+        if not markers:
             items.append(
                 DoctorItem(
                     level="WARN",
                     title=f"Agent {agent_name}",
-                    details=f"Missing agent.dph: {agent_dph}",
+                    details="Workspace missing AGENTS.md/SOUL.md/HEARTBEAT.md markers.",
                     hint=f"Run: bin/everbot init {agent_name}",
                 )
             )
             continue
 
-        content = ""
-        try:
-            content = agent_dph.read_text(encoding="utf-8")
-        except Exception as e:
-            items.append(
-                DoctorItem(
-                    level="ERROR",
-                    title=f"Agent {agent_name}",
-                    details=f"Failed to read agent.dph: {e}",
-                )
+        items.append(
+            DoctorItem(
+                level="OK",
+                title=f"Agent {agent_name}",
+                details=f"Workspace OK ({', '.join(markers)}).",
             )
-            continue
+        )
 
-        fmt = detect_agent_dph_format(content)
-        if fmt == "legacy_yaml":
-            items.append(
-                DoctorItem(
-                    level="WARN",
-                    title=f"Agent {agent_name} agent.dph",
-                    details="Legacy YAML-style agent.dph detected.",
-                    hint=f"Run: bin/everbot migrate-agent --agent {agent_name}",
-                )
-            )
-        elif fmt == "unknown":
-            items.append(
-                DoctorItem(
-                    level="WARN",
-                    title=f"Agent {agent_name} agent.dph",
-                    details="Unknown agent.dph format; Dolphin may fail to parse it.",
-                    hint=f"Open: {agent_dph} and ensure it contains DPH blocks with '->'.",
-                )
-            )
-        else:
-            items.append(
-                DoctorItem(
-                    level="OK",
-                    title=f"Agent {agent_name} agent.dph",
-                    details="DPH format detected.",
-                )
-            )
 
         # Basic env check for Aliyun model config
         if models_path is not None:

--- a/src/everbot/infra/user_data.py
+++ b/src/everbot/infra/user_data.py
@@ -272,16 +272,20 @@ class UserDataManager:
         return self.get_agent_tmp_dir(agent_name) / f"trajectory_{safe_session}.json"
 
     def list_agents(self) -> List[str]:
-        """列出所有 Agent"""
+        """List agent workspace directories (milkie; no agent.dph required)."""
         if not self.agents_dir.exists():
             return []
 
         agents = []
         for d in self.agents_dir.iterdir():
-            if d.is_dir() and (d / "agent.dph").exists():
+            if not d.is_dir() or d.name.startswith("."):
+                continue
+            # milkie identity: workspace markdown markers (not legacy agent.dph).
+            if any((d / name).exists() for name in ("AGENTS.md", "SOUL.md", "HEARTBEAT.md")):
                 agents.append(d.name)
 
         return sorted(agents)
+
 
     def get_workspace_files(self, agent_name: str) -> Dict[str, Optional[str]]:
         """
@@ -452,14 +456,6 @@ class UserDataManager:
             "USER.md": """# 用户画像
 
 （待补充）
-""",
-            "agent.dph": f"""/explore/(model="$model_name", system_prompt="$workspace_instructions", tools=[_bash, _python, _date, _read_file, _read_folder])
-{agent_name} Agent
-
-当前时间：$current_time
-
-请根据用户的要求提供帮助。
--> answer
 """,
         }
 

--- a/tests/unit/test_agent_workspace_no_dph_gate.py
+++ b/tests/unit/test_agent_workspace_no_dph_gate.py
@@ -1,0 +1,53 @@
+"""#193 P0e — agent identity must not require agent.dph (milkie-only)."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from src.everbot.cli.doctor import collect_doctor_report
+from src.everbot.infra.user_data import UserDataManager
+
+
+def test_list_agents_includes_workspace_without_agent_dph(tmp_path: Path):
+    home = tmp_path / "alfred"
+    mgr = UserDataManager(alfred_home=home)
+    mgr.ensure_directories()
+    agent_dir = mgr.get_agent_dir("milkie_only")
+    agent_dir.mkdir(parents=True)
+    (agent_dir / "AGENTS.md").write_text("# agent\n", encoding="utf-8")
+    # Explicitly no agent.dph
+    assert not (agent_dir / "agent.dph").exists()
+
+    agents = mgr.list_agents()
+    assert "milkie_only" in agents
+
+
+def test_init_agent_workspace_does_not_write_agent_dph(tmp_path: Path):
+    home = tmp_path / "alfred"
+    mgr = UserDataManager(alfred_home=home)
+    mgr.ensure_directories()
+    mgr.init_agent_workspace("new_bot")
+
+    agent_dir = mgr.get_agent_dir("new_bot")
+    assert (agent_dir / "AGENTS.md").exists()
+    assert (agent_dir / "SOUL.md").exists() or (agent_dir / "AGENTS.md").exists()
+    assert not (agent_dir / "agent.dph").exists()
+
+
+def test_doctor_does_not_warn_missing_agent_dph(tmp_path: Path):
+    home = tmp_path / "alfred"
+    mgr = UserDataManager(alfred_home=home)
+    mgr.ensure_directories()
+    agent_dir = mgr.get_agent_dir("demo")
+    agent_dir.mkdir(parents=True)
+    (agent_dir / "AGENTS.md").write_text("# demo\n", encoding="utf-8")
+    (agent_dir / "SOUL.md").write_text("# soul\n", encoding="utf-8")
+
+    items = collect_doctor_report(project_root=tmp_path, alfred_home=home)
+    dph_warns = [
+        i
+        for i in items
+        if "agent.dph" in (i.details or "").lower()
+        or "agent.dph" in (i.title or "").lower()
+        or "dolphin" in (i.details or "").lower()
+    ]
+    assert dph_warns == [], f"unexpected dph/dolphin doctor items: {dph_warns}"

--- a/tests/unit/test_everbot_basic.py
+++ b/tests/unit/test_everbot_basic.py
@@ -44,7 +44,8 @@ class TestUserDataManager:
             assert (agent_dir / "HEARTBEAT.md").exists()
             assert (agent_dir / "MEMORY.md").exists()
             assert (agent_dir / "USER.md").exists()
-            assert (agent_dir / "agent.dph").exists()
+            assert not (agent_dir / "agent.dph").exists()
+
 
     def test_list_agents(self):
         """测试 Agent 列表"""


### PR DESCRIPTION
## Summary
- `list_agents`：以 AGENTS.md / SOUL.md / HEARTBEAT.md 识别工作区
- `init`：不再写入 `agent.dph`
- `doctor`：检查 milkie 工作区标记，不再要求/解析 Dolphin dph

## Test plan
- [x] `pytest tests/unit/test_agent_workspace_no_dph_gate.py tests/unit/test_everbot_basic.py::TestUserDataManager tests/unit/test_doctor.py`

Tracks #193 S5/P0e