### PR TITLE
chore: setup/CI 去掉 dolphin 强制依赖（#193 P0f）

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,15 +21,12 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install Dolphin SDK
-        run: |
-          pip install "git+https://github.com/kweaver-ai/dolphin.git@main"
-
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install pytest pytest-asyncio pytest-cov
+
 
       - name: Run unit tests
         env:

--- a/bin/setup
+++ b/bin/setup
@@ -39,19 +39,7 @@ echo "[3/3] Installing dependencies..."
 pip install --upgrade pip -q
 pip install -r "${PROJECT_ROOT}/requirements.txt" -q
 
-# 4. Check dolphin (agent framework, install from source)
-if python -c "import dolphin" 2>/dev/null; then
-  echo "    Dolphin SDK ✓"
-else
-  echo ""
-  echo "WARNING: Dolphin SDK not installed."
-  echo "         EverBot requires dolphin to run. Install it from source:"
-  echo "         pip install -e /path/to/dolphin"
-  echo ""
-  missing_dolphin=1
-fi
-
-# 5. Create ALFRED_HOME dirs
+# 4. Create ALFRED_HOME dirs
 ALFRED_HOME="${ALFRED_HOME:-$HOME/.alfred}"
 mkdir -p "${ALFRED_HOME}/logs" "${ALFRED_HOME}/agents"
 
@@ -61,9 +49,7 @@ echo "    venv:        ${VENV_DIR}"
 echo "    ALFRED_HOME: ${ALFRED_HOME}"
 echo ""
 echo "Next steps:"
-echo "  source .venv/bin/activate   # 激活虚拟环境"
-if [[ "${missing_dolphin:-0}" == "1" ]]; then
-  echo "  pip install -e /path/to/dolphin  # 安装 Dolphin SDK"
-fi
-echo "  bin/everbot init <agent_name>    # 创建 Agent"
-echo "  bin/everbot start                # 启动"
+echo "  source .venv/bin/activate   # activate venv"
+echo "  bin/everbot init <agent_name>    # create Agent"
+echo "  bin/everbot start                # start daemon"
+

--- a/tests/unit/test_no_dolphin_install_gate.py
+++ b/tests/unit/test_no_dolphin_install_gate.py
@@ -1,0 +1,22 @@
+"""#193 P0f — setup/CI must not require dolphin SDK (milkie-only runtime)."""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_bin_setup_has_no_dolphin_requirement():
+    setup = (_ROOT / "bin" / "setup").read_text(encoding="utf-8")
+    assert "import dolphin" not in setup
+    assert "missing_dolphin" not in setup
+    assert re.search(r"(?i)requires dolphin", setup) is None
+    assert "pip install -e /path/to/dolphin" not in setup
+
+
+def test_ci_workflow_does_not_install_dolphin():
+    wf = (_ROOT / ".github" / "workflows" / "test.yml").read_text(encoding="utf-8")
+    assert "Install Dolphin SDK" not in wf
+    assert "dolphin.git" not in wf
+    assert re.search(r"(?i)pip install.*dolphin", wf) is None


### PR DESCRIPTION
## Summary
- `bin/setup` 删除 dolphin 检查与安装提示
- CI 删除 Install Dolphin SDK 步骤
- 单测锁住两处不再出现 dolphin 强制安装

## Test plan
- [x] `pytest tests/unit/test_no_dolphin_install_gate.py`

Closes #193