### PR TITLE
【session】compaction 工具链改自然语言编码 (#205)

### DIFF
--- a/src/everbot/core/agent/provider/milkie/provider.py
+++ b/src/everbot/core/agent/provider/milkie/provider.py
@@ -1036,7 +1036,11 @@ def _rewrite_history_regions(regions_snap: Any, history_messages: list) -> Any:
 
 
 def _history_messages_to_pairs(history_messages: list) -> list:
-    """Fold alfred history into (user, assistant_text) pairs for milkie regions."""
+    """Fold alfred history into (user, assistant_text) pairs for milkie regions.
+
+    Tool chains become ``Used {name}.`` / ``Result: {body}`` prose so compacted
+    history cannot few-shot a fake ``[tool_call …]`` DSL (#205).
+    """
     pairs: list = []
     i = 0
     msgs = [m for m in history_messages if isinstance(m, dict)]
@@ -1056,15 +1060,16 @@ def _history_messages_to_pairs(history_messages: list) -> list:
                     for tc in cur.get("tool_calls") or []:
                         fn = (tc or {}).get("function") or {}
                         name = fn.get("name") or ""
-                        args = fn.get("arguments") or ""
-                        asst_parts.append(f"[tool_call {name}({args})]")
+                        # Natural prose, not a fake DSL — models few-shot `[tool_call …]`
+                        # from compacted history and emit it as plain text (#205).
+                        if name:
+                            asst_parts.append(f"Used {name}.")
                 elif cur.get("role") == "tool":
                     body = cur.get("content") if isinstance(cur.get("content"), str) else ""
-                    tcid = cur.get("tool_call_id") or ""
                     # Bound tool body so a single region cannot re-inflate the base
                     if len(body) > 2000:
                         body = body[:2000] + "…"
-                    asst_parts.append(f"[tool_result {tcid}] {body}")
+                    asst_parts.append(f"Result: {body}")
                 i += 1
             pairs.append((user_text or "", "\n".join(asst_parts)))
         else:

--- a/tests/unit/test_history_compaction.py
+++ b/tests/unit/test_history_compaction.py
@@ -875,11 +875,7 @@ class TestSessionManagerCompact:
                     user = content.get("userInput") or ""
                     asst = content.get("assistantText") or ""
                     msgs.append(_user(user))
-                    # Unfold tool prose folded by milkie rewrite when present.
-                    if "[tool_call" in asst or "[tool_result" in asst:
-                        msgs.append(_assistant(asst))
-                    else:
-                        msgs.append(_assistant(asst))
+                    msgs.append(_assistant(asst))
             return msgs
 
         class FakeMilkieServe:

--- a/tests/unit/test_milkie_provider.py
+++ b/tests/unit/test_milkie_provider.py
@@ -15,6 +15,7 @@ from src.everbot.core.agent.provider.milkie.provider import (
     MilkieAgentHandle,
     MilkieProvider,
     MilkieSessionImportConflict,
+    _history_messages_to_pairs,
 )
 
 
@@ -1450,6 +1451,65 @@ def test_import_session_with_manifest_posts_import_as_is():
     assert cap["body"]["session"]["manifest"]["latestRunId"] == "run-old"
 
 
+def test_history_messages_to_pairs_folds_tools_as_prose():
+    """#205: tool_calls fold to Used/Result prose, never a fake [tool_call] DSL."""
+    pairs = _history_messages_to_pairs(
+        [
+            {"role": "user", "content": "search the repo"},
+            {
+                "role": "assistant",
+                "content": "searching",
+                "tool_calls": [
+                    {
+                        "id": "tc_live",
+                        "type": "function",
+                        "function": {"name": "search", "arguments": '{"q":"open"}'},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "tc_live", "content": "found A B C"},
+            {"role": "assistant", "content": "working on open task"},
+            {"role": "user", "content": "thanks"},
+            {"role": "assistant", "content": "you're welcome"},
+        ]
+    )
+    assert pairs == [
+        (
+            "search the repo",
+            "searching\nUsed search.\nResult: found A B C\nworking on open task",
+        ),
+        ("thanks", "you're welcome"),
+    ]
+    blob = "\n".join(asst for _, asst in pairs)
+    assert "[tool_call" not in blob
+    assert "[tool_result" not in blob
+    assert '{"q":"open"}' not in blob
+
+    long_body = "x" * 2500
+    truncated = _history_messages_to_pairs(
+        [
+            {"role": "user", "content": "q"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {"function": {"name": "search", "arguments": "{}"}},
+                ],
+            },
+            {"role": "tool", "content": long_body},
+        ]
+    )
+    assert truncated == [("q", "Used search.\nResult: " + ("x" * 2000) + "…")]
+
+    nameless = _history_messages_to_pairs(
+        [
+            {"role": "user", "content": "q"},
+            {"role": "assistant", "content": "hi", "tool_calls": [{"function": {}}]},
+        ]
+    )
+    assert nameless == [("q", "hi")]
+
+
 def test_import_session_from_compacted_history_rewrites_and_imports():
     """#166 S4: alfred {history_messages} → export live portable → rewrite
     history:turn-* regions → POST /session/import under same contextId.
@@ -1529,8 +1589,11 @@ def test_import_session_from_compacted_history_rewrites_and_imports():
     assert "old bulk message" not in hist_blob
     assert "CRITICAL_CONSTRAINT" in hist_blob or "Python 3.11" in hist_blob
     assert "open task" in hist_blob.lower() or "search" in hist_blob.lower()
-    # Tool chain folded into assistant text (milkie pair regions).
-    assert "tc_live" in hist_blob or "tool_call" in hist_blob or "tool_result" in hist_blob
+    # Tool chain folded as natural prose, not a fake `[tool_call …]` DSL (#205).
+    assert "Used search." in hist_blob
+    assert "Result: found A B C" in hist_blob
+    assert "[tool_call" not in hist_blob
+    assert "[tool_result" not in hist_blob
 
     # previousRunId chain broken so getSessionHistory does not walk old runs.
     started = [e for e in session["events"] if e.get("type") == "agent.run.started"]


### PR DESCRIPTION
## 背景

#205：compaction 把工具链折成 `[tool_call name(args)]` 写入 milkie pair，glm 模仿后整段当最终回复泄漏到 Telegram。

## 改动

- `_history_messages_to_pairs`：`Used {name}.` / `Result: {body}`，不再写伪 DSL；args 不写入；Result 仍截 2000 字
- 对应 unit：直接测 fold；import rewrite 断言 prose、禁止 `[tool_call`
- 清掉 compaction 测试里对旧 DSL 的死分支

## 不做

出站按字符串剥 `[tool_call`；自动 `/clear`

## 测试

`PYTHONPATH=. pytest tests/unit/test_milkie_provider.py tests/unit/test_history_compaction.py` → 108 passed

## 部署后

受影响会话需 `/clear`（已写入的旧 DSL 不会自己变）