### PR TITLE
fix(runtime): isolate concurrent grok cli invocations

### DIFF
--- a/src/everbot/core/agent/provider/grok_cli/invoke.py
+++ b/src/everbot/core/agent/provider/grok_cli/invoke.py
@@ -9,7 +9,10 @@ from __future__ import annotations
 import json
 import os
 import shutil
+import signal
 import subprocess
+import tempfile
+import time
 from pathlib import Path
 from typing import Any, Callable, Optional
 
@@ -81,6 +84,41 @@ def _child_env(base: Optional[dict[str, str]] = None) -> dict[str, str]:
     return env
 
 
+def _has_terminal_json(path: Path) -> bool:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError):
+        return False
+    return isinstance(data, dict) and (
+        isinstance(data.get("text"), str) or data.get("type") == "error"
+    )
+
+
+def _stop_process_group(proc: subprocess.Popen) -> None:
+    try:
+        pgid = os.getpgid(proc.pid)
+    except (ProcessLookupError, OSError):
+        pgid = None
+    try:
+        if pgid is not None:
+            os.killpg(pgid, signal.SIGTERM)
+        else:
+            proc.terminate()
+        proc.wait(timeout=1)
+    except (ProcessLookupError, OSError, subprocess.TimeoutExpired):
+        pass
+    finally:
+        try:
+            if pgid is not None:
+                os.killpg(pgid, signal.SIGKILL)
+            elif proc.poll() is None:
+                proc.kill()
+        except (ProcessLookupError, OSError):
+            pass
+        if proc.poll() is None:
+            proc.wait(timeout=5)
+
+
 def default_grok_runner(
     cmd: str,
     args: list[str],
@@ -90,31 +128,42 @@ def default_grok_runner(
     stdout_file: Path,
     timeout: Optional[float] = None,
 ) -> None:
-    """Run grok; stdout goes to ``stdout_file``. Resolves ``grok`` on PATH."""
+    """Run grok and stop once its terminal JSON is complete."""
     exe = resolve_grok_executable(cmd)
     stdout_file.parent.mkdir(parents=True, exist_ok=True)
-    with open(stdout_file, "w", encoding="utf-8") as out:
+    limit = timeout or DEFAULT_TIMEOUT_S
+    deadline = time.monotonic() + limit
+    terminal = False
+    with (
+        open(stdout_file, "w", encoding="utf-8") as out,
+        tempfile.TemporaryFile(mode="w+", encoding="utf-8") as err_file,
+    ):
         proc = subprocess.Popen(
             [exe, *args],
             cwd=str(cwd),
             env=env,
             stdout=out,
-            stderr=subprocess.PIPE,
+            stderr=err_file,
             text=True,
             start_new_session=True,
         )
         try:
-            _, err = proc.communicate(timeout=timeout or DEFAULT_TIMEOUT_S)
-        except subprocess.TimeoutExpired:
-            try:
-                os.killpg(os.getpgid(proc.pid), 15)
-            except (ProcessLookupError, OSError):
-                proc.kill()
-            proc.wait(timeout=5)
-            raise RuntimeError(f"grok CLI timeout after {timeout or DEFAULT_TIMEOUT_S}s") from None
-    if proc.returncode not in (0, None):
+            while proc.poll() is None:
+                if _has_terminal_json(stdout_file):
+                    terminal = True
+                    _stop_process_group(proc)
+                    break
+                if time.monotonic() >= deadline:
+                    raise RuntimeError(f"grok CLI timeout after {limit}s")
+                time.sleep(0.05)
+        finally:
+            if proc.poll() is None:
+                _stop_process_group(proc)
+        terminal = terminal or _has_terminal_json(stdout_file)
+        err_file.seek(0)
+        err = err_file.read()
+    if proc.returncode not in (0, None) and not terminal:
         msg = (err or "").strip()[:500] or f"exit {proc.returncode}"
-        # JSON error envelope may still be in stdout_file; caller parses it.
         if not stdout_file.exists() or not stdout_file.read_text(encoding="utf-8").strip():
             raise RuntimeError(f"grok exited {proc.returncode}: {msg}")
 
@@ -129,38 +178,41 @@ def invoke_grok(
     environ: Optional[dict[str, str]] = None,
 ) -> dict[str, Any]:
     """Write prompt file, spawn grok headless, return parsed JSON object."""
-    work = Path(cwd)
-    prompt_path = work / PROMPT_REL
-    stdout_path = work / STDOUT_REL
-    prompt_path.parent.mkdir(parents=True, exist_ok=True)
-    prompt_path.write_text(prompt, encoding="utf-8")
-    args = [
-        "--prompt-file",
-        str(PROMPT_REL),
-        "--output-format",
-        "json",
-        "--always-approve",
-        "--no-plan",
-    ]
-    if model.strip().startswith("grok-"):
-        args += ["-m", model.strip()]
-    (runner or default_grok_runner)(
-        GROK_BIN,
-        args,
-        cwd=work,
-        env=_child_env(environ),
-        stdout_file=stdout_path,
-        timeout=timeout,
-    )
-    if not stdout_path.exists():
-        raise RuntimeError(f"grok 无 stdout 输出:{stdout_path}")
-    raw = stdout_path.read_text(encoding="utf-8").strip()
-    if not raw:
-        raise RuntimeError(f"grok stdout 为空:{stdout_path}")
-    try:
-        data = json.loads(raw)
-    except json.JSONDecodeError as exc:
-        raise RuntimeError(f"grok stdout 非 JSON:{raw[:300]!r}") from exc
-    if not isinstance(data, dict):
-        raise RuntimeError(f"grok stdout 非 object:{type(data).__name__}")
-    return data
+    work = Path(cwd).resolve()
+    scratch_root = work / PROMPT_REL.parent
+    scratch_root.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix="run-", dir=scratch_root) as scratch_name:
+        scratch = Path(scratch_name)
+        prompt_path = scratch / PROMPT_REL.name
+        stdout_path = scratch / STDOUT_REL.name
+        prompt_path.write_text(prompt, encoding="utf-8")
+        args = [
+            "--prompt-file",
+            str(prompt_path.relative_to(work)),
+            "--output-format",
+            "json",
+            "--always-approve",
+            "--no-plan",
+        ]
+        if model.strip().startswith("grok-"):
+            args += ["-m", model.strip()]
+        (runner or default_grok_runner)(
+            GROK_BIN,
+            args,
+            cwd=work,
+            env=_child_env(environ),
+            stdout_file=stdout_path,
+            timeout=timeout,
+        )
+        if not stdout_path.exists():
+            raise RuntimeError(f"grok 无 stdout 输出:{stdout_path}")
+        raw = stdout_path.read_text(encoding="utf-8").strip()
+        if not raw:
+            raise RuntimeError(f"grok stdout 为空:{stdout_path}")
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(f"grok stdout 非 JSON:{raw[:300]!r}") from exc
+        if not isinstance(data, dict):
+            raise RuntimeError(f"grok stdout 非 object:{type(data).__name__}")
+        return data

--- a/tests/e2e/test_grok_cli_runtime_e2e.py
+++ b/tests/e2e/test_grok_cli_runtime_e2e.py
@@ -1,0 +1,44 @@
+"""End-to-end process isolation for concurrent grok-cli turns."""
+from __future__ import annotations
+
+import os
+from concurrent.futures import ThreadPoolExecutor
+
+from src.everbot.core.agent.provider.grok_cli.invoke import invoke_grok
+
+
+def test_concurrent_grok_processes_return_own_terminal_output(tmp_path, monkeypatch):
+    fake_grok = tmp_path / "fake-grok"
+    fake_grok.write_text(
+        "#!/usr/bin/env python3\n"
+        "import json, os, pathlib, sys, time\n"
+        "args = sys.argv[1:]\n"
+        "prompt = pathlib.Path(args[args.index('--prompt-file') + 1]).read_text()\n"
+        "pathlib.Path(f'{prompt}.pid').write_text(str(os.getpid()))\n"
+        "print(json.dumps({'text': prompt}), flush=True)\n"
+        "time.sleep(30)\n",
+        encoding="utf-8",
+    )
+    fake_grok.chmod(0o755)
+    monkeypatch.setattr(
+        "src.everbot.core.agent.provider.grok_cli.invoke.resolve_grok_executable",
+        lambda _cmd: str(fake_grok),
+    )
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        futures = [
+            pool.submit(invoke_grok, prompt, cwd=tmp_path, timeout=5)
+            for prompt in ("heartbeat", "hi")
+        ]
+        results = [future.result(timeout=2)["text"] for future in futures]
+
+    assert results == ["heartbeat", "hi"]
+    for prompt in ("heartbeat", "hi"):
+        pid = int((tmp_path / f"{prompt}.pid").read_text())
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            pass
+        else:
+            raise AssertionError(f"grok process {pid} was not cleaned up")
+    assert list((tmp_path / "tmp" / "grok-cli").iterdir()) == []

--- a/tests/unit/test_grok_cli_provider.py
+++ b/tests/unit/test_grok_cli_provider.py
@@ -2,12 +2,18 @@
 from __future__ import annotations
 
 import json
+import os
+import subprocess
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+from threading import Barrier
 
 import pytest
 
 from src.everbot.core.agent.provider import get_provider_for_agent, provider_for, reset_provider
 from src.everbot.core.agent.provider.grok_cli.invoke import (
+    _has_terminal_json,
+    default_grok_runner,
     grok_json_to_progress,
     invoke_grok,
 )
@@ -24,6 +30,8 @@ def _fake_runner_factory(recorded: dict, payload: dict | None = None):
         recorded["env"] = dict(env)
         recorded["stdout_file"] = str(stdout_file)
         recorded["timeout"] = timeout
+        prompt_arg = args[args.index("--prompt-file") + 1]
+        recorded["prompt"] = (Path(cwd) / prompt_arg).read_text(encoding="utf-8")
         Path(stdout_file).write_text(body, encoding="utf-8")
 
     return fake_runner
@@ -73,6 +81,92 @@ async def test_run_turn_maps_json_text_to_progress(tmp_path, monkeypatch):
             texts.append(item.get("answer") or "")
     joined = "".join(texts)
     assert "pong" in joined
+
+
+def test_concurrent_invocations_use_isolated_prompt_and_stdout_files(tmp_path):
+    calls = []
+    ready = Barrier(2)
+
+    def runner(cmd, args, *, cwd, env, stdout_file, timeout=None):
+        prompt_arg = args[args.index("--prompt-file") + 1]
+        calls.append((Path(cwd) / prompt_arg, Path(stdout_file)))
+        ready.wait(timeout=1)
+        prompt = (Path(cwd) / prompt_arg).read_text(encoding="utf-8")
+        Path(stdout_file).write_text(json.dumps({"text": prompt}), encoding="utf-8")
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        futures = [
+            pool.submit(invoke_grok, text, cwd=tmp_path, runner=runner)
+            for text in ("first", "second")
+        ]
+        results = [future.result(timeout=2)["text"] for future in futures]
+
+    assert results == ["first", "second"]
+    assert calls[0][0] != calls[1][0]
+    assert calls[0][1] != calls[1][1]
+
+
+@pytest.mark.parametrize("payload", [{"text": "pong"}, {"type": "error", "message": "upstream"}])
+def test_runner_stops_process_group_after_terminal_json(tmp_path, monkeypatch, payload):
+    script = tmp_path / "fake-grok"
+    pid_file = tmp_path / "pids"
+    script.write_text(
+        "#!/usr/bin/env python3\n"
+        "import json, os, pathlib, subprocess, time\n"
+        "child = subprocess.Popen(['/bin/sh', '-c', \"trap '' TERM; sleep 30\"])\n"
+        f"pathlib.Path({str(pid_file)!r}).write_text(f'{{os.getpid()}} {{child.pid}}')\n"
+        f"print({json.dumps(payload)!r}, flush=True)\n"
+        "time.sleep(30)\n",
+        encoding="utf-8",
+    )
+    script.chmod(0o755)
+    monkeypatch.setattr(
+        "src.everbot.core.agent.provider.grok_cli.invoke.resolve_grok_executable",
+        lambda _cmd: str(script),
+    )
+    stdout_file = tmp_path / "out.json"
+
+    default_grok_runner(
+        "grok", [], cwd=tmp_path, env={}, stdout_file=stdout_file, timeout=5
+    )
+
+    assert json.loads(stdout_file.read_text(encoding="utf-8")) == payload
+    for pid in map(int, pid_file.read_text().split()):
+        state = subprocess.run(
+            ["ps", "-o", "stat=", "-p", str(pid)], capture_output=True, text=True, check=False
+        ).stdout.strip()
+        assert not state or state.startswith("Z")
+
+
+def test_terminal_json_tolerates_partial_utf8(tmp_path):
+    stdout_file = tmp_path / "out.json"
+    stdout_file.write_bytes(b'{"text":"\xe4')
+    assert _has_terminal_json(stdout_file) is False
+    stdout_file.write_text('{"text":"你"}', encoding="utf-8")
+    assert _has_terminal_json(stdout_file) is True
+
+
+def test_runner_timeout_cleans_process(tmp_path, monkeypatch):
+    script = tmp_path / "silent-grok"
+    pid_file = tmp_path / "pid"
+    script.write_text(
+        "#!/bin/sh\n"
+        f"echo $$ > {pid_file}\n"
+        "sleep 30\n",
+        encoding="utf-8",
+    )
+    script.chmod(0o755)
+    monkeypatch.setattr(
+        "src.everbot.core.agent.provider.grok_cli.invoke.resolve_grok_executable",
+        lambda _cmd: str(script),
+    )
+
+    with pytest.raises(RuntimeError, match="timeout"):
+        default_grok_runner(
+            "grok", [], cwd=tmp_path, env={}, stdout_file=tmp_path / "out.json", timeout=0.1
+        )
+    with pytest.raises(ProcessLookupError):
+        os.kill(int(pid_file.read_text()), 0)
 
 
 def test_grok_cli_skips_dolphin_history_restore():
@@ -196,7 +290,7 @@ async def test_run_turn_includes_prior_history(tmp_path):
     ]
     async for _ in provider.run_turn(handle, "what is my name?"):
         pass
-    prompt = (tmp_path / "tmp" / "grok-cli" / "_prompt.md").read_text(encoding="utf-8")
+    prompt = recorded["prompt"]
     assert "my name is Ada" in prompt
     assert "what is my name?" in prompt
     hist = handle.variables["history_messages"]


### PR DESCRIPTION
## Summary

- 为每次 grok-cli 调用创建独立临时目录，消除用户对话与 Heartbeat 的 prompt/stdout 覆盖
- 轮询单 JSON 终态；成功或错误 JSON 完整落盘后立即清理整个进程组并返回
- 补并发、UTF-8 分段写、无输出超时、忽略 SIGTERM 的后代进程及真实 subprocess E2E 回归

## 5 Why / Solution

完整分析见 #209。根因是首版 runtime 假设单调用 happy path：固定文件名 + 只等待进程退出。修复保持既有 grok CLI/JSON 契约，仅隔离每次 I/O 并在既有终态出现时提前收敛。

## Tests

- `python -m pytest -q tests/unit/` → 2140 passed
- `python -m pytest -q tests/unit/test_grok_cli_provider.py tests/e2e/test_grok_cli_runtime_e2e.py` → 16 passed
- `uvx ruff check --select F,E9 ...` → passed
- `python -m compileall ...` → passed
- `git diff --check` → passed

## Review

双 reviewer 检查了并发、终态解析、进程组清理与复杂度。review 提出的部分 UTF-8、SIGTERM 后代泄漏、timeout 覆盖、TemporaryDirectory 与 Barrier 问题均已修正。

Closes #209
