### PR TITLE
fix(heartbeat): isolated 推送完整报告而非执行摘要（#193）

### DIFF
--- a/src/everbot/core/runtime/heartbeat.py
+++ b/src/everbot/core/runtime/heartbeat.py
@@ -1414,9 +1414,49 @@ If not, reply with `HEARTBEAT_OK`.
             logger.debug("[%s] capture_trace 留证失败(忽略):%s", self.agent_name, exc)
 
     @staticmethod
+    def _looks_like_exec_summary(text: str) -> bool:
+        """Heuristic: short ops/status recap that should not replace a real report."""
+        t = (text or "").strip()
+        if not t or len(t) > 1500:
+            return False
+        markers = (
+            "执行状态",
+            "任务 ID",
+            "Task ID",
+            "原始数据",
+            "exitCode",
+            "执行摘要",
+            "任务执行完成",
+            "报告生成完成",
+        )
+        hits = sum(1 for m in markers if m in t)
+        if hits >= 2:
+            return True
+        if t.startswith("✅") and hits >= 1 and "🔥" not in t and "arxiv.org" not in t.lower():
+            return True
+        return False
+
+    @staticmethod
+    def _looks_like_user_report(text: str) -> bool:
+        """Heuristic: full user-facing digest / analysis body."""
+        t = (text or "").strip()
+        if len(t) < 280:
+            return False
+        markers = ("🔥", "arxiv.org", "核心创新", "## ", "### ", "投资信号", "逐条解读")
+        return sum(1 for m in markers if m in t) >= 2
+
+
+    @staticmethod
     def _extract_llm_result(events: list[dict[str, Any]]) -> str:
-        """Extract final LLM text from streamed turn events."""
+        """Extract final LLM text from streamed turn events.
+
+        milkie multi-step turns may emit several full ``answer`` snapshots.
+        Prefer the last non-empty answer, but if a later short execution
+        summary would replace an earlier full user-facing report, keep the
+        report (Telegram delivers this string as the heartbeat body).
+        """
         answer = ""
+        answers: list[str] = []
         deltas: list[str] = []
         seen_llm_progress: set[str] = set()
         for event in events:
@@ -1438,11 +1478,25 @@ If not, reply with `HEARTBEAT_OK`.
                 if isinstance(part, str) and part:
                     deltas.append(part)
                 full = progress.get("answer")
-                if isinstance(full, str) and full:
+                if isinstance(full, str) and full.strip():
                     answer = full
+                    answers.append(full)
+        if answers:
+            last = answers[-1]
+            # Prefer an earlier full report over a trailing ops/status brief.
+            candidates = [a for a in answers if HeartbeatRunner._looks_like_user_report(a)]
+            if candidates and HeartbeatRunner._looks_like_exec_summary(last):
+                best = max(candidates, key=len)
+                if len(best) > len(last) and (
+                    len(best) >= max(len(last) * 2, 400) or len(best) - len(last) >= 200
+                ):
+                    return best
+            return last
         if answer:
             return answer
         return "".join(deltas)
+
+
 
     async def _load_or_create_turn_session(self, session_id: str, session_type: str) -> Any:
         """Load one session for TurnExecutor or build a lightweight stub."""

--- a/src/everbot/core/runtime/heartbeat_utils.py
+++ b/src/everbot/core/runtime/heartbeat_utils.py
@@ -62,14 +62,25 @@ def build_isolated_task_prompt(task: Any) -> str:
     """Build the user-message prompt for an isolated task execution.
 
     Single source of truth — used by both heartbeat.py and cron.py.
+
+    The final assistant message is what Telegram/mailbox deliver as the
+    heartbeat_delivery body. It must be the full user-facing report, not a
+    short execution summary after the real report was produced mid-turn.
     """
     task_id = str(getattr(task, "id", "task"))
     task_title = str(getattr(task, "title", "") or "")
     task_desc = str(getattr(task, "description", "") or "")
     return (
-        "Execute this scheduled isolated routine task and summarize the result briefly.\n"
+        "Execute this scheduled isolated routine task and produce the full user-facing report.\n"
         "IMPORTANT: Respond in the SAME language as the task title/description. "
         "Use a consistent, structured format (headings + bullet points).\n\n"
+        "DELIVERY (critical): Your FINAL reply is delivered verbatim to the user "
+        "(Telegram / mailbox). The final message MUST be the complete report body "
+        "the user should read — NOT an execution summary, status checklist, task-id "
+        "recap, or \"done\" brief after you already drafted the report. "
+        "If a skill defines push/report format requirements, the final reply must "
+        "satisfy them in full. Do not end with meta commentary about where files were saved "
+        "unless the task explicitly asks for ops status only.\n\n"
         "CRITICAL: You MUST use real tools (_bash, _python, _load_resource_skill) to fetch "
         "actual data. NEVER fabricate, simulate, or hardcode data. If a tool or data source "
         "fails, report the error honestly — do NOT generate fake results.\n"
@@ -82,7 +93,8 @@ def build_isolated_task_prompt(task: Any) -> str:
         "came from a tool, call the `cite` tool to link that claim to the `objectId` the tool "
         "returned (a non-empty `_bash`/`_python`/data-tool result carries an `objectId`). This "
         "makes 「来源哪里」 answerable via get_lineage and the source impossible to fabricate. "
-        "Cite real objectIds only — never invent one.\n"
+        "Cite real objectIds only — never invent one. Prefer citing in the same turn as the "
+        "final report text (or earlier) without replacing the report body with a status note.\n"
         "When the task description contains `_load_resource_skill(...)`, call the "
         "`_load_resource_skill` tool directly. Never execute `_load_resource_skill(...)` "
         "inside `_python` or `_bash`.\n\n"
@@ -90,3 +102,4 @@ def build_isolated_task_prompt(task: Any) -> str:
         f"Title: {task_title}\n"
         f"Description: {task_desc}\n"
     )
+

--- a/tests/unit/test_heartbeat_runner_core.py
+++ b/tests/unit/test_heartbeat_runner_core.py
@@ -341,6 +341,35 @@ class TestExtractLlmResult:
         ]
         assert HeartbeatRunner._extract_llm_result(events) == "Hello World"
 
+    def test_prefers_full_report_over_trailing_exec_summary(self):
+        """#193: final short status must not replace an earlier full report body.
+
+        Isolated paper runs often emit the real digest as a mid-turn assistant
+        message, then a short ✅ execution summary after cite tools. Delivery
+        uses lastTextOutput / extracted answer — prefer the report.
+        """
+        report = (
+            "## 📚 今日 AI 论文热榜\n\n"
+            "### 1. 🔥🔥🔥🔥 AISPA\n"
+            "- 🔍 **核心创新点**：user-centric prompt auditing\n"
+            "- 🔗 [arXiv](https://arxiv.org/abs/2607.28617)\n"
+        ) * 3  # long enough to beat short status threshold
+        summary = (
+            "✅ **每日论文报告生成完成**。\n"
+            "- **任务 ID**：routine_476c4861\n"
+            "- **执行状态**：成功\n"
+            "- **原始数据**：~/.alfred/agents/demo_agent/tmp/papers.json\n"
+        )
+        events = [
+            {"_progress": [{"stage": "llm", "id": "a1", "answer": report}]},
+            {"_progress": [{"stage": "llm", "id": "a2", "answer": summary}]},
+        ]
+        out = HeartbeatRunner._extract_llm_result(events)
+        assert "AISPA" in out
+        assert "核心创新点" in out
+        assert "执行状态" not in out or len(out) > len(summary)
+
+
 
 # ============================================================
 # 4. _normalize_reflection_routine

--- a/tests/unit/test_heartbeat_utils.py
+++ b/tests/unit/test_heartbeat_utils.py
@@ -44,3 +44,26 @@ def test_build_isolated_task_prompt_includes_fail_fast():
     assert "FAIL-FAST" in prompt
     assert "SELECTOR_OR_STRUCTURE_CHANGED" in prompt
     assert "STOP" in prompt
+
+
+def test_build_isolated_task_prompt_requires_full_user_facing_report():
+    """#193: Telegram delivers lastTextOutput — must be the full report, not a status brief.
+
+    Production bug: prompt said "summarize the result briefly", so paper-discovery
+    generated a full digest mid-turn then replaced it with an execution summary
+    as the final assistant message (what users actually received).
+    """
+    prompt = build_isolated_task_prompt(
+        _Task(
+            id="routine_476c4861",
+            title="每日论文报告生成",
+            description="使用 paper-discovery 生成今日 AI 论文报告",
+        )
+    )
+    low = prompt.lower()
+    assert "summarize the result briefly" not in low
+    assert "execution summary" not in low or "not an execution summary" in low
+    # Final user-visible message must be the report body.
+    assert "final reply" in low or "final message" in low or "entire response" in low
+    assert "user-facing" in low or "user facing" in low or "推送" in prompt or "deliver" in low
+


### PR DESCRIPTION
## Summary
用户反馈：论文 routine 在 Telegram 只收到「每日论文报告生成完成」执行摘要，没有论文正文。

根因：
1. `build_isolated_task_prompt` 写了 “summarize the result briefly”
2. Agent 中间生成了完整报告，最终 `lastTextOutput` 被收成 status brief
3. `_extract_llm_result` 只取最后一次 answer

修复：
- isolated prompt 明确要求 **FINAL reply = 完整用户报告**
- 提取逻辑：若末条是执行摘要、前面有完整报告，优先长报告

## Test plan
- [x] `pytest tests/unit/test_heartbeat_utils.py tests/unit/test_heartbeat_runner_core.py::TestExtractLlmResult`
- [ ] 合入后 restart + 再跑论文 routine 验证 Telegram 正文

Related #193