### PR TITLE
【scheduler】LLM 不可用时 isolated claim 退避 (#202)

### DIFF
--- a/.env.secrets.example
+++ b/.env.secrets.example
@@ -8,7 +8,7 @@
 #
 # This keeps a single source of truth for all environments.
 
-# Kimi (default LLM in dolphin.yaml)
+# Kimi (models.yaml cloud credentials)
 export KIMI_API_BASE=
 export KIMI_API_KEY=
 

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ htmlcov/
 HEARTBEAT.md
 
 # Sensitive config (use example files as templates)
+# leftover local dolphin.yaml is ignored, not read
 config/dolphin.yaml
 config/dolphin.yaml.bak-74
 config/models.yaml

--- a/config/models.yaml.example
+++ b/config/models.yaml.example
@@ -1,7 +1,6 @@
-# 模型路由配置(#74 正名,前身 dolphin.yaml —— dolphin 已于 #38 移除,本文件是纯数据)
-# 消费方:src/everbot/core/agent/provider/model_config.py(_SkillLLMClient / OneshotLLMProvider)
+# 模型路由配置
+# 消费方:src/everbot/core/agent/provider/model_config.py
 # 查找顺序:~/.alfred/models.yaml → ./config/models.yaml → repo config/models.yaml
-#         (同位置内旧名 dolphin.yaml 兜底)
 
 # #155: top-level default/fast are SYSTEM FALLBACK only (no agent context).
 # Agent intent lives in everbot.agents.<name>.model — skill scripts inherit via

--- a/skills/skill-installer/scripts/list.py
+++ b/skills/skill-installer/scripts/list.py
@@ -20,24 +20,6 @@ def find_skills_directories() -> List[Path]:
         Path.cwd() / "skills",
         home / ".alfred" / "skills",
     ]
-
-    # Also check from config if available
-    config_path = Path.cwd() / "config" / "dolphin.yaml"
-    if config_path.exists():
-        try:
-            import yaml
-            with open(config_path) as f:
-                config = yaml.safe_load(f)
-                resource_dirs = config.get("resource_skills", {}).get("directories", [])
-                for d in resource_dirs:
-                    path = Path(d).expanduser()
-                    if path.exists():
-                        candidates.append(path)
-        except ImportError:
-            pass
-        except Exception:
-            pass
-
     return [p for p in candidates if p.exists() and p.is_dir()]
 
 

--- a/skills/skill-installer/scripts/remove.py
+++ b/skills/skill-installer/scripts/remove.py
@@ -17,24 +17,6 @@ def find_skills_directories() -> List[Path]:
         Path.cwd() / "skills",
         home / ".alfred" / "skills",
     ]
-
-    # Also check from config if available
-    config_path = Path.cwd() / "config" / "dolphin.yaml"
-    if config_path.exists():
-        try:
-            import yaml
-            with open(config_path) as f:
-                config = yaml.safe_load(f)
-                resource_dirs = config.get("resource_skills", {}).get("directories", [])
-                for d in resource_dirs:
-                    path = Path(d).expanduser()
-                    if path.exists():
-                        candidates.append(path)
-        except ImportError:
-            pass
-        except Exception:
-            pass
-
     return [p for p in candidates if p.exists() and p.is_dir()]
 
 

--- a/skills/skill-installer/scripts/update.py
+++ b/skills/skill-installer/scripts/update.py
@@ -43,24 +43,6 @@ def find_skills_directories() -> List[Path]:
         Path.cwd() / "skills",
         home / ".alfred" / "skills",
     ]
-
-    # Also check from config if available
-    config_path = Path.cwd() / "config" / "dolphin.yaml"
-    if config_path.exists():
-        try:
-            import yaml
-            with open(config_path) as f:
-                config = yaml.safe_load(f)
-                resource_dirs = config.get("resource_skills", {}).get("directories", [])
-                for d in resource_dirs:
-                    path = Path(d).expanduser()
-                    if path.exists():
-                        candidates.append(path)
-        except ImportError:
-            pass
-        except Exception:
-            pass
-
     return [p for p in candidates if p.exists() and p.is_dir()]
 
 

--- a/src/everbot/cli/daemon.py
+++ b/src/everbot/cli/daemon.py
@@ -186,11 +186,7 @@ class EverBotDaemon:
             # Share the heartbeat probe health gate with isolated work (#180).
             # Gate before claim so due tasks are not stuck claimed during outages.
             if getattr(runner, "is_llm_unavailable", False):
-                logger.info(
-                    "Skip isolated claim for %s: LLM unavailable",
-                    task_key,
-                )
-                return False
+                raise LLMUnavailableError(f"LLM unavailable for {task_key}")
             claim = getattr(runner, "claim_isolated_task", None)
             if not callable(claim):
                 return False

--- a/src/everbot/cli/daemon.py
+++ b/src/everbot/cli/daemon.py
@@ -826,8 +826,7 @@ async def main():
 
     parser = argparse.ArgumentParser(description="EverBot Daemon")
     parser.add_argument("--config", type=str, help="EverBot 配置文件路径")
-    parser.add_argument("--dolphin-config", type=str, help="Dolphin 全局配置文件路径")
-    parser.add_argument("--model", type=str, default=None, help="默认模型名称（为空则使用 Dolphin 配置默认）")
+    parser.add_argument("--model", type=str, default=None, help="默认模型名称")
     parser.add_argument("--log-level", type=str, default="INFO",
                        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
                        help="日志级别")
@@ -835,7 +834,6 @@ async def main():
 
     daemon = EverBotDaemon(
         config_path=args.config,
-        global_config_path=args.dolphin_config,
         default_model=args.model,
     )
     configure_daemon_logging(

--- a/src/everbot/cli/doctor.py
+++ b/src/everbot/cli/doctor.py
@@ -27,22 +27,11 @@ class DoctorItem:
 
 
 def resolve_model_config_source(user_data: UserDataManager, project_root: Path) -> Tuple[str, Optional[Path]]:
-    """
-    Resolve which model-routing config file is effectively used.
-
-    #74:正名 models.yaml,同位置内旧名 dolphin.yaml 兜底(与
-    model_config.find_model_config_path 同语义)。
-
-    Returns:
-        (source_label, path or None)
-    """
+    """Resolve which models.yaml is used. dolphin.yaml is not a source."""
     candidates = [
         ("alfred", user_data.models_config_path),
-        ("alfred", user_data.dolphin_config_path),
         ("project", (project_root / "config" / "models.yaml").resolve()),
-        ("project", (project_root / "config" / "dolphin.yaml").resolve()),
         ("cwd", Path("./config/models.yaml").resolve()),
-        ("cwd", Path("./config/dolphin.yaml").resolve()),
     ]
 
     for label, path in candidates:
@@ -138,15 +127,14 @@ def collect_doctor_report(
             )
         )
 
-    # Model routing config(#74:正名 models.yaml;skillkit 检查随死配置移除 ——
-    # tool.enabled_tools 自 #38 去 dolphin 后无 runtime 消费方,体检它只产噪音)
+    # Model routing: models.yaml only.
     source, models_path = resolve_model_config_source(user_data, project_root)
     if models_path is None:
         items.append(
             DoctorItem(
                 level="WARN",
                 title="Model routing config",
-                details="No model routing YAML found (models.yaml / legacy dolphin.yaml).",
+                details="No model routing YAML found (models.yaml).",
                 hint=f"Create {user_data.models_config_path} (copy from config/models.yaml).",
             )
         )

--- a/src/everbot/cli/main.py
+++ b/src/everbot/cli/main.py
@@ -162,7 +162,6 @@ async def cmd_start_async(args):
     """启动守护进程（异步）"""
     daemon = EverBotDaemon(
         config_path=args.config,
-        global_config_path=getattr(args, 'dolphin_config', None),
         default_model=getattr(args, 'model', None),
     )
     await daemon.start()
@@ -269,7 +268,6 @@ def cmd_heartbeat(args):
         run_heartbeat_once(
             args.agent,
             config_path=args.config,
-            dolphin_config_path=getattr(args, "dolphin_config", None),
             model=getattr(args, "model", None),
             force=bool(getattr(args, "force", False)),
         )
@@ -357,8 +355,7 @@ def _build_parser() -> argparse.ArgumentParser:
 
     # start 命令（推荐使用 bin/everbot start）
     parser_start = subparsers.add_parser("start", help="启动守护进程（推荐使用 bin/everbot）")
-    parser_start.add_argument("--dolphin-config", type=str, help="Dolphin 配置文件路径")
-    parser_start.add_argument("--model", type=str, default=None, help="默认模型（为空则使用 Dolphin 配置默认）")
+    parser_start.add_argument("--model", type=str, default=None, help="默认模型")
     parser_start.set_defaults(func=cmd_start)
 
     # stop 命令
@@ -380,14 +377,12 @@ def _build_parser() -> argparse.ArgumentParser:
     parser_heartbeat = subparsers.add_parser("heartbeat", help="手动触发心跳")
     parser_heartbeat.add_argument("--agent", required=True, help="Agent 名称")
     parser_heartbeat.add_argument("--force", action="store_true", help="忽略活跃时段限制")
-    parser_heartbeat.add_argument("--dolphin-config", type=str, help="Dolphin 配置文件路径")
-    parser_heartbeat.add_argument("--model", type=str, default=None, help="默认模型（为空则使用 Dolphin 配置默认）")
+    parser_heartbeat.add_argument("--model", type=str, default=None, help="默认模型")
     parser_heartbeat.set_defaults(func=cmd_heartbeat)
 
     # migrate-agent 命令
-    parser_migrate = subparsers.add_parser("migrate-agent", help="迁移/修复 agent.dph（兼容旧格式）")
+    parser_migrate = subparsers.add_parser("migrate-agent", help="已废弃")
     parser_migrate.add_argument("--agent", required=True, help="Agent 名称")
-    parser_migrate.add_argument("--dolphin-config", type=str, help="Dolphin 配置文件路径")
     parser_migrate.set_defaults(func=cmd_migrate_agent)
 
     # doctor 命令

--- a/src/everbot/core/agent/provider/milkie/agent_spec.py
+++ b/src/everbot/core/agent/provider/milkie/agent_spec.py
@@ -1,8 +1,8 @@
-"""dolphin.yaml 风格 model 配置 → milkie agent.md ModelConfig 映射(sidecar 产品化奠基)。
+"""models.yaml routing (llms/clouds) → milkie agent.md ModelConfig.
 
 milkie serve 用 `--agent <md>` 加载单 agent,其 frontmatter 的 `model:`(默认档)与
-`models.<tier>:`(具名档,milkie#126)需要 ``{provider, model, adapter, baseUrl}``。
-alfred 的 dolphin.yaml 用 ``llms.<name> = {cloud, model_name, type_api}`` +
+`models.<tier>:`(具名档)需要 ``{provider, model, adapter, baseUrl}``。
+alfred ``models.yaml`` 用 ``llms.<name> = {cloud, model_name, type_api}`` +
 ``clouds.<cloud> = {api, api_key}`` 描述模型,本模块做这层翻译。
 
 注意(已知 gap):milkie OpenAICompatibleAdapter 的 apiKey 仅从 env 读,serve 的

--- a/src/everbot/core/agent/provider/model_config.py
+++ b/src/everbot/core/agent/provider/model_config.py
@@ -1,8 +1,7 @@
-"""模型路由配置(dolphin-free)。
+"""模型路由配置。
 
-从 ``models.yaml``(#74 正名;legacy ``dolphin.yaml`` 兜底)读取 llms/clouds + 默认/快速档。
-此前 milkie pool 经 dolphin factory 的 ``global_config_path`` 取这份配置,导致 milkie
-仍耦合 dolphin;本模块用同样的查找顺序独立定位,去掉该耦合(#38 去 dolphin)。
+从 ``models.yaml`` 读取 llms/clouds + 默认/快速档。
+查找顺序:~/.alfred/models.yaml → ./config/models.yaml → repo config/models.yaml。
 
 文件 schema(``config/models.yaml``):
     default: <llm-name>        # 系统级 fallback(无 agent 上下文时;亦兼容旧键 default_model)
@@ -27,9 +26,7 @@ from typing import Any, Dict, Literal, Optional
 import yaml
 
 
-# #74:正名 models.yaml(dolphin 已于 #38 移除,旧名误导);同位置内新名优先、
-# 旧名兜底 —— 用户 home 级 dolphin.yaml 覆盖仍优先于 cwd/repo 的新名,改名不悄换生效配置。
-_CONFIG_NAMES = ("models.yaml", "dolphin.yaml")
+_CONFIG_NAME = "models.yaml"
 
 
 def find_model_config_path(
@@ -48,11 +45,11 @@ def find_model_config_path(
         repo_config or Path(__file__).resolve().parents[5] / "config",  # repo config/
     )
     for base in bases:
-        for name in _CONFIG_NAMES:
-            p = base / name
-            if p.exists():
-                return p
+        p = base / _CONFIG_NAME
+        if p.exists():
+            return p
     return None
+
 
 
 _ENV_PLACEHOLDER = __import__("re").compile(r"\$\{[^}]+\}")

--- a/src/everbot/core/runtime/control.py
+++ b/src/everbot/core/runtime/control.py
@@ -49,7 +49,6 @@ async def run_heartbeat_once(
     agent_name: str,
     *,
     config_path: Optional[str] = None,
-    dolphin_config_path: Optional[str] = None,
     model: Optional[str] = None,
     force: bool = False,
 ) -> str:

--- a/src/everbot/core/runtime/scheduler.py
+++ b/src/everbot/core/runtime/scheduler.py
@@ -81,6 +81,24 @@ class InlineSchedule:
     max_backoff_minutes: int = 60
 
 
+
+@dataclass
+class IsolatedSchedule:
+    """Per-agent isolated-task scheduling state (#202).
+
+    Isolated due tasks reappear every 1s tick. When claim raises
+    LLMUnavailableError the whole agent's isolated set shares one backoff
+    clock so we do not log or claim on every tick. max_backoff_minutes
+    defaults to 2 so probe recovery starts work within the S2 bound.
+    """
+
+    agent_name: str
+    base_interval_minutes: int = 1
+    next_isolated_at: Optional[datetime] = None
+    consecutive_failures: int = 0
+    max_backoff_minutes: int = 2
+
+
 @dataclass
 class InspectorSchedule:
     """Per-agent inspector scheduling state.
@@ -128,6 +146,7 @@ class Scheduler:
         agent_schedules: Optional[Dict[str, AgentSchedule]] = None,
         inspector_schedules: Optional[Dict[str, InspectorSchedule]] = None,
         inline_schedules: Optional[Dict[str, InlineSchedule]] = None,
+        isolated_schedules: Optional[Dict[str, IsolatedSchedule]] = None,
         tick_interval_seconds: float = 1.0,
         state_file: Optional[Path] = None,
     ):
@@ -140,6 +159,7 @@ class Scheduler:
         self._agent_schedules: Dict[str, AgentSchedule] = dict(agent_schedules or {})
         self._inspector_schedules: Dict[str, InspectorSchedule] = dict(inspector_schedules or {})
         self._inline_schedules: Dict[str, InlineSchedule] = dict(inline_schedules or {})
+        self._isolated_schedules: Dict[str, IsolatedSchedule] = dict(isolated_schedules or {})
         self._tick_interval_seconds = tick_interval_seconds
         self._running = False
         self._state_file = state_file
@@ -180,6 +200,18 @@ class Scheduler:
                 inlines[name] = lentry
             if inlines:
                 state["__inline__"] = inlines
+            isolated: Dict[str, Any] = {}
+            for name, osched in self._isolated_schedules.items():
+                if osched.next_isolated_at is None and osched.consecutive_failures == 0:
+                    continue
+                oentry: Dict[str, Any] = {
+                    "consecutive_failures": osched.consecutive_failures,
+                }
+                if osched.next_isolated_at is not None:
+                    oentry["next_isolated_at"] = osched.next_isolated_at.isoformat()
+                isolated[name] = oentry
+            if isolated:
+                state["__isolated__"] = isolated
             self._state_file.parent.mkdir(parents=True, exist_ok=True)
             self._state_file.write_text(json.dumps(state, indent=2), encoding="utf-8")
         except Exception:
@@ -241,6 +273,20 @@ class Scheduler:
                     except (ValueError, TypeError):
                         pass
                 lsched.consecutive_failures = int(lvalue.get("consecutive_failures", 0) or 0)
+            isolated_state = state.get("__isolated__", {})
+            for name, ovalue in isolated_state.items():
+                if not isinstance(ovalue, dict):
+                    continue
+                osched = self._get_isolated_schedule(name)
+                iso_str = ovalue.get("next_isolated_at")
+                if iso_str:
+                    try:
+                        osched.next_isolated_at = datetime.fromisoformat(iso_str)
+                    except (ValueError, TypeError):
+                        pass
+                osched.consecutive_failures = int(
+                    ovalue.get("consecutive_failures", 0) or 0
+                )
             logger.debug("Restored scheduler state from %s", self._state_file)
         except Exception:
             logger.debug("Failed to restore scheduler state", exc_info=True)
@@ -275,6 +321,15 @@ class Scheduler:
             )
             self._inline_schedules[agent_name] = schedule
         return schedule
+
+    def _get_isolated_schedule(self, agent_name: str) -> IsolatedSchedule:
+        """Return the isolated backoff schedule for an agent, creating it lazily."""
+        schedule = self._isolated_schedules.get(agent_name)
+        if schedule is None:
+            schedule = IsolatedSchedule(agent_name=agent_name)
+            self._isolated_schedules[agent_name] = schedule
+        return schedule
+
 
     # -- Core tick ----------------------------------------------------------
 
@@ -384,16 +439,53 @@ class Scheduler:
                     # single flaky task can't stall the whole agent's inline path.
                     logger.exception("Inline task execution failed for %s", agent_name)
 
-        # Isolated: claim then dispatch, per-task error isolation
+        # Isolated: agent-level LLM backoff, then per-task claim/run (#202).
         if self._claim_task is not None and self._run_isolated is not None:
+            isolated_by_agent: Dict[str, List[SchedulerTask]] = {}
             for task in isolated_tasks:
-                try:
-                    claimed = await self._claim_task(task.id)
-                    if not claimed:
-                        continue
-                    await self._run_isolated(task, ts)
-                except Exception:
-                    logger.exception("Isolated task %s failed", task.id)
+                isolated_by_agent.setdefault(task.agent_name, []).append(task)
+            for agent_name, tasks in isolated_by_agent.items():
+                schedule = self._get_isolated_schedule(agent_name)
+                next_at = (
+                    self._normalize_ts(schedule.next_isolated_at)
+                    if schedule.next_isolated_at is not None
+                    else None
+                )
+                if next_at is not None and ts < next_at:
+                    continue
+                blocked = False
+                for task in tasks:
+                    if blocked:
+                        break
+                    try:
+                        claimed = await self._claim_task(task.id)
+                        if not claimed:
+                            continue
+                        await self._run_isolated(task, ts)
+                        schedule.consecutive_failures = 0
+                        schedule.next_isolated_at = None
+                        self._save_state()
+                    except LLMUnavailableError:
+                        schedule.consecutive_failures += 1
+                        base_interval = max(1, schedule.base_interval_minutes)
+                        backoff_minutes = min(
+                            base_interval * (2 ** schedule.consecutive_failures),
+                            schedule.max_backoff_minutes,
+                        )
+                        schedule.next_isolated_at = ts + timedelta(
+                            minutes=backoff_minutes
+                        )
+                        logger.warning(
+                            "Skip isolated claim for %s: LLM unavailable "
+                            "(consecutive_failures=%d, next_retry_in=%d min)",
+                            agent_name,
+                            schedule.consecutive_failures,
+                            backoff_minutes,
+                        )
+                        blocked = True
+                        self._save_state()
+                    except Exception:
+                        logger.exception("Isolated task %s failed", task.id)
 
     async def _tick_inspector(self, ts: datetime) -> None:
         """Trigger due inspector ticks (low-frequency observation)."""

--- a/src/everbot/infra/user_data.py
+++ b/src/everbot/infra/user_data.py
@@ -43,11 +43,6 @@ class UserDataManager:
         return self.alfred_home / "models.yaml"
 
     @property
-    def dolphin_config_path(self) -> Path:
-        """legacy 模型配置路径(#38 去 dolphin 后旧名残留,仅兜底查找用)"""
-        return self.alfred_home / "dolphin.yaml"
-
-    @property
     def agents_dir(self) -> Path:
         """Agent 工作区目录"""
         return self.alfred_home / "agents"

--- a/tests/unit/test_doctor.py
+++ b/tests/unit/test_doctor.py
@@ -73,7 +73,7 @@ def test_doctor_reports_missing_config_and_agents_dir():
 # 原两条钉住该函数的用例一并撤销。
 
 
-# ── #74: doctor 同步改名(models.yaml 优先、dolphin.yaml 兜底、撤 skillkit 残留检查) ──
+# ── doctor only recognizes models.yaml ──
 
 
 def test_doctor_resolves_models_yaml_first(tmp_path):
@@ -88,8 +88,9 @@ def test_doctor_resolves_models_yaml_first(tmp_path):
     assert path == home / "models.yaml"
 
 
-def test_doctor_legacy_dolphin_still_resolves(tmp_path):
+def test_doctor_ignores_dolphin_yaml_only(tmp_path, monkeypatch):
     from src.everbot.cli.doctor import resolve_model_config_source
+    monkeypatch.chdir(tmp_path)
     home = tmp_path / ".alfred"
     home.mkdir(parents=True)
     proj_cfg = tmp_path / "config"
@@ -97,8 +98,18 @@ def test_doctor_legacy_dolphin_still_resolves(tmp_path):
     (proj_cfg / "dolphin.yaml").write_text("default: y\n", encoding="utf-8")
     ud = UserDataManager(alfred_home=home)
     label, path = resolve_model_config_source(ud, tmp_path)
-    assert label == "project"
-    assert path == proj_cfg / "dolphin.yaml"
+    assert label == "default"
+    assert path is None
+
+
+def test_doctor_missing_models_yaml_message_omits_dolphin(tmp_path):
+    home = tmp_path / ".alfred"
+    items = collect_doctor_report(project_root=tmp_path, alfred_home=home)
+    routing = [i for i in items if i.title == "Model routing config"]
+    assert routing
+    blob = " ".join(f"{i.details} {i.hint or ''}" for i in routing).lower()
+    assert "dolphin" not in blob
+    assert "models.yaml" in blob
 
 
 def test_doctor_report_drops_dead_skillkit_check(tmp_path):

--- a/tests/unit/test_inline_backoff.py
+++ b/tests/unit/test_inline_backoff.py
@@ -401,8 +401,8 @@ class TestDaemonIsolatedHealthGate:
         sched = self._build(runner, tmp_path)
         due = list(sched._get_due_tasks(datetime.now()) or [])
         assert any(t.id == "a:t1" for t in due)
-        assert asyncio.run(sched._claim_task("a:t1")) is False
-        runner.claim_isolated_task.assert_not_awaited()
+        with pytest.raises(LLMUnavailableError):
+            asyncio.run(sched._claim_task("a:t1"))
 
     def test_claim_and_run_when_llm_available(self, tmp_path):
         from types import SimpleNamespace

--- a/tests/unit/test_isolated_claim_backoff.py
+++ b/tests/unit/test_isolated_claim_backoff.py
@@ -1,0 +1,327 @@
+"""Tests for #202: isolated claim backoff when the LLM is unavailable.
+
+#78 backed off the inline path. Isolated claim still returned False on every
+1s tick, flooding logs. The scheduler must gate isolated work per agent until
+the next retry, and recover within 2 minutes after the probe is healthy.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+
+from src.everbot.core.jobs.llm_errors import LLMUnavailableError
+from src.everbot.core.runtime.scheduler import IsolatedSchedule, Scheduler, SchedulerTask
+
+
+def _due_isolated(*task_ids: str, agent: str = "demo_agent"):
+    def _get_due(ts):
+        return [
+            SchedulerTask(id=tid, agent_name=agent, execution_mode="isolated")
+            for tid in task_ids
+        ]
+
+    return _get_due
+
+
+class TestIsolatedClaimBackoff:
+    def test_llm_unavailable_claim_backs_off(self):
+        claims = []
+
+        async def _claim(task_id):
+            claims.append(task_id)
+            raise LLMUnavailableError("llm down")
+
+        async def _run(task, ts):
+            raise AssertionError("must not run while LLM is down")
+
+        schedule = IsolatedSchedule(
+            agent_name="demo_agent",
+            base_interval_minutes=1,
+            max_backoff_minutes=2,
+        )
+        scheduler = Scheduler(
+            get_due_tasks=_due_isolated("demo_agent:t1"),
+            claim_task=_claim,
+            run_isolated=_run,
+            isolated_schedules={"demo_agent": schedule},
+        )
+        ts = datetime(2026, 8, 18, 8, 11, tzinfo=timezone.utc)
+        asyncio.run(scheduler._tick_tasks(ts))
+        assert claims == ["demo_agent:t1"]
+        assert schedule.consecutive_failures == 1
+        assert schedule.next_isolated_at == ts + timedelta(minutes=2)
+
+    def test_backoff_gates_claim_until_next_retry(self):
+        claims = []
+
+        async def _claim(task_id):
+            claims.append(task_id)
+            raise LLMUnavailableError("llm down")
+
+        async def _run(task, ts):
+            return None
+
+        ts = datetime(2026, 8, 18, 8, 11, tzinfo=timezone.utc)
+        schedule = IsolatedSchedule(
+            agent_name="demo_agent",
+            next_isolated_at=ts + timedelta(minutes=2),
+            consecutive_failures=1,
+            max_backoff_minutes=2,
+        )
+        scheduler = Scheduler(
+            get_due_tasks=_due_isolated("demo_agent:t1"),
+            claim_task=_claim,
+            run_isolated=_run,
+            isolated_schedules={"demo_agent": schedule},
+        )
+        asyncio.run(scheduler._tick_tasks(ts + timedelta(seconds=30)))
+        assert claims == []
+        assert schedule.consecutive_failures == 1
+
+    def test_agent_gate_covers_all_due_isolated_tasks(self):
+        claims = []
+
+        async def _claim(task_id):
+            claims.append(task_id)
+            raise LLMUnavailableError("llm down")
+
+        async def _run(task, ts):
+            return None
+
+        schedule = IsolatedSchedule(agent_name="demo_agent", max_backoff_minutes=2)
+        scheduler = Scheduler(
+            get_due_tasks=_due_isolated("demo_agent:gray", "demo_agent:serenity"),
+            claim_task=_claim,
+            run_isolated=_run,
+            isolated_schedules={"demo_agent": schedule},
+        )
+        ts = datetime(2026, 8, 18, 8, 11, tzinfo=timezone.utc)
+        asyncio.run(scheduler._tick_tasks(ts))
+        assert claims == ["demo_agent:gray"]
+        assert schedule.next_isolated_at is not None
+
+    def test_false_claim_does_not_backoff(self):
+        claims = []
+
+        async def _claim(task_id):
+            claims.append(task_id)
+            return False
+
+        async def _run(task, ts):
+            return None
+
+        schedule = IsolatedSchedule(agent_name="demo_agent")
+        scheduler = Scheduler(
+            get_due_tasks=_due_isolated("demo_agent:t1"),
+            claim_task=_claim,
+            run_isolated=_run,
+            isolated_schedules={"demo_agent": schedule},
+        )
+        ts = datetime(2026, 8, 18, 8, 11, tzinfo=timezone.utc)
+        asyncio.run(scheduler._tick_tasks(ts))
+        asyncio.run(scheduler._tick_tasks(ts + timedelta(seconds=1)))
+        assert claims == ["demo_agent:t1", "demo_agent:t1"]
+        assert schedule.consecutive_failures == 0
+        assert schedule.next_isolated_at is None
+
+    def test_success_clears_backoff(self):
+        async def _claim(task_id):
+            return True
+
+        ran = []
+
+        async def _run(task, ts):
+            ran.append(task.id)
+
+        schedule = IsolatedSchedule(
+            agent_name="demo_agent",
+            consecutive_failures=3,
+            next_isolated_at=None,
+        )
+        scheduler = Scheduler(
+            get_due_tasks=_due_isolated("demo_agent:t1"),
+            claim_task=_claim,
+            run_isolated=_run,
+            isolated_schedules={"demo_agent": schedule},
+        )
+        ts = datetime(2026, 8, 18, 8, 40, tzinfo=timezone.utc)
+        asyncio.run(scheduler._tick_tasks(ts))
+        assert ran == ["demo_agent:t1"]
+        assert schedule.consecutive_failures == 0
+        assert schedule.next_isolated_at is None
+
+    def test_other_agent_not_gated(self):
+        claims = []
+
+        async def _claim(task_id):
+            claims.append(task_id)
+            if task_id.startswith("down:"):
+                raise LLMUnavailableError("llm down")
+            return True
+
+        ran = []
+
+        async def _run(task, ts):
+            ran.append(task.id)
+
+        def _get_due(ts):
+            return [
+                SchedulerTask(id="down:t1", agent_name="down", execution_mode="isolated"),
+                SchedulerTask(id="up:t1", agent_name="up", execution_mode="isolated"),
+            ]
+
+        scheduler = Scheduler(
+            get_due_tasks=_get_due,
+            claim_task=_claim,
+            run_isolated=_run,
+        )
+        ts = datetime(2026, 8, 18, 8, 11, tzinfo=timezone.utc)
+        asyncio.run(scheduler._tick_tasks(ts))
+        assert "down:t1" in claims
+        assert ran == ["up:t1"]
+
+    def test_backoff_capped_at_two_minutes(self):
+        async def _claim(task_id):
+            raise LLMUnavailableError("llm down")
+
+        async def _run(task, ts):
+            return None
+
+        schedule = IsolatedSchedule(
+            agent_name="demo_agent",
+            base_interval_minutes=1,
+            max_backoff_minutes=2,
+            consecutive_failures=99,
+        )
+        scheduler = Scheduler(
+            get_due_tasks=_due_isolated("demo_agent:t1"),
+            claim_task=_claim,
+            run_isolated=_run,
+            isolated_schedules={"demo_agent": schedule},
+        )
+        ts = datetime(2026, 8, 18, 8, 11, tzinfo=timezone.utc)
+        asyncio.run(scheduler._tick_tasks(ts))
+        assert schedule.next_isolated_at - ts <= timedelta(minutes=2, seconds=1)
+
+    def test_ten_minute_window_claim_attempts_at_most_ten(self):
+        """S1: 10 minutes of 1s ticks, each due task is claimed ≤ 10 times."""
+        claims = []
+
+        async def _claim(task_id):
+            claims.append(task_id)
+            raise LLMUnavailableError("llm down")
+
+        async def _run(task, ts):
+            return None
+
+        scheduler = Scheduler(
+            get_due_tasks=_due_isolated("demo_agent:gray", "demo_agent:serenity"),
+            claim_task=_claim,
+            run_isolated=_run,
+        )
+        t0 = datetime(2026, 8, 18, 8, 11, tzinfo=timezone.utc)
+
+        async def _drive():
+            for i in range(601):
+                await scheduler.tick(t0 + timedelta(seconds=i))
+
+        asyncio.run(_drive())
+        assert claims.count("demo_agent:gray") <= 10
+        assert claims.count("demo_agent:serenity") <= 10
+
+    def test_recovers_within_two_minutes_after_probe_up(self):
+        """S2: after LLM recovers, the next claim/run happens within 2 minutes."""
+        llm_down = True
+        ran = []
+
+        async def _claim(task_id):
+            if llm_down:
+                raise LLMUnavailableError("llm down")
+            return True
+
+        async def _run(task, ts):
+            ran.append(ts)
+
+        scheduler = Scheduler(
+            get_due_tasks=_due_isolated("demo_agent:t1"),
+            claim_task=_claim,
+            run_isolated=_run,
+        )
+        t0 = datetime(2026, 8, 18, 8, 11, tzinfo=timezone.utc)
+        asyncio.run(scheduler.tick(t0))
+        assert ran == []
+
+        llm_down = False
+        recovered_at = t0 + timedelta(seconds=10)
+        deadline = recovered_at + timedelta(minutes=2)
+
+        async def _drive():
+            ts = recovered_at
+            while ts <= deadline:
+                await scheduler.tick(ts)
+                if ran:
+                    return
+                ts += timedelta(seconds=1)
+
+        asyncio.run(_drive())
+        assert ran, "isolated task did not start within 2 minutes of probe recovery"
+        assert ran[0] <= deadline
+
+    def test_state_persistence_round_trip(self, tmp_path):
+        state_file = tmp_path / "scheduler_state.json"
+        nxt = datetime(2026, 8, 18, 8, 13, tzinfo=timezone.utc)
+        schedule = IsolatedSchedule(
+            agent_name="demo_agent",
+            consecutive_failures=2,
+            next_isolated_at=nxt,
+        )
+        Scheduler(
+            isolated_schedules={"demo_agent": schedule},
+            state_file=state_file,
+        )._save_state()
+
+        restored = Scheduler(state_file=state_file)
+        sched2 = restored._get_isolated_schedule("demo_agent")
+        assert sched2.consecutive_failures == 2
+        assert sched2.next_isolated_at == nxt
+
+
+class TestDaemonIsolatedClaimRaises:
+    def _build(self, runner, tmp_path):
+        from types import SimpleNamespace
+        from unittest.mock import AsyncMock
+
+        from src.everbot.cli.daemon import EverBotDaemon
+
+        daemon = EverBotDaemon.__new__(EverBotDaemon)
+        daemon.heartbeat_runners = {"a": runner}
+        daemon._scheduler_cron_jobs = True
+        daemon._scheduler_run_heartbeat = AsyncMock()
+        daemon.user_data = SimpleNamespace(alfred_home=tmp_path)
+        return daemon._build_scheduler()
+
+    def test_claim_raises_when_llm_unavailable(self, tmp_path):
+        from datetime import datetime
+        from types import SimpleNamespace
+        from unittest.mock import AsyncMock
+
+        import pytest
+
+        runner = SimpleNamespace(
+            is_llm_unavailable=True,
+            claim_isolated_task=AsyncMock(return_value=True),
+            execute_isolated_claimed_task=AsyncMock(),
+            list_due_inline_tasks=lambda now=None: [],
+            list_due_isolated_tasks=lambda now=None: [{"id": "t1", "timeout_seconds": 30}],
+            interval_minutes=30,
+            night_interval_minutes=None,
+            active_hours=(0, 24),
+            inspect_interval_minutes=30,
+            inspect_night_interval_minutes=None,
+        )
+        sched = self._build(runner, tmp_path)
+        list(sched._get_due_tasks(datetime.now()) or [])
+        with pytest.raises(LLMUnavailableError):
+            asyncio.run(sched._claim_task("a:t1"))
+        runner.claim_isolated_task.assert_not_awaited()

--- a/tests/unit/test_milkie_provider.py
+++ b/tests/unit/test_milkie_provider.py
@@ -1085,8 +1085,8 @@ def test_injected_system_prompt_loader_is_used(monkeypatch):
     monkeypatch.setattr(
         "src.everbot.infra.config.get_config", lambda *a, **k: {}
     )
-    # #38:_build_pool 现经 model_config.load_model_config 读模型路由(非 dolphin factory),
-    # 走真实 config/dolphin.yaml 即可;_CapturingLauncher 忽略 llms/clouds,无害。
+    # _build_pool reads model routing via model_config.load_model_config.
+    # _CapturingLauncher ignores llms/clouds.
 
     # 模块级默认 loader 一旦被调用就炸 → 证明注入版真正接通(而非静默走默认)
     def _default_must_not_be_called(agent_name):

--- a/tests/unit/test_model_config.py
+++ b/tests/unit/test_model_config.py
@@ -25,7 +25,7 @@ llms:
 
 
 def _write(tmp_path) -> Path:
-    p = tmp_path / "dolphin.yaml"
+    p = tmp_path / "models.yaml"
     p.write_text(_YAML, encoding="utf-8")
     return p
 
@@ -158,7 +158,7 @@ def test_route_merges_cloud_and_llm_extra_body_llm_wins(tmp_path):
     assert r2.extra_body == {"cloud_flag": True, "thinking": {"type": "enabled"}}
 
 
-# ── #74: models.yaml 正名,dolphin.yaml legacy 兜底(同位置新名优先) ────
+# ── models.yaml only; dolphin.yaml is not a config source ────
 
 
 from src.everbot.core.agent.provider.model_config import find_model_config_path
@@ -171,7 +171,7 @@ def _mk_cfg(base: Path, name: str) -> Path:
     return p
 
 
-def test_find_prefers_models_over_dolphin_in_same_location(tmp_path):
+def test_find_uses_models_yaml_even_if_dolphin_yaml_exists(tmp_path):
     home = tmp_path / "home"
     models = _mk_cfg(home, "models.yaml")
     _mk_cfg(home, "dolphin.yaml")
@@ -180,14 +180,21 @@ def test_find_prefers_models_over_dolphin_in_same_location(tmp_path):
     assert got == models
 
 
-def test_find_legacy_home_dolphin_beats_lower_priority_models(tmp_path):
-    """用户 home 级旧名覆盖必须仍优先于 cwd/repo 的新名 —— 改名不得悄换生效配置。"""
+def test_find_ignores_home_dolphin_yaml_when_cwd_has_models(tmp_path):
     home = tmp_path / "home"
     cwdc = tmp_path / "cwdc"
-    legacy = _mk_cfg(home, "dolphin.yaml")
-    _mk_cfg(cwdc, "models.yaml")
+    _mk_cfg(home, "dolphin.yaml")
+    cwd_models = _mk_cfg(cwdc, "models.yaml")
     got = find_model_config_path(home=home, cwd_config=cwdc, repo_config=tmp_path / "n")
-    assert got == legacy
+    assert got == cwd_models
+
+
+def test_find_returns_none_when_only_dolphin_yaml_exists(tmp_path):
+    home = tmp_path / "home"
+    _mk_cfg(home, "dolphin.yaml")
+    got = find_model_config_path(
+        home=home, cwd_config=tmp_path / "n1", repo_config=tmp_path / "n2")
+    assert got is None
 
 
 def test_find_falls_back_cwd_then_repo(tmp_path):


### PR DESCRIPTION
Fixes #202

## 做了什么
- isolated due 任务按 **agent** 共用 `IsolatedSchedule`，`LLMUnavailableError` 后指数退避、上限 2 分钟
- daemon `_claim_task` 不可用时抛错，不再每秒 `return False` 刷 `Skip isolated claim`
- 单测覆盖 S1（10 分钟 1s tick，每任务 claim ≤ 10）和 S2（probe 恢复后 2 分钟内 run）

## 验证
- `pytest tests/unit/test_isolated_claim_backoff.py tests/unit/test_inline_backoff.py tests/unit/test_core_runtime.py tests/unit/test_heartbeat_runner_core.py` → 146 passed
- 本机 `bin/everbot stop && start`：pid 81076，`HEARTBEAT_OK`，`ops diagnose` healthy