### PR TITLE
【runtime】demo_agent 切到本机 grok-cli

### DIFF
--- a/bin/everbot
+++ b/bin/everbot
@@ -428,6 +428,15 @@ case "${cmd}" in
             # 不再 exec(否则无法回报);pid 未变 = 重启没生效,非零退出报错。
             _svc_pid() { launchctl print "${_svc_target}" 2>/dev/null | awk -F'= *' '/^[[:space:]]*pid =/{gsub(/[^0-9]/,"",$2); print $2; exit}'; }
             _old_pid="$(_svc_pid)"
+            # A leftover non-launchd daemon (pidfile) can hold everbot.lock;
+            # kickstart then looks successful while status still shows the old pid.
+            _file_pid="$(read_pid)"
+            if is_running "${_file_pid}" && [[ "${_file_pid}" != "${_old_pid}" ]]; then
+              echo "Stopping leftover daemon (pid=${_file_pid}) that holds the lock..."
+              kill "${_file_pid}" 2>/dev/null || true
+              wait_for_exit "${_file_pid}" 10 || kill -9 "${_file_pid}" 2>/dev/null || true
+              rm -f "${PID_FILE}" || true
+            fi
             launchctl kickstart -k "${_svc_target}"
             _new_pid=""
             for _i in $(seq 1 30); do

--- a/config/everbot.example.yaml
+++ b/config/everbot.example.yaml
@@ -48,7 +48,8 @@ everbot:
     # 示例 Agent: daily_insight
     daily_insight:
       workspace: ~/.alfred/agents/daily_insight
-      # model: volcengine/glm-5.2  # 每 agent 覆盖默认模型（everbot.agents.<name>.model > everbot.default_model）。
+      # model: grok-4.6  # 每 agent 覆盖默认模型（everbot.agents.<name>.model > everbot.default_model）。
+      # runtime: grok-cli  # 缺省 milkie sidecar; grok-cli = 宿主 spawn 本机 grok CLI（OAuth,非 xAI HTTP）。
       # skills:                    # 每 agent 技能白/黑名单（milkie 经 discover_skills 扫工作区 SKILL.md）。
       #   include: [daily-attractor]
       #   exclude: []

--- a/docs/design/grok-cli-host-runtime.md
+++ b/docs/design/grok-cli-host-runtime.md
@@ -1,0 +1,62 @@
+# L1：demo_agent 宿主 spawn grok CLI
+
+- 状态: Approved（目标会话授权推荐方案）
+- 最后更新: 2026-08-27
+- 关联: 本机 Alfred 从火山引擎 HTTP 切到 grok CLI；不改 milkie
+
+## 背景
+
+`demo_agent` / `_reflector` 经 milkie sidecar 打火山引擎 OpenAI 兼容端点（`glm-5.2`）。该账号停用。xAI HTTP（`XAI_API_KEY`）无额度。本机 `grok login`（OAuth）可用。kairo / researcher 以宿主 spawn `grok -p` / `--prompt-file` 为 runtime。milkie #251：`agent-cli` 由宿主启动，milkie 不 spawn grok。
+
+## 目标与非目标
+
+**目标**
+
+- `demo_agent` 对话与心跳 turn 由本机 grok CLI headless 驱动，经既有 `AgentProvider.run_turn` → `_progress` 交付回复。
+- grok 子进程环境不含 `XAI_API_KEY`，使用 `~/.grok/auth.json` OAuth。
+- 其它 agent（如 `coding-master`）仍走 milkie HTTP。
+
+**非目标**
+
+- 不改 milkie 去 spawn grok，不实现 milkie `agent-cli` 生命周期。
+- 不使用 `https://api.x.ai/v1`，不消耗 `XAI_API_KEY` team credits。
+- 不要求 milkie 对等：SSE token 流、`skill_list` / `run_command`、sidecar sandbox、milkie trace HTML。
+- 不把 Alfred skill 迁到 grok marketplace；grok 用自带工具 + 工作区已有文件。
+- 不迁移 `coding-master`。
+
+## 思路与折衷
+
+- **选择**：在 Alfred `AgentProvider` 后新增 `GrokCliProvider`，kairo 同款：写 prompt 文件、injectable runner、解析 JSON `text`、产出 llm `_progress`。放弃把 grok 当 OpenAI completions 塞进 milkie gateway——CLI 是完整 agent，不是 tool_calls 端点。
+- **选择**：`everbot.agents.<name>.runtime: grok-cli` 显式路由；未设则 milkie。放弃用模型名猜测 runtime。
+- **放弃**：本地 HTTP 代理包装 grok CLI 给 milkie——双层 agent、无原生 tool_calls、冷启动更差。
+- **放弃**：xAI HTTP——403 无额度。
+
+折衷：grok 是 agent（自带工具、冷启动约 20s、默认 system 很大）。「能 work」= 能交付非空回复，不是 milkie 工具调用对等。
+
+## 边界
+
+- In：`GrokCliProvider`、per-agent `runtime` 路由、`provider_for` 按 handle 分发、demo_agent/_reflector 配置、status 展示 grok-cli、子进程擦除 `XAI_API_KEY`。
+- Out：milkie 源码、coding-master、xAI HTTP、grok marketplace 技能重写。
+
+## 主路径与关键状态
+
+- 空：`runtime` 未设 → milkie，行为不变。
+- 成功：用户/心跳发一句 → 宿主 `grok --prompt-file … --output-format json` → JSON `text` 进 `_progress` → Telegram/web/心跳看到回复。`./bin/everbot status` 生效模型为 `grok-cli` 而非 `glm-5.2`。
+- 错：grok 不在 PATH / OAuth 失效 / JSON `type=error` → `RuntimeError`，不伪装成「(无响应)」；不得落到火山或 xAI HTTP 401/403。
+- 不做的界面：不为 grok-cli 新增 Web 设置页。
+
+## 测试意图
+
+- **E2E**：`./bin/everbot restart` + `status` 两次，demo_agent 为 grok-cli；一条 ping turn 回复含 pong（CLI/OAuth 不可用则记录真实失败，不编 transcript）。
+- **Integration**：N/A（不引入新外部服务；live 验证走本机 grok）。
+- **Unit**：注入 fake runner，断言 argv、子进程无 `XAI_API_KEY`、`_progress` 含 pong。
+
+## 是否需要 L2
+
+否。无新公共 HTTP/CLI 契约；`runtime` 为既有 agent 配置块上的可选键；无新存数/权限模型。实现细节归本变更。
+
+## 关联
+
+- milkie #251 模型连接契约（host spawn CLI）
+- kairo `GrokProvider`、researcher `GrokCliAdapter`
+- 术语：见 `docs/glossary.md` grok-cli

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,3 +1,9 @@
+# 名词表
+
+| 规范名 | 一句话定义 | 禁止别称 |
+|---|---|---|
+| grok-cli | 宿主 spawn 本机 `grok` CLI 作为 agent runtime 的路径，走 OAuth 登录而非 HTTP 模型端点。 | grok HTTP、xAI API、SpaceXAI HTTP |
+
 # Alfred 术语表
 
 ## 核心概念

--- a/src/everbot/cli/agent_model_state.py
+++ b/src/everbot/cli/agent_model_state.py
@@ -38,15 +38,33 @@ def collect_agent_model_states(
     *,
     milkie_root,
     configured_resolver: Callable[[str], Optional[str]],
+    runtime_resolver: Optional[Callable[[str], Optional[str]]] = None,
 ) -> List[dict]:
     """对每个 agent 汇总 {agent, effective, configured, stale}。
 
     effective 来自运行 agent.md;configured 来自配置解析。无 agent.md(sidecar 未拉起)
     → effective=None、stale=False(尚无"生效"可言)。
+    ``runtime_resolver`` 返回 ``grok-cli`` 时不读 milkie agent.md,生效/配置均为 grok-cli。
     """
     root = Path(milkie_root)
     out: List[dict] = []
     for name in agent_names:
+        runtime = None
+        if runtime_resolver is not None:
+            try:
+                runtime = runtime_resolver(name)
+            except Exception:
+                runtime = None
+        if runtime == "grok-cli":
+            out.append(
+                {
+                    "agent": name,
+                    "effective": "grok-cli",
+                    "configured": "grok-cli",
+                    "stale": False,
+                }
+            )
+            continue
         effective = parse_agent_md_model(root / name / "agent.md")
         try:
             configured = configured_resolver(name)

--- a/src/everbot/cli/daemon.py
+++ b/src/everbot/cli/daemon.py
@@ -252,10 +252,7 @@ class EverBotDaemon:
             active_hours = tuple(getattr(runner, "active_hours", (8, 22)))
             _night = getattr(runner, "night_interval_minutes", None)
             if _night is not None and int(_night) <= 0:
-                logger.warning(
-                    "[%s] night_interval_minutes=%s is invalid (must be > 0); treating as None (skip at night)",
-                    agent_name, _night,
-                )
+                # 0 = skip heartbeats outside active_hours (intentional, not invalid).
                 _night = None
             agent_schedules[agent_name] = AgentSchedule(
                 agent_name=agent_name,
@@ -265,10 +262,6 @@ class EverBotDaemon:
             )
             _inspect_night = getattr(runner, "inspect_night_interval_minutes", None)
             if _inspect_night is not None and int(_inspect_night) <= 0:
-                logger.warning(
-                    "[%s] inspect_night_interval_minutes=%s is invalid (must be > 0); treating as None (skip at night)",
-                    agent_name, _inspect_night,
-                )
                 _inspect_night = None
             inspector_schedules[agent_name] = InspectorSchedule(
                 agent_name=agent_name,

--- a/src/everbot/cli/main.py
+++ b/src/everbot/cli/main.py
@@ -120,8 +120,16 @@ def _print_agent_model_states() -> None:
             key = resolve_agent_model(agent_name)
             return (mc.llms.get(key) or {}).get("model_name") if key else None
 
+        agents_cfg = ((config.get("everbot") or {}).get("agents") or {})
+
+        def _runtime(agent_name: str):
+            return (agents_cfg.get(agent_name) or {}).get("runtime")
+
         states = collect_agent_model_states(
-            agents, milkie_root=milkie_root, configured_resolver=_configured
+            agents,
+            milkie_root=milkie_root,
+            configured_resolver=_configured,
+            runtime_resolver=_runtime,
         )
     except Exception as e:  # status 是只读自检,绝不因此崩
         logging.getLogger(__name__).debug("agent model state collect failed: %s", e)

--- a/src/everbot/core/agent/provider/__init__.py
+++ b/src/everbot/core/agent/provider/__init__.py
@@ -47,8 +47,25 @@ def _telegram_serving_agents(everbot_cfg: dict) -> set:
     return agents
 
 
+def _agent_runtime(agent_name: str, everbot_cfg: dict | None = None) -> str:
+    """everbot.agents.<name>.runtime, default milkie."""
+    cfg = everbot_cfg if everbot_cfg is not None else _load_everbot_cfg()
+    agent_cfg = ((cfg.get("agents") or {}).get(agent_name) or {})
+    runtime = agent_cfg.get("runtime") or "milkie"
+    return str(runtime)
+
+
+def agent_uses_grok_cli(agent_name: str | None, everbot_cfg: dict | None = None) -> bool:
+    """True when this agent is configured to host-spawn grok CLI."""
+    if not agent_name:
+        return False
+    return _agent_runtime(agent_name, everbot_cfg) == "grok-cli"
+
+
 def _make_provider(name: str = "milkie") -> "AgentProvider":
-    # dolphin 已移除;milkie 是唯一 provider。per-agent base_url 由 spawn 的 sidecar 提供。
+    if name == "grok-cli":
+        from .grok_cli.provider import GrokCliProvider
+        return GrokCliProvider()
     from .milkie.provider import MilkieProvider
     return MilkieProvider()
 
@@ -56,14 +73,15 @@ def _make_provider(name: str = "milkie") -> "AgentProvider":
 def get_provider_for_agent(agent_name: str) -> "AgentProvider":
     """Per-agent provider 路由。
 
-    #38 起 dolphin 已移除,milkie 是唯一 runtime;所有 agent → 单例 MilkieProvider
-    (其内部 per-agent sidecar 池按 agent 名 spawn/复用)。保留显式 ``provider`` 配置读取
-    仅为前向兼容,值不影响结果。
+    ``everbot.agents.<name>.runtime: grok-cli`` → 宿主 spawn grok CLI;
+    其余（缺省）→ 单例 MilkieProvider（内部 per-agent sidecar 池）。
     """
-    cached = _provider_by_name.get("milkie")
+    runtime = _agent_runtime(agent_name)
+    key = "grok-cli" if runtime == "grok-cli" else "milkie"
+    cached = _provider_by_name.get(key)
     if cached is None:
-        cached = _make_provider()
-        _provider_by_name["milkie"] = cached
+        cached = _make_provider(key)
+        _provider_by_name[key] = cached
     return cached
 
 
@@ -82,15 +100,30 @@ def oneshot_llm_provider() -> "AgentProvider":
     return cached
 
 
-def provider_for(agent) -> "AgentProvider":
-    """Return the provider that owns this agent OBJECT。
+def uses_dolphin_executor(agent) -> bool:
+    """True only for legacy in-process dolphin agents that expose ``.executor``.
 
-    #38 起只有 milkie:所有 agent(``MilkieAgentHandle``)→ 单例 MilkieProvider。
+    Grok-cli / milkie handles have no executor; callers must skip
+    ``agent.executor.context`` even if provider routing is wrong.
     """
-    cached = _provider_by_name.get("milkie")
+    return getattr(agent, "executor", None) is not None
+
+
+def provider_for(agent) -> "AgentProvider":
+    """Return the provider that owns this agent OBJECT."""
+    from .grok_cli.provider import GrokCliAgentHandle
+
+    name = getattr(agent, "name", "") or ""
+    is_grok = (
+        isinstance(agent, GrokCliAgentHandle)
+        or getattr(agent, "runtime", None) == "grok-cli"
+        or (bool(name) and _agent_runtime(name) == "grok-cli")
+    )
+    key = "grok-cli" if is_grok else "milkie"
+    cached = _provider_by_name.get(key)
     if cached is None:
-        cached = _make_provider()
-        _provider_by_name["milkie"] = cached
+        cached = _make_provider(key)
+        _provider_by_name[key] = cached
     return cached
 
 
@@ -126,8 +159,10 @@ __all__ = [
     "AgentProvider",
     "get_provider",
     "get_provider_for_agent",
+    "agent_uses_grok_cli",
     "oneshot_llm_provider",
     "provider_for",
+    "uses_dolphin_executor",
     "shutdown_all_providers",
     "reset_provider",
 ]

--- a/src/everbot/core/agent/provider/grok_cli/__init__.py
+++ b/src/everbot/core/agent/provider/grok_cli/__init__.py
@@ -1,0 +1,5 @@
+"""Host-spawned grok CLI agent runtime (kairo-style; not an HTTP model)."""
+
+from .provider import GrokCliProvider
+
+__all__ = ["GrokCliProvider"]

--- a/src/everbot/core/agent/provider/grok_cli/invoke.py
+++ b/src/everbot/core/agent/provider/grok_cli/invoke.py
@@ -1,0 +1,166 @@
+"""Spawn grok CLI headless and map JSON stdout onto _progress items.
+
+I/O (subprocess) is isolated behind an injectable ``runner`` so unit tests
+never call the real binary. Mapping (JSON ``text`` → llm _progress) is
+pure and separately asserted.
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+GROK_BIN = "grok"
+PROMPT_REL = Path("tmp") / "grok-cli" / "_prompt.md"
+STDOUT_REL = Path("tmp") / "grok-cli" / "_grok_stdout.json"
+DEFAULT_TIMEOUT_S = 600.0
+
+Runner = Callable[..., None]
+
+
+def resolve_grok_executable(cmd: str = GROK_BIN) -> str:
+    """Resolve grok on PATH or ``~/.local/bin/grok``."""
+    if Path(cmd).is_file():
+        return cmd
+    found = shutil.which(cmd)
+    if found:
+        return found
+    fallback = Path.home() / ".local" / "bin" / cmd
+    if fallback.is_file():
+        return str(fallback)
+    return cmd
+
+
+def grok_cli_available() -> bool:
+    """True when ``grok --version`` exits 0 (kairo ``_cli_available``)."""
+    exe = resolve_grok_executable()
+    try:
+        r = subprocess.run(
+            [exe, "--version"], capture_output=True, timeout=10, check=False
+        )
+        return r.returncode == 0
+    except Exception:
+        return False
+
+
+def grok_json_to_progress(data: dict[str, Any]) -> list[dict[str, Any]]:
+    """JSON stdout → dolphin-style llm _progress items.
+
+    Success field is ``text`` (kairo #61). Error envelope is
+    ``{"type":"error","message":...}`` and is raised before mapping.
+    """
+    if data.get("type") == "error":
+        raise RuntimeError(f"grok 报错:{data.get('message')!r}")
+    text = data.get("text")
+    if not isinstance(text, str) or not text.strip():
+        raise RuntimeError("grok stdout 缺 text 字段")
+    return [{"stage": "llm", "delta": text, "answer": "", "id": "llm"}]
+
+
+def grok_oneshot_text(
+    prompt: str,
+    *,
+    cwd: Path,
+    model: str = "",
+    runner: Optional[Runner] = None,
+) -> str:
+    """Headless grok CLI → assistant text (oneshot / skill complete)."""
+    data = invoke_grok(prompt, cwd=cwd, model=model, runner=runner)
+    items = grok_json_to_progress(data)
+    if not items:
+        return ""
+    return (items[0].get("answer") or items[0].get("delta") or "").strip()
+
+
+def _child_env(base: Optional[dict[str, str]] = None) -> dict[str, str]:
+    env = dict(base if base is not None else os.environ)
+    env.pop("XAI_API_KEY", None)
+    return env
+
+
+def default_grok_runner(
+    cmd: str,
+    args: list[str],
+    *,
+    cwd: Path,
+    env: dict[str, str],
+    stdout_file: Path,
+    timeout: Optional[float] = None,
+) -> None:
+    """Run grok; stdout goes to ``stdout_file``. Resolves ``grok`` on PATH."""
+    exe = resolve_grok_executable(cmd)
+    stdout_file.parent.mkdir(parents=True, exist_ok=True)
+    with open(stdout_file, "w", encoding="utf-8") as out:
+        proc = subprocess.Popen(
+            [exe, *args],
+            cwd=str(cwd),
+            env=env,
+            stdout=out,
+            stderr=subprocess.PIPE,
+            text=True,
+            start_new_session=True,
+        )
+        try:
+            _, err = proc.communicate(timeout=timeout or DEFAULT_TIMEOUT_S)
+        except subprocess.TimeoutExpired:
+            try:
+                os.killpg(os.getpgid(proc.pid), 15)
+            except (ProcessLookupError, OSError):
+                proc.kill()
+            proc.wait(timeout=5)
+            raise RuntimeError(f"grok CLI timeout after {timeout or DEFAULT_TIMEOUT_S}s") from None
+    if proc.returncode not in (0, None):
+        msg = (err or "").strip()[:500] or f"exit {proc.returncode}"
+        # JSON error envelope may still be in stdout_file; caller parses it.
+        if not stdout_file.exists() or not stdout_file.read_text(encoding="utf-8").strip():
+            raise RuntimeError(f"grok exited {proc.returncode}: {msg}")
+
+
+def invoke_grok(
+    prompt: str,
+    *,
+    cwd: Path,
+    model: str = "",
+    runner: Optional[Runner] = None,
+    timeout: Optional[float] = None,
+    environ: Optional[dict[str, str]] = None,
+) -> dict[str, Any]:
+    """Write prompt file, spawn grok headless, return parsed JSON object."""
+    work = Path(cwd)
+    prompt_path = work / PROMPT_REL
+    stdout_path = work / STDOUT_REL
+    prompt_path.parent.mkdir(parents=True, exist_ok=True)
+    prompt_path.write_text(prompt, encoding="utf-8")
+    args = [
+        "--prompt-file",
+        str(PROMPT_REL),
+        "--output-format",
+        "json",
+        "--always-approve",
+        "--no-plan",
+    ]
+    if model.strip().startswith("grok-"):
+        args += ["-m", model.strip()]
+    (runner or default_grok_runner)(
+        GROK_BIN,
+        args,
+        cwd=work,
+        env=_child_env(environ),
+        stdout_file=stdout_path,
+        timeout=timeout,
+    )
+    if not stdout_path.exists():
+        raise RuntimeError(f"grok 无 stdout 输出:{stdout_path}")
+    raw = stdout_path.read_text(encoding="utf-8").strip()
+    if not raw:
+        raise RuntimeError(f"grok stdout 为空:{stdout_path}")
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"grok stdout 非 JSON:{raw[:300]!r}") from exc
+    if not isinstance(data, dict):
+        raise RuntimeError(f"grok stdout 非 object:{type(data).__name__}")
+    return data

--- a/src/everbot/core/agent/provider/grok_cli/provider.py
+++ b/src/everbot/core/agent/provider/grok_cli/provider.py
@@ -1,0 +1,242 @@
+"""GrokCliProvider — host-spawned grok CLI behind AgentProvider.run_turn."""
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, AsyncIterator, Optional
+
+from ..base import SkillObservationBatch
+from .....infra.dolphin_compat import KEY_HISTORY
+from .invoke import DEFAULT_TIMEOUT_S, grok_json_to_progress, invoke_grok
+
+_HISTORY_MAX_MESSAGES = 16
+_HISTORY_MAX_CHARS = 800
+
+
+def _format_history(messages: list) -> str:
+    """Render recent chat turns for the grok prompt (bounded)."""
+    if not messages:
+        return ""
+    recent = messages[-_HISTORY_MAX_MESSAGES:]
+    lines = ["# Conversation so far"]
+    for msg in recent:
+        if not isinstance(msg, dict):
+            continue
+        role = str(msg.get("role") or "user")
+        content = msg.get("content") or ""
+        if not isinstance(content, str):
+            content = str(content)
+        content = content.strip()
+        if not content:
+            continue
+        if len(content) > _HISTORY_MAX_CHARS:
+            content = content[:_HISTORY_MAX_CHARS] + "…"
+        lines.append(f"{role}: {content}")
+    if len(lines) == 1:
+        return ""
+    return "\n".join(lines)
+
+logger = logging.getLogger(__name__)
+
+REFLECTOR_AGENT = "_reflector"
+
+
+@dataclass
+class GrokCliAgentHandle:
+    """In-process handle: grok CLI has no milkie sidecar / contextId."""
+
+    name: str
+    workspace: Path
+    runtime: str = "grok-cli"
+    persona: str = ""
+    model: str = ""
+    variables: dict[str, Any] = field(default_factory=dict)
+    session_id: str = ""
+
+
+class GrokCliProvider:
+    """Drive one turn via ``grok --prompt-file`` and yield llm ``_progress``."""
+
+    def __init__(self, *, runner=None, model: str = "") -> None:
+        self._runner = runner
+        self._model = model
+
+    async def create_agent(
+        self,
+        agent_name: str,
+        workspace_path: Path,
+        model_name: Optional[str] = None,
+        extra_variables: Optional[dict] = None,
+        tools_override: Optional[list[str]] = None,
+    ) -> GrokCliAgentHandle:
+        workspace = Path(workspace_path)
+        persona = self._persona_for(agent_name, workspace)
+        model = model_name or self._model or self._resolve_model(agent_name)
+        handle = GrokCliAgentHandle(
+            name=agent_name,
+            workspace=workspace,
+            persona=persona,
+            model=model,
+            variables=dict(extra_variables or {}),
+        )
+        return handle
+
+    @staticmethod
+    def _persona_for(agent_name: str, workspace: Path) -> str:
+        if agent_name == REFLECTOR_AGENT:
+            from ....runtime.inspector import _REFLECT_SYSTEM_PROMPT
+
+            return _REFLECT_SYSTEM_PROMPT
+        from .....infra.workspace import WorkspaceLoader
+
+        if not workspace.exists():
+            raise FileNotFoundError(
+                f"agent workspace not found for '{agent_name}': {workspace}"
+            )
+        return WorkspaceLoader(workspace).build_system_prompt()
+
+    @staticmethod
+    def _resolve_model(agent_name: str) -> str:
+        try:
+            from ...agent_config import resolve_agent_model
+
+            return resolve_agent_model(agent_name) or ""
+        except Exception:
+            return ""
+
+    def is_paused(self, agent: Any) -> bool:
+        return False
+
+    def is_error(self, agent: Any) -> bool:
+        return False
+
+    def capture_trace(self, agent: Any) -> Optional[Any]:
+        return None
+
+    def is_user_interrupt_paused(self, agent: Any) -> bool:
+        return False
+
+    async def call_llm(
+        self,
+        context: Any,
+        prompt: str,
+        temperature: float = 0.3,
+        fast: bool = False,
+        raise_on_error: bool = True,
+    ) -> str:
+        cwd = Path(getattr(context, "workspace", None) or ".")
+        model = getattr(context, "model", None) or self._model
+        try:
+            data = await asyncio.to_thread(
+                invoke_grok,
+                prompt,
+                cwd=cwd,
+                model=model,
+                runner=self._runner,
+            )
+            items = grok_json_to_progress(data)
+            return (items[0].get("answer") or items[0].get("delta") or "") if items else ""
+        except Exception as exc:
+            if raise_on_error:
+                raise
+            return f"grok-cli call_llm error: {exc}"
+
+    async def run_turn(
+        self,
+        agent: Any,
+        message: Any,
+        *,
+        system_prompt: str = "",
+        is_first_turn: bool = False,
+        stream_mode: str = "delta",
+    ) -> AsyncIterator[dict]:
+        handle: GrokCliAgentHandle = agent
+        text = message if isinstance(message, str) else str(message)
+        history_block = _format_history(self._history(handle))
+        parts = [p for p in (handle.persona, system_prompt, history_block, text) if p]
+        prompt = "\n\n---\n\n".join(parts)
+        cwd = handle.workspace if handle.workspace.exists() else Path(".")
+        data = await asyncio.to_thread(
+            invoke_grok,
+            prompt,
+            cwd=cwd,
+            model=handle.model or self._model,
+            runner=self._runner,
+            timeout=DEFAULT_TIMEOUT_S,
+        )
+        reply = ""
+        for item in grok_json_to_progress(data):
+            reply = item.get("delta") or item.get("answer") or reply
+            yield {"_progress": [item]}
+        self._append_turn(handle, text, reply)
+
+    @staticmethod
+    def _history(handle: GrokCliAgentHandle) -> list:
+        raw = handle.variables.get("history_messages") or handle.variables.get(KEY_HISTORY) or []
+        return list(raw) if isinstance(raw, list) else []
+
+    @staticmethod
+    def _append_turn(handle: GrokCliAgentHandle, user_text: str, assistant_text: str) -> None:
+        hist = GrokCliProvider._history(handle)
+        hist.append({"role": "user", "content": user_text})
+        if assistant_text:
+            hist.append({"role": "assistant", "content": assistant_text})
+        handle.variables["history_messages"] = hist
+        handle.variables[KEY_HISTORY] = hist
+
+    def set_variable(self, agent: Any, key: str, value: Any) -> None:
+        agent.variables[key] = value
+
+    def get_variable(self, agent: Any, key: str) -> Any:
+        return agent.variables.get(key)
+
+    def init_trajectory(self, agent: Any, path: str, overwrite: bool = False) -> None:
+        return None
+
+    def get_skill_observations(self, agent: Any) -> SkillObservationBatch:
+        return SkillObservationBatch(skill_names=(), complete=True, reason="")
+
+    def set_session_id(self, agent: Any, session_id: str) -> None:
+        if session_id:
+            agent.session_id = session_id
+
+    def finalize_trajectory_on_error(self, agent: Any) -> None:
+        return None
+
+    def has_skill(self, agent: Any, name: str) -> bool:
+        return False
+
+    def register_skillkit(self, agent: Any, skillkit: Any) -> None:
+        name = getattr(skillkit, "getName", lambda: type(skillkit).__name__)()
+        logger.debug("GrokCliProvider.register_skillkit no-op for '%s'", name)
+
+    def export_session(self, agent: Any) -> dict:
+        history = self._history(agent)
+        return {"history_messages": history, "variables": dict(agent.variables)}
+
+    def import_session(self, agent: Any, portable_state: dict) -> None:
+        if not isinstance(portable_state, dict):
+            raise TypeError("portable_state must be a dict")
+        history = portable_state.get("history_messages")
+        if isinstance(history, list):
+            agent.variables["history_messages"] = history
+            agent.variables[KEY_HISTORY] = history
+        variables = portable_state.get("variables")
+        if isinstance(variables, dict):
+            agent.variables.update(variables)
+
+    def needs_history_restore(self) -> bool:
+        # Same as milkie: no dolphin executor. Persona is baked at create_agent;
+        # restore_to_agent must not touch agent.executor (heartbeat/chat crash).
+        return False
+
+    async def interrupt(self, agent: Any) -> None:
+        return None
+
+    async def resume(self, agent: Any, message: str) -> None:
+        return None
+
+    async def shutdown_sidecars(self) -> None:
+        return None

--- a/src/everbot/core/agent/provider/oneshot_llm.py
+++ b/src/everbot/core/agent/provider/oneshot_llm.py
@@ -10,7 +10,9 @@
 """
 from __future__ import annotations
 
+import asyncio
 import logging
+from pathlib import Path
 from typing import Any
 
 import httpx
@@ -44,6 +46,26 @@ class OneshotLLMProvider:
     ) -> str:
         # Per-call agent intent wins over constructor default (#193 P0d).
         effective_agent = agent_name if agent_name is not None else self._agent_name
+        from . import agent_uses_grok_cli
+        from ..agent_config import resolve_agent_model
+
+        if agent_uses_grok_cli(effective_agent):
+            from .grok_cli.invoke import grok_oneshot_text
+
+            model = resolve_agent_model(effective_agent) if effective_agent else ""
+            cwd = Path.home() / ".alfred" / "agents" / (effective_agent or "demo_agent")
+            if not cwd.exists():
+                cwd = Path.home() / ".alfred"
+            try:
+                return await asyncio.to_thread(
+                    grok_oneshot_text, prompt, cwd=cwd, model=model
+                )
+            except Exception as exc:
+                msg = f"oneshot LLM grok-cli 失败: {exc}"
+                if raise_on_error:
+                    raise RuntimeError(msg) from exc
+                return msg
+
         try:
             route = resolve_model(
                 agent_name=effective_agent,

--- a/src/everbot/core/channel/core_service.py
+++ b/src/everbot/core/channel/core_service.py
@@ -909,9 +909,12 @@ class ChannelCoreService:
         the missing variable and rebuilds fresh instructions from the workspace
         files on disk (AGENTS.md, HEARTBEAT.md, MEMORY.md, etc.).
         """
-        if not provider_for(agent).needs_history_restore():
-            # milkie: workspace_instructions 已 bake 进 agent.md;serve 自持久化,无 in-process
-            # context 可回灌 → reload-if-missing 是 dolphin-only 概念,直接返回。
+        from ..agent.provider import uses_dolphin_executor
+
+        if (not provider_for(agent).needs_history_restore()) or (
+            not uses_dolphin_executor(agent)
+        ):
+            # milkie/grok-cli: workspace_instructions 已 bake 进 persona;无 .executor。
             return
         ctx = agent.executor.context
         get_var = getattr(ctx, "get_var_value", None)
@@ -947,8 +950,10 @@ class ChannelCoreService:
     def _cache_runtime_workspace_instructions(self, agent: Any, agent_name: str) -> None:
         """Cache workspace instructions from agent context for strategy lookup."""
         self._ensure_runtime_context_strategy()
+        from ..agent.provider import uses_dolphin_executor
+
         provider = provider_for(agent)
-        if provider.needs_history_restore():
+        if provider.needs_history_restore() and uses_dolphin_executor(agent):
             # dolphin: 进程内 context,行为保持不变
             context = agent.executor.context
             get_var = getattr(context, "get_var_value", None)

--- a/src/everbot/core/runtime/cron.py
+++ b/src/everbot/core/runtime/cron.py
@@ -275,8 +275,15 @@ class CronExecutor:
     def _resolve_skill_model(self) -> str:
         """Resolve the model for skill LLM calls via #155 single entry.
 
+        grok-cli agents must not fall through to models.yaml ``fast`` (volcengine).
         ``tier=fast``: models.yaml fast (scoring), then agent, then system default.
         """
+        from ..agent.provider import agent_uses_grok_cli
+        from ..agent.agent_config import resolve_agent_model
+
+        if agent_uses_grok_cli(self.agent_name):
+            return resolve_agent_model(self.agent_name) or "grok-4.6"
+
         from ..agent.provider.model_config import resolve_logical_model_name
 
         try:
@@ -286,8 +293,6 @@ class CronExecutor:
             )
             return name
         except Exception:
-            from ..agent.agent_config import resolve_agent_model
-
             return resolve_agent_model(self.agent_name)
 
     # ── Scheduler-facing task listing ─────────────────────────
@@ -930,11 +935,11 @@ class CronExecutor:
     @staticmethod
     def _build_job_system_prompt(agent: Any, task: Task) -> str:
         """Build isolated job system prompt from base workspace + task description."""
-        from ..agent.provider import provider_for
+        from ..agent.provider import provider_for, uses_dolphin_executor
 
         provider = provider_for(agent)
         base = ""
-        if provider.needs_history_restore():
+        if provider.needs_history_restore() and uses_dolphin_executor(agent):
             # dolphin: 进程内 context,行为保持不变(优先属性,回退 get_variable)
             context = agent.executor.context
             if hasattr(context, "workspace_instructions"):
@@ -942,7 +947,7 @@ class CronExecutor:
             elif hasattr(context, "get_variable"):
                 base = str(context.get_variable("workspace_instructions") or "")
         else:
-            # milkie: 无 .executor;workspace_instructions 走 serve /context/get(可能为 None)
+            # milkie/grok-cli: 无 .executor
             base = str(provider.get_variable(agent, "workspace_instructions") or "")
         task_description = str(task.description or "").strip()
         if not task_description:

--- a/src/everbot/core/runtime/heartbeat.py
+++ b/src/everbot/core/runtime/heartbeat.py
@@ -1090,6 +1090,14 @@ If not, reply with `HEARTBEAT_OK`.
             return False
         self._last_probe_at = now
         try:
+            from ..agent.provider import _agent_runtime
+
+            if _agent_runtime(self.agent_name) == "grok-cli":
+                from ..agent.provider.grok_cli.invoke import grok_cli_available
+
+                if grok_cli_available():
+                    return True
+                raise RuntimeError("grok CLI not found")
             client = self._create_skill_llm_client()
             await asyncio.wait_for(
                 client.complete("ping", max_tokens=1),
@@ -1526,15 +1534,15 @@ If not, reply with `HEARTBEAT_OK`.
     async def _run_heartbeat_turn(self, agent: Any, message: str) -> str:
         """Run heartbeat turn via TurnExecutor and runtime context strategies."""
         try:
-            from ..agent.provider import provider_for
+            from ..agent.provider import provider_for, uses_dolphin_executor
 
             provider = provider_for(agent)
-            if provider.needs_history_restore():
+            if provider.needs_history_restore() and uses_dolphin_executor(agent):
                 # dolphin: 进程内 context,行为保持不变
                 ctx = agent.executor.context
                 self._runtime_workspace_instructions = self._get_workspace_instructions(ctx)
             else:
-                # milkie: 无 .executor;workspace_instructions 走 serve(可能为 None)
+                # milkie/grok-cli: 无 .executor
                 value = provider.get_variable(agent, "workspace_instructions")
                 self._runtime_workspace_instructions = value if isinstance(value, str) else ""
 
@@ -1806,25 +1814,47 @@ class _SkillLLMClient:
             messages.append({"role": "system", "content": system})
         messages.append({"role": "user", "content": prompt})
 
-        model = model_override or self._model
-        if not model:
-            import os
+        import os
 
+        model = model_override or self._model
+        agent_name = (
+            os.environ.get("EVERBOT_AGENT")
+            or os.environ.get("ALFRED_AGENT")
+            or None
+        )
+        from ..agent.provider import agent_uses_grok_cli
+
+        if agent_uses_grok_cli(agent_name) or str(model).startswith("grok"):
+            if not str(model).startswith("grok"):
+                from ..agent.agent_config import resolve_agent_model
+
+                model = resolve_agent_model(agent_name) if agent_name else "grok-4.6"
+            # Fall through to grok CLI branch below (do not resolve yaml fast→volcengine).
+        elif not model:
             # Explicit ops override still wins; otherwise #155 resolve fast tier
             # (no hard-coded deepseek-chat — that key is often expired).
             model = (os.environ.get("ALFRED_SKILL_MODEL") or "").strip()
             if not model:
                 from ..agent.provider.model_config import resolve_logical_model_name
 
-                agent_name = (
-                    os.environ.get("EVERBOT_AGENT")
-                    or os.environ.get("ALFRED_AGENT")
-                    or None
-                )
                 model, _source = resolve_logical_model_name(
                     agent_name=agent_name,
                     tier="fast",
                 )
+
+        if agent_uses_grok_cli(agent_name) or str(model).startswith("grok"):
+            from pathlib import Path
+
+            from ..agent.provider.grok_cli.invoke import grok_oneshot_text
+
+            agent = agent_name or "demo_agent"
+            cwd = Path.home() / ".alfred" / "agents" / agent
+            if not cwd.exists():
+                cwd = Path.home() / ".alfred"
+            prompt_full = f"{system}\n\n{prompt}" if system else prompt
+            return await asyncio.to_thread(
+                grok_oneshot_text, prompt_full, cwd=cwd, model=str(model)
+            )
 
         # Resolve endpoint/credentials from config/models.yaml
         route = _resolve_skill_model_route(model)

--- a/src/everbot/core/session/persistence.py
+++ b/src/everbot/core/session/persistence.py
@@ -625,11 +625,37 @@ class SessionPersistence:
         but is no longer used.  Heartbeat results are now delivered exclusively
         via mailbox deposit and consumed as user-message prefix on the next turn.
         """
-        from ..agent.provider import provider_for  # local: avoid import cycle
-        if not provider_for(agent).needs_history_restore():
-            # milkie 等自持久化 provider:serve 用 sqlite/jsonl 跨重启从 checkpoint
-            # 恢复(milkie#130),无需 alfred 把存档历史灌回进程内 agent。
-            logger.debug("provider 自持久化会话,跳过 restore history 灌回")
+        from ..agent.provider import provider_for, uses_dolphin_executor  # local: avoid import cycle
+        from ...infra.dolphin_compat import KEY_HISTORY
+
+        provider = provider_for(agent)
+        if getattr(agent, "runtime", None) == "grok-cli":
+            history = self._filter_empty_assistant_messages(
+                session_data.history_messages or []
+            )
+            history = prepare_for_restore(history)
+            history = self._heal_orphan_tool_messages(history)
+            restore_variables = {
+                k: v for k, v in (session_data.variables or {}).items()
+                if k not in {"workspace_instructions", "_history", "model_name", "intervention_explore_block_vars"}
+                and v is not None
+            }
+            provider.import_session(
+                agent,
+                {"history_messages": history, "variables": restore_variables},
+            )
+            provider.set_variable(agent, KEY_HISTORY, history)
+            logger.debug(
+                "grok-cli session restore: %s history=%s",
+                session_data.session_id,
+                len(history),
+            )
+            return
+        if (not provider.needs_history_restore()) or (
+            not uses_dolphin_executor(agent)
+        ):
+            # milkie: no dolphin executor; skip in-process history灌回.
+            logger.debug("provider 自持久化会话或无 dolphin executor,跳过 restore history 灌回")
             return
         try:
             # 0a. Strip bare empty assistant messages (content="" with no tool_calls).

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -5,7 +5,8 @@
 - 提供 `_DelegatingTestProvider`:镜像「旧 DolphinProvider 委托给 agent 自身方法」的行为,
   供大量用脚本化/fake agent(暴露 continue_chat/arun/executor.context/snapshot 等)测试
   编排器、会话、上下文逻辑的单测复用。autouse fixture 把 `provider_for` 按 agent 类型分派:
-  非 MilkieAgentHandle(脚本 fake agent)→ 委托 fake;MilkieAgentHandle → 真 MilkieProvider。
+  非 MilkieAgentHandle/GrokCliAgentHandle(脚本 fake agent)→ 委托 fake;
+  真 handle → 真 MilkieProvider / GrokCliProvider。
   消费模块都是函数内 `from ..agent.provider import provider_for`(调用时实时取),故 patch
   一处包级 `provider_for` 即影响全部消费者。
 """
@@ -119,15 +120,16 @@ class _DelegatingTestProvider:
 
 @pytest.fixture(autouse=True)
 def _delegate_fake_agents_to_test_provider(monkeypatch):
-    """`provider_for` 按 agent 类型分派:脚本 fake agent → 委托 fake;真 handle → 真 milkie。"""
+    """`provider_for` 按 agent 类型分派:脚本 fake agent → 委托 fake;真 handle → 真 provider。"""
     import src.everbot.core.agent.provider as prov
+    from src.everbot.core.agent.provider.grok_cli.provider import GrokCliAgentHandle
     from src.everbot.core.agent.provider.milkie.provider import MilkieAgentHandle
 
     real_provider_for = prov.provider_for
     fake = _DelegatingTestProvider()
 
     def _smart(agent):
-        if isinstance(agent, MilkieAgentHandle):
+        if isinstance(agent, (MilkieAgentHandle, GrokCliAgentHandle)):
             return real_provider_for(agent)
         return fake
 

--- a/tests/unit/test_agent_model_state.py
+++ b/tests/unit/test_agent_model_state.py
@@ -66,6 +66,21 @@ def test_collect_states_not_stale_when_match(tmp_path):
     assert states[0]["stale"] is False
 
 
+def test_collect_states_grok_cli_runtime_not_glm(tmp_path):
+    milkie_root = tmp_path / "milkie"
+    milkie_root.mkdir()
+    states = collect_agent_model_states(
+        ["demo_agent"],
+        milkie_root=milkie_root,
+        configured_resolver=lambda a: "glm-5.2",
+        runtime_resolver=lambda a: "grok-cli",
+    )
+    s = states[0]
+    assert s["effective"] == "grok-cli"
+    assert s["configured"] == "grok-cli"
+    assert s["stale"] is False
+
+
 def test_collect_states_no_sidecar_when_agent_md_absent(tmp_path):
     milkie_root = tmp_path / "milkie"
     milkie_root.mkdir()

--- a/tests/unit/test_grok_cli_provider.py
+++ b/tests/unit/test_grok_cli_provider.py
@@ -1,0 +1,281 @@
+"""Host-spawned grok CLI provider: argv, env scrub, JSON text → _progress."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from src.everbot.core.agent.provider import get_provider_for_agent, provider_for, reset_provider
+from src.everbot.core.agent.provider.grok_cli.invoke import (
+    grok_json_to_progress,
+    invoke_grok,
+)
+from src.everbot.core.agent.provider.grok_cli.provider import GrokCliProvider
+
+
+def _fake_runner_factory(recorded: dict, payload: dict | None = None):
+    body = json.dumps(payload if payload is not None else {"text": "pong"})
+
+    def fake_runner(cmd, args, *, cwd, env, stdout_file, timeout=None):
+        recorded["cmd"] = cmd
+        recorded["args"] = list(args)
+        recorded["cwd"] = str(cwd)
+        recorded["env"] = dict(env)
+        recorded["stdout_file"] = str(stdout_file)
+        recorded["timeout"] = timeout
+        Path(stdout_file).write_text(body, encoding="utf-8")
+
+    return fake_runner
+
+
+def test_invoke_grok_headless_argv_and_scrubs_xai_key(tmp_path, monkeypatch):
+    monkeypatch.setenv("XAI_API_KEY", "xai-must-not-leak")
+    recorded: dict = {}
+    data = invoke_grok(
+        "Reply with exactly: pong",
+        cwd=tmp_path,
+        model="grok-4.6",
+        runner=_fake_runner_factory(recorded),
+    )
+    assert recorded["cmd"] == "grok"
+    args = recorded["args"]
+    assert "--output-format" in args
+    assert "json" in args
+    assert "--prompt-file" in args or "-p" in args
+    assert "XAI_API_KEY" not in recorded["env"]
+    assert data.get("text") == "pong"
+    items = grok_json_to_progress(data)
+    assert items
+    assert items[0]["stage"] == "llm"
+    assert "pong" in (items[0].get("delta") or items[0].get("answer") or "")
+
+
+@pytest.mark.asyncio
+async def test_run_turn_maps_json_text_to_progress(tmp_path, monkeypatch):
+    monkeypatch.setenv("XAI_API_KEY", "xai-must-not-leak")
+    recorded: dict = {}
+    provider = GrokCliProvider(runner=_fake_runner_factory(recorded))
+    (tmp_path / "SOUL.md").write_text("You are a test agent.", encoding="utf-8")
+    handle = await provider.create_agent("demo_agent", tmp_path)
+    events = []
+    async for ev in provider.run_turn(handle, "Reply with exactly: pong"):
+        events.append(ev)
+    assert recorded["cmd"] == "grok"
+    assert "--output-format" in recorded["args"]
+    assert "json" in recorded["args"]
+    assert "--prompt-file" in recorded["args"] or "-p" in recorded["args"]
+    assert "XAI_API_KEY" not in recorded["env"]
+    texts = []
+    for ev in events:
+        for item in ev.get("_progress") or []:
+            texts.append(item.get("delta") or "")
+            texts.append(item.get("answer") or "")
+    joined = "".join(texts)
+    assert "pong" in joined
+
+
+def test_grok_cli_skips_dolphin_history_restore():
+    assert GrokCliProvider().needs_history_restore() is False
+
+
+@pytest.mark.asyncio
+async def test_probe_llm_grok_cli_skips_http(monkeypatch, tmp_path):
+    from src.everbot.core.runtime.heartbeat import HeartbeatRunner
+    from types import SimpleNamespace
+    from unittest.mock import AsyncMock
+
+    runner = HeartbeatRunner(
+        agent_name="demo_agent",
+        workspace_path=tmp_path,
+        session_manager=SimpleNamespace(
+            get_primary_session_id=lambda n: f"web_session_{n}",
+            get_heartbeat_session_id=lambda n: f"heartbeat_session_{n}",
+        ),
+        agent_factory=AsyncMock(),
+        interval_minutes=1,
+        active_hours=(0, 24),
+        max_retries=3,
+        on_result=None,
+    )
+    monkeypatch.setattr(
+        "src.everbot.core.agent.provider._agent_runtime",
+        lambda name, everbot_cfg=None: "grok-cli",
+    )
+    monkeypatch.setattr(
+        "src.everbot.core.agent.provider.grok_cli.invoke.grok_cli_available",
+        lambda: True,
+    )
+    called = []
+
+    async def boom(*_a, **_k):
+        called.append(1)
+        raise AssertionError("HTTP complete must not run for grok-cli probe")
+
+    monkeypatch.setattr(
+        "src.everbot.core.runtime.heartbeat._SkillLLMClient.complete",
+        boom,
+    )
+    assert await runner._probe_llm() is True
+    assert called == []
+
+
+@pytest.mark.asyncio
+async def test_provider_for_real_handle_skips_executor_paths(tmp_path):
+    """Shipped restore/cron/heartbeat gates skip agent.executor on a real handle."""
+    reset_provider()
+    (tmp_path / "SOUL.md").write_text("You are a test agent.", encoding="utf-8")
+    created = GrokCliProvider(runner=_fake_runner_factory({}))
+    handle = await created.create_agent("demo_agent", tmp_path)
+
+    routed = provider_for(handle)
+    assert type(routed).__name__ == "GrokCliProvider"
+    assert routed.needs_history_restore() is False
+    assert getattr(handle, "executor", None) is None
+
+    from src.everbot.core.session.persistence import SessionPersistence
+    from src.everbot.core.session.session_data import SessionData
+
+    persistence = SessionPersistence(sessions_dir=str(tmp_path / "sessions"))
+    session = SessionData(
+        session_id="heartbeat_session_demo_agent",
+        agent_name="demo_agent",
+        model_name="grok-4.6",
+        session_type="heartbeat",
+        history_messages=[{"role": "user", "content": "hi"}],
+        variables={},
+        created_at="2026-01-01T00:00:00",
+        updated_at="2026-01-01T00:00:00",
+    )
+    await persistence.restore_to_agent(handle, session)
+    restored = handle.variables.get("history_messages") or []
+    assert restored and restored[0].get("content") == "hi"
+
+    from src.everbot.core.runtime.cron import CronExecutor
+    from src.everbot.core.tasks.task_manager import Task
+
+    prompt = CronExecutor._build_job_system_prompt(
+        handle, Task(id="t1", title="t", description="do the thing")
+    )
+    assert "do the thing" in prompt
+    reset_provider()
+
+
+def test_get_provider_for_agent_routes_grok_cli(monkeypatch):
+    reset_provider()
+    import src.everbot.core.agent.provider as mod
+
+    monkeypatch.setattr(
+        mod,
+        "_load_everbot_cfg",
+        lambda: {
+            "agents": {
+                "demo_agent": {"runtime": "grok-cli"},
+                "coding-master": {"model": "deepseek-chat"},
+            }
+        },
+    )
+    grok = get_provider_for_agent("demo_agent")
+    milkie = get_provider_for_agent("coding-master")
+    assert type(grok).__name__ == "GrokCliProvider"
+    assert type(milkie).__name__ == "MilkieProvider"
+    handle = type("H", (), {"runtime": "grok-cli", "name": "demo_agent"})()
+    assert provider_for(handle) is grok
+    reset_provider()
+
+
+@pytest.mark.asyncio
+async def test_run_turn_includes_prior_history(tmp_path):
+    recorded: dict = {}
+    provider = GrokCliProvider(runner=_fake_runner_factory(recorded))
+    (tmp_path / "SOUL.md").write_text("You are a test agent.", encoding="utf-8")
+    handle = await provider.create_agent("demo_agent", tmp_path)
+    handle.variables["history_messages"] = [
+        {"role": "user", "content": "my name is Ada"},
+        {"role": "assistant", "content": "hi Ada"},
+    ]
+    async for _ in provider.run_turn(handle, "what is my name?"):
+        pass
+    prompt = (tmp_path / "tmp" / "grok-cli" / "_prompt.md").read_text(encoding="utf-8")
+    assert "my name is Ada" in prompt
+    assert "what is my name?" in prompt
+    hist = handle.variables["history_messages"]
+    assert hist[-1]["role"] == "assistant"
+    assert "pong" in (hist[-1].get("content") or "")
+
+
+@pytest.mark.asyncio
+async def test_oneshot_grok_cli_does_not_http(monkeypatch, tmp_path):
+    from src.everbot.core.agent.provider.oneshot_llm import OneshotLLMProvider
+
+    http = []
+
+    def fake_oneshot(prompt, *, cwd, model="", runner=None):
+        return "pong"
+
+    monkeypatch.setattr(
+        "src.everbot.core.agent.provider.agent_uses_grok_cli",
+        lambda name, everbot_cfg=None: name == "demo_agent",
+    )
+    monkeypatch.setattr(
+        "src.everbot.core.agent.agent_config.resolve_agent_model",
+        lambda name: "grok-4.6",
+    )
+    monkeypatch.setattr(
+        "src.everbot.core.agent.provider.grok_cli.invoke.grok_oneshot_text",
+        fake_oneshot,
+    )
+
+    async def boom(*_a, **_k):
+        http.append(1)
+        raise AssertionError("oneshot must not HTTP for grok-cli")
+
+    monkeypatch.setattr("httpx.AsyncClient.post", boom)
+    out = await OneshotLLMProvider().call_llm(None, "ping", agent_name="demo_agent")
+    assert out == "pong"
+    assert http == []
+
+
+@pytest.mark.asyncio
+async def test_skill_complete_grok_cli_skips_volcengine(monkeypatch):
+    from src.everbot.core.runtime.heartbeat import _SkillLLMClient
+
+    monkeypatch.setattr(
+        "src.everbot.core.agent.provider.agent_uses_grok_cli",
+        lambda name, everbot_cfg=None: True,
+    )
+    monkeypatch.setenv("EVERBOT_AGENT", "demo_agent")
+    monkeypatch.setattr(
+        "src.everbot.core.agent.provider.grok_cli.invoke.grok_oneshot_text",
+        lambda prompt, *, cwd, model="", runner=None: "pong",
+    )
+    routed = []
+
+    def boom_route(model):
+        routed.append(model)
+        raise AssertionError("must not resolve volcengine route")
+
+    monkeypatch.setattr(
+        "src.everbot.core.runtime.heartbeat._resolve_skill_model_route",
+        boom_route,
+    )
+    client = _SkillLLMClient(model="doubao-nothink")
+    out = await client.complete("score this")
+    assert out == "pong"
+    assert routed == []
+
+
+def test_cron_skill_model_grok_cli_not_volcengine(monkeypatch):
+    from src.everbot.core.runtime.cron import CronExecutor
+
+    monkeypatch.setattr(
+        "src.everbot.core.agent.provider.agent_uses_grok_cli",
+        lambda name, everbot_cfg=None: name == "demo_agent",
+    )
+    monkeypatch.setattr(
+        "src.everbot.core.agent.agent_config.resolve_agent_model",
+        lambda name: "grok-4.6",
+    )
+    ex = CronExecutor.__new__(CronExecutor)
+    ex.agent_name = "demo_agent"
+    assert ex._resolve_skill_model() == "grok-4.6"


### PR DESCRIPTION
## 摘要

`demo_agent` / `_reflector` 不再打火山引擎 OpenAI 兼容端点。宿主 spawn 本机 `grok` CLI（OAuth，擦除 `XAI_API_KEY`），经既有 `AgentProvider.run_turn` → `_progress` 交付回复。oneshot / skill 打分对 grok-cli agent 同样不走 ark。

Closes #207

## 改动

- 新增 `GrokCliProvider`：`grok --prompt-file --output-format json`
- `everbot.agents.<name>.runtime: grok-cli` 路由；`coding-master` 仍 milkie
- 会话历史灌进 prompt；restart 清残留 daemon；`night_interval: 0` 不再误报

## 验证

- 单测（注入 fake runner）：argv、无 `XAI_API_KEY`、oneshot/skill 不 HTTP、history 进 prompt
- 本机：`./bin/everbot restart` + `status` → `demo_agent: grok-cli / grok-cli`；`run_turn` ping ×2 回复 `pong`；heartbeat `--force` → `HEARTBEAT_OK`

## 非目标

不改 milkie spawn grok；不用 `api.x.ai`；不对等 milkie 流式 / `skill_list`。