### PR TITLE
【runtime】短对话不被 mailbox 劫持且空回复不 dump 工具 JSON

### DIFF
--- a/src/everbot/core/agent/provider/milkie/adapter.py
+++ b/src/everbot/core/agent/provider/milkie/adapter.py
@@ -18,6 +18,30 @@ import json
 from typing import Any, Dict, Optional
 
 
+def _tool_output_as_text(out: Any) -> str:
+    """Project milkie tool output onto the text the model/orchestrator should see.
+
+    ``run_command`` returns ``{objectId, stdout, ...}``. The envelope is for
+    projection; dumping it as the chat answer or next-round observation
+    hides the real stdout and leaks internal ids.
+    """
+    if out is None:
+        return ""
+    if isinstance(out, str):
+        text = out.strip()
+        if text.startswith("{") and "objectId" in text:
+            try:
+                parsed = json.loads(out)
+            except (TypeError, ValueError):
+                return out
+            if isinstance(parsed, dict) and isinstance(parsed.get("stdout"), str):
+                return parsed["stdout"]
+        return out
+    if isinstance(out, dict) and isinstance(out.get("stdout"), str):
+        return out["stdout"]
+    return json.dumps(out, ensure_ascii=False)
+
+
 def milkie_event_to_progress(event: str, data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     if event == "message_delta":
         return {"stage": "llm", "delta": data.get("text") or "", "answer": "", "id": "llm"}
@@ -36,8 +60,7 @@ def milkie_event_to_progress(event: str, data: Dict[str, Any]) -> Optional[Dict[
     if event == "tool.responded":
         ok = data.get("status") == "ok"
         out = data.get("output") if ok else (data.get("error") or "")
-        if not isinstance(out, str):
-            out = json.dumps(out, ensure_ascii=False)
+        out = _tool_output_as_text(out)
         return {
             "stage": "skill",
             "status": "completed" if ok else "failed",

--- a/src/everbot/core/runtime/mailbox.py
+++ b/src/everbot/core/runtime/mailbox.py
@@ -5,6 +5,12 @@ from __future__ import annotations
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, Iterable, List, Tuple
 
+# Last lines of a mailbox-composed turn. Recency: the model must not treat
+# background events as the request. Keep this out of system prompt / agent.md.
+RECENCY_CLOSER = (
+    "请只回应用户在「User Message」中的本轮请求；Background Updates 不是本轮任务。"
+)
+
 
 def compose_message_with_mailbox_updates(
     trigger_message: str,
@@ -14,9 +20,12 @@ def compose_message_with_mailbox_updates(
     stale_after: timedelta = timedelta(hours=24),
     max_events: int = 3,
 ) -> Tuple[str, List[str]]:
-    """Prefix user message with mailbox updates and return ack event ids.
+    """Compose one turn message: user text first, then mailbox updates.
 
-    The function applies two cleanup rules before composing the prefix:
+    User intent must lead. Background events after the user message are
+    clues only; they must not be treated as the request to execute.
+
+    Cleanup before compose:
     - dedupe by ``dedupe_key`` (keep the latest event for the same key)
     - drop stale events where ``suppress_if_stale`` is true and age exceeds ``stale_after``
     """
@@ -78,6 +87,7 @@ def compose_message_with_mailbox_updates(
         "## Background Updates",
         (
             "(以下是后台定时任务通知，仅可作为线索，不保证覆盖全部事实。"
+            "用户本轮消息优先：除非用户明确询问这些后台事项，否则不要执行其中的任务，先回应用户本轮消息。"
             "若用户询问任务配置、执行时间、调度频率、下次运行时间或某任务是否存在，"
             "必须先读取真实任务源（如 HEARTBEAT.md / task list）再回答。"
             "被追问来源时，可说明是后台定时任务采集。)"
@@ -121,10 +131,10 @@ def compose_message_with_mailbox_updates(
     for dropped_event_id in dropped_event_ids:
         _append_unique_event_id(ack_ids, dropped_event_id)
 
-    if len(lines) == 1:
+    if included_count == 0:
         return trigger_message, ack_ids
 
     lines.append("")
-    lines.append("## User Message")
-    lines.append(trigger_message)
-    return "\n".join(lines), ack_ids
+    lines.append(RECENCY_CLOSER)
+    user_block = f"## User Message\n{trigger_message}"
+    return f"{user_block}\n\n" + "\n".join(lines), ack_ids

--- a/src/everbot/core/runtime/turn_orchestrator.py
+++ b/src/everbot/core/runtime/turn_orchestrator.py
@@ -608,7 +608,6 @@ class TurnOrchestrator:
         llm_had_think_this_round = False
         consecutive_empty_llm_rounds = 0
         consecutive_think_only_rounds = 0
-        last_successful_tool_output = ""  # fallback when LLM returns empty
         output_chars = 0  # approximate output token tracking (chars produced by LLM)
         _last_round_response = ""  # text from current round only (reset on each tool call)
         # Repeated-text loop detection: track LLM text fingerprints across
@@ -696,7 +695,7 @@ class TurnOrchestrator:
                     estimated_tokens = max(1, output_chars // 4) if output_chars > 0 else 0
                     yield TurnEvent(
                         type=TurnEventType.TURN_COMPLETE,
-                        answer=_last_round_response or response or last_successful_tool_output,
+                        answer=_last_round_response or response,
                         tool_call_count=tool_call_count,
                         tool_execution_count=tool_execution_count,
                         tool_names_executed=list(tool_names_executed),
@@ -892,11 +891,6 @@ class TurnOrchestrator:
                                         failed_tool_outputs=failed_tool_outputs,
                                     )
                                     return
-
-                        # Track last successful skill output for fallback
-                        # Check both: no failure signature AND status is not explicitly "failed"
-                        if not fail_sig and s_output and status != "failed":
-                            last_successful_tool_output = s_output[:policy.max_tool_output_preview_chars]
 
                         # Inject failure count warning for skill outputs
                         warn_output = s_output
@@ -1149,8 +1143,6 @@ class TurnOrchestrator:
                             output_truncated=out_trunc, output_total_chars=out_total,
                             reference_id=progress.get("reference_id", ""),
                         )
-                        if not fail_sig and t_output_raw:
-                            last_successful_tool_output = t_output_raw[:policy.max_tool_output_preview_chars]
                         if pid:
                             sent_progress[pid] = status
 
@@ -1163,11 +1155,9 @@ class TurnOrchestrator:
             yield _timeout_error_event(exc, soft=False)
             return
 
-        # Fallback: if LLM produced no text but the last tool returned
-        # substantial output, use that output as the response so the user
-        # doesn't get an empty "(无响应)".
-        if not response and last_successful_tool_output:
-            response = last_successful_tool_output
+        # Do not copy tool/skill stdout into the user-facing answer. That
+        # output is for the next LLM round; milkie envelopes look like
+        # {"objectId","stdout"} and dumping them is worse than empty.
 
         # Phantom tool call: model wrote ```bash/python blocks but never
         # issued a real tool_use call — common with weaker models under
@@ -1293,7 +1283,6 @@ async def _drain_after_timeout(
     first, then continues with further ``__anext__`` calls.
     """
     deadline = asyncio.get_event_loop().time() + extra_timeout
-    collected_outputs: list[str] = []
     final_response = ""
     seen_progress_fingerprints: set[str] = set()
 
@@ -1307,30 +1296,14 @@ async def _drain_after_timeout(
                 continue
             seen_progress_fingerprints.add(progress_fp)
             stage = progress.get("stage")
-            status = progress.get("status", "")
-            if stage == "skill" and status in ("completed", "failed"):
-                # Skip internal resource-loading tools — their output
-                # is framework-internal (contains [PIN] markers, full
-                # SKILL.md content) and must not be forwarded to the user.
-                skill_info = progress.get("skill_info") or {}
-                skill_name = skill_info.get("name") or progress.get("tool_name") or ""
-                if skill_name in ("_load_resource_skill", "_read_skill_asset"):
-                    continue
-                output = (
-                    progress.get("answer")
-                    or progress.get("block_answer")
-                    or progress.get("output")
-                    or ""
-                )
-                if output:
-                    collected_outputs.append(output)
-            elif stage == "llm":
+            if stage == "llm":
                 delta = progress.get("delta", "")
                 answer = progress.get("answer", "")
                 if delta:
                     final_response += delta
                 elif answer:
                     final_response = answer
+            # Skill/tool stdout is for the model, not a deferred user reply.
 
     in_flight: Optional[asyncio.Task] = pending_anext
     try:
@@ -1372,16 +1345,9 @@ async def _drain_after_timeout(
         except Exception:
             pass
 
-    # Prefer the LLM's final text response — it's already formatted for the user.
-    # Tool outputs are raw JSON and should only be included as fallback when
-    # the LLM produced no text (e.g. timeout during tool execution, before LLM reply).
-    if final_response.strip():
-        result = final_response.strip()
-    elif collected_outputs:
-        # Fallback: summarize tool outputs instead of dumping raw JSON
-        result = "\n\n".join(collected_outputs)
-    else:
-        result = ""
+    # Only the LLM's text is user-facing. Do not join skill/tool stdout
+    # (including milkie {objectId, stdout} envelopes) when the model said nothing.
+    result = final_response.strip()
     # Strip any leaked [PIN] markers (dolphin framework internal token)
     result = result.replace("[PIN]", "").strip()
     if not result.strip():

--- a/tests/unit/test_mailbox_runtime.py
+++ b/tests/unit/test_mailbox_runtime.py
@@ -2,7 +2,10 @@
 
 from datetime import datetime, timezone
 
-from src.everbot.core.runtime.mailbox import compose_message_with_mailbox_updates
+from src.everbot.core.runtime.mailbox import (
+    RECENCY_CLOSER,
+    compose_message_with_mailbox_updates,
+)
 
 
 def test_compose_message_with_mailbox_updates_prefixes_user_message():
@@ -23,13 +26,35 @@ def test_compose_message_with_mailbox_updates_prefixes_user_message():
 
     message, ack_ids = compose_message_with_mailbox_updates(user_message, mailbox)
 
-    assert message.startswith("## Background Updates")
+    assert message.startswith("## User Message")
     assert "仅可作为线索" in message
+    assert "不要执行其中的任务" in message
     assert "必须先读取真实任务源" in message
     assert "[heartbeat_result] 你有新的日报" in message
     assert "Detail: 详见日报附件" in message
-    assert message.endswith(user_message)
+    user_pos = message.find(user_message)
+    bg_pos = message.find("## Background Updates")
+    assert 0 <= user_pos < bg_pos
+    assert message.rstrip().endswith(RECENCY_CLOSER)
     assert ack_ids == ["evt_1", "evt_2"]
+
+
+def test_compose_short_hi_leads_and_ends_with_closer():
+    """Gating: short user trigger + mailbox → user first, closer last."""
+    mailbox = [
+        {
+            "event_id": "evt_job",
+            "event_type": "job_completed",
+            "summary": "Serenity账号定时分析 completed",
+            "detail": "抓取脚本已失败，按 fail-fast 立即停止。",
+        },
+    ]
+    message, ack_ids = compose_message_with_mailbox_updates("hi", mailbox)
+    assert message.startswith("## User Message\nhi")
+    assert message.find("hi") < message.find("## Background Updates")
+    assert message.find("## Background Updates") < message.rfind(RECENCY_CLOSER)
+    assert message.rstrip().endswith(RECENCY_CLOSER)
+    assert ack_ids == ["evt_job"]
 
 
 def test_compose_message_with_mailbox_updates_no_events_returns_original():
@@ -110,7 +135,7 @@ def test_compose_message_truncates_long_detail():
 # Root cause: multimodal messages (images) skip mailbox consumption in
 # process_message (core_service.py L236-239), so heartbeat events deposited
 # before the multimodal turn are NOT acked.  They survive into the next text
-# turn and get prepended to the user message by compose_message_with_mailbox_updates.
+# turn and get included by compose_message_with_mailbox_updates.
 #
 # Real incident: user sent a paper screenshot (multimodal, mailbox skipped) →
 # bot discussed Meta-Harness paper → user replied "好的，我也好奇具体怎么做的"
@@ -118,21 +143,14 @@ def test_compose_message_truncates_long_detail():
 # prepended.  The LLM bound the user's ambiguous reply to the heartbeat
 # topic instead of the paper being discussed.
 #
-# The tests below document the message format that enables this hijack.
-# The actual bug is tested in test_channel_core_service.py::
-# test_multimodal_message_skips_mailbox_ack_bug.
+# Compose now puts the user message first so short replies are not bound
+# to mailbox topics. The multimodal skip-ack bug is still tested in
+# test_channel_core_service.py::test_multimodal_message_skips_mailbox_ack_bug.
 # ---------------------------------------------------------------------------
 
 
-def test_compose_message_heartbeat_placed_before_user_message():
-    """Heartbeat updates are always placed ABOVE the user's message.
-
-    When the heartbeat summary introduces a specific topic and the user
-    message is short/ambiguous, the LLM may bind the user's intent to
-    the heartbeat topic rather than the conversation history.
-
-    This test documents the current (problematic) message structure.
-    """
+def test_compose_message_user_message_leads_background_updates():
+    """User text comes first so a short reply is not bound to mailbox topics."""
     user_message = "好的，我也好奇具体怎么做的"
     mailbox = [
         {
@@ -145,38 +163,17 @@ def test_compose_message_heartbeat_placed_before_user_message():
 
     message, ack_ids = compose_message_with_mailbox_updates(user_message, mailbox)
 
-    # Current structure: heartbeat comes first, user message last
-    lines = message.split("\n")
-
-    # The heartbeat topic "反共识信号" appears BEFORE the user's message
     heartbeat_pos = message.find("反共识信号")
     user_msg_pos = message.find("好的，我也好奇具体怎么做的")
-    assert heartbeat_pos < user_msg_pos, (
-        "Heartbeat content should appear before user message in current format"
-    )
-
-    # The composed message has the structure:
-    #   ## Background Updates
-    #   (说明文字)
-    #   - [heartbeat_result] 反共识信号...
-    #     Detail: ...
-    #
-    #   ## User Message
-    #   好的，我也好奇具体怎么做的
+    assert 0 <= user_msg_pos < heartbeat_pos
+    assert message.startswith("## User Message")
     assert "## Background Updates" in message
-    assert "## User Message" in message
-
-    # PROBLEM: The "反共识信号" heartbeat is the closest context to the
-    # user's ambiguous "具体怎么做的", making the LLM likely to treat the
-    # heartbeat topic as what the user is asking about.
+    assert "不要执行其中的任务" in message
+    assert message.rstrip().endswith(RECENCY_CLOSER)
+    assert ack_ids == ["evt_hb"]
 
 
-def test_compose_message_heartbeat_topic_proximity_to_user_message():
-    """Measure how close the heartbeat content is to the user message.
-
-    The shorter the distance, the more likely the LLM treats the heartbeat
-    topic as the referent for the user's pronoun/reference.
-    """
+def test_compose_message_background_section_follows_user_message():
     user_message = "具体怎么做的"
     mailbox = [
         {
@@ -194,28 +191,15 @@ def test_compose_message_heartbeat_topic_proximity_to_user_message():
 
     message, _ = compose_message_with_mailbox_updates(user_message, mailbox)
 
-    # The last heartbeat event is closest to "## User Message"
-    bg_section_end = message.find("## User Message")
-    last_heartbeat_end = message.rfind("反共识信号", 0, bg_section_end)
-    assert last_heartbeat_end != -1, "Heartbeat topic should be present before user message"
-
-    # The gap between last heartbeat content and user message header is small
-    gap = bg_section_end - last_heartbeat_end
-    # With current format this gap is typically < 100 chars (just a blank line + header)
-    assert gap < 150, (
-        f"Gap between heartbeat topic and user message is {gap} chars — "
-        f"close enough for LLM to mis-attribute user intent"
-    )
+    user_header = message.find("## User Message")
+    bg_header = message.find("## Background Updates")
+    assert 0 <= user_header < bg_header
+    assert message.find(user_message) < message.find("反共识信号")
+    assert message.rstrip().endswith(RECENCY_CLOSER)
+    assert message.rfind("## Background Updates") < message.rfind(RECENCY_CLOSER)
 
 
-def test_compose_message_multiple_events_last_one_closest_to_user():
-    """When multiple heartbeat events are included, the LAST one is closest
-    to the user message and most likely to hijack intent.
-
-    In the real incident, a benign "Evaluated 2/8 skills" was followed by
-    a topical "反共识信号已顺利生成" — the latter was closest to the user's
-    message and became the mis-attributed referent.
-    """
+def test_compose_message_multiple_events_stay_after_user_message():
     user_message = "好的，我也好奇具体怎么做的"
     mailbox = [
         {
@@ -233,13 +217,10 @@ def test_compose_message_multiple_events_last_one_closest_to_user():
 
     message, _ = compose_message_with_mailbox_updates(user_message, mailbox)
 
-    user_section_start = message.find("## User Message")
-    # The topical event (反共识) appears after the benign one and closer to user
+    user_pos = message.find(user_message)
     benign_pos = message.find("Evaluated 2/8 skills")
     topical_pos = message.find("反共识信号已顺利生成")
-    assert benign_pos < topical_pos < user_section_start, (
-        "Events are ordered chronologically; last event is closest to user message"
-    )
+    assert 0 <= user_pos < benign_pos < topical_pos
 
 
 def test_compose_message_warns_task_queries_to_verify_real_task_source():
@@ -264,3 +245,6 @@ def test_compose_message_warns_task_queries_to_verify_real_task_source():
     assert "任务配置、执行时间、调度频率、下次运行时间" in message
     assert "必须先读取真实任务源" in message
     assert "HEARTBEAT.md / task list" in message
+    assert "不要执行其中的任务" in message
+    assert message.find(user_message) < message.find("## Background Updates")
+    assert message.rstrip().endswith(RECENCY_CLOSER)

--- a/tests/unit/test_milkie_adapter.py
+++ b/tests/unit/test_milkie_adapter.py
@@ -68,6 +68,32 @@ def test_tool_responded_non_string_output_is_json_encoded():
     assert json.loads(p["answer"]) == {"k": 1}
 
 
+def test_tool_responded_unwraps_objectid_stdout_envelope():
+    envelope = {
+        "objectId": "obj:sha256:59173f96",
+        "stdout": "aleabitoreddit posts",
+        "outputBytes": 32,
+    }
+    p = milkie_event_to_progress(
+        "tool.responded",
+        {"toolName": "run_command", "toolCallId": "tc", "status": "ok", "output": envelope},
+    )
+    assert p["answer"] == "aleabitoreddit posts"
+    assert "objectId" not in p["answer"]
+
+
+def test_tool_responded_unwraps_objectid_stdout_json_string():
+    raw = json.dumps(
+        {"objectId": "obj:sha256:ab", "stdout": "hello from shell"},
+        ensure_ascii=False,
+    )
+    p = milkie_event_to_progress(
+        "tool.responded",
+        {"toolName": "run_command", "toolCallId": "tc", "status": "ok", "output": raw},
+    )
+    assert p["answer"] == "hello from shell"
+
+
 def test_pid_pairs_running_and_completed_via_toolcallid():
     """同一 toolCallId 让 running/completed 配对(turn_orchestrator 靠 pid 去重/配对)。"""
     a = milkie_event_to_progress("tool.requested", {"toolName": "t", "input": {}, "toolCallId": "X"})

--- a/tests/unit/test_turn_orchestrator.py
+++ b/tests/unit/test_turn_orchestrator.py
@@ -1167,17 +1167,21 @@ async def test_empty_output_loop_not_triggered_when_think_present():
 
 
 # ---------------------------------------------------------------------------
-# last_successful_tool_output fallback tests
+# Empty LLM after tools: do not dump tool stdout as the user answer
 # ---------------------------------------------------------------------------
 
+def _assert_empty_user_answer(events: list[TurnEvent]) -> None:
+    complete = next(e for e in events if e.type == TurnEventType.TURN_COMPLETE)
+    assert not (complete.answer or "").strip()
+
+
 @pytest.mark.asyncio
-async def test_tool_output_fallback_when_llm_empty():
-    """When LLM produces no text, last successful tool_output should be used as response."""
+async def test_tool_output_not_used_as_answer_when_llm_empty():
+    """Tool stdout is for the next LLM round, not the Telegram/Web bubble."""
     script = [
         _progress_event(_llm_delta("", think="reasoning about tools")),
         _progress_event(_tool_call("_bash", "echo analysis", pid="tc1")),
         _progress_event(_tool_output("_bash", "Analysis result: all good", pid="to1")),
-        # LLM produces only thinking, no visible text
         _progress_event(_llm_delta("", think="done, returning result")),
     ]
     agent = _ScriptedAgent(script)
@@ -1186,16 +1190,37 @@ async def test_tool_output_fallback_when_llm_empty():
     async for te in orch.run_turn(agent, "go"):
         events.append(te)
 
+    _assert_empty_user_answer(events)
     complete = next(e for e in events if e.type == TurnEventType.TURN_COMPLETE)
-    assert complete.answer, "Expected fallback to last_successful_tool_output, got empty"
-    assert "Analysis result" in complete.answer
+    assert "Analysis result" not in (complete.answer or "")
 
 
 @pytest.mark.asyncio
-async def test_skill_output_fallback_when_llm_empty():
-    """When LLM produces no text after skill calls, last successful skill output
-    should be used as response. This is the production bug: skill outputs don't
-    update last_successful_tool_output, causing empty '(无响应)' replies."""
+async def test_milkie_run_command_envelope_not_used_as_answer():
+    """Incident: empty glm round + last run_command JSON dumped to Telegram."""
+    envelope = (
+        '{"objectId": "obj:sha256:59173f96abb48c52972dd0c705a4718fb02f46832875a19e4f",'
+        ' "stdout": "aleabitoreddit (@aleaditorebdit) / Posts / X"}'
+    )
+    script = [
+        _progress_event(_skill_call("run_command", "search.py aleabitoreddit", pid="sk1")),
+        _progress_event(_skill_output("run_command", envelope, pid="so1")),
+    ]
+    agent = _ScriptedAgent(script)
+    orch = TurnOrchestrator(TurnPolicy(max_attempts=1, max_tool_calls=10))
+    events: list[TurnEvent] = []
+    async for te in orch.run_turn(agent, "hi"):
+        events.append(te)
+
+    complete = next(e for e in events if e.type == TurnEventType.TURN_COMPLETE)
+    answer = complete.answer or ""
+    assert "objectId" not in answer
+    assert "aleabitoreddit" not in answer
+    assert not answer.strip()
+
+
+@pytest.mark.asyncio
+async def test_skill_output_not_used_as_answer_when_llm_empty():
     script = [
         _progress_event(_llm_delta("", think="loading skill")),
         _progress_event(_skill_call("_load_resource_skill", "example-skill", pid="sk1")),
@@ -1203,7 +1228,6 @@ async def test_skill_output_fallback_when_llm_empty():
         _progress_event(_llm_delta("", think="running analysis")),
         _progress_event(_skill_call("_bash", "dispatch.py analyze", pid="sk2")),
         _progress_event(_skill_output("_bash", "Deep Review: 5 bugs found ...", pid="so2")),
-        # LLM produces only thinking, no visible text
         _progress_event(_llm_delta("", think="analysis complete")),
     ]
     agent = _ScriptedAgent(script)
@@ -1213,22 +1237,18 @@ async def test_skill_output_fallback_when_llm_empty():
         events.append(te)
 
     complete = next(e for e in events if e.type == TurnEventType.TURN_COMPLETE)
-    assert complete.answer, "Expected fallback to last successful skill output, got empty"
-    assert "Deep Review" in complete.answer
+    assert "Deep Review" not in (complete.answer or "")
+    assert not (complete.answer or "").strip()
 
 
 @pytest.mark.asyncio
-async def test_skill_output_fallback_ignores_failed_skill_output():
-    """Only successful skill outputs should be used as fallback.
-    A failed skill output (with error signature) should NOT overwrite
-    a previous successful output."""
+async def test_failed_skill_output_not_used_as_answer():
     script = [
         _progress_event(_llm_delta("", think="step 1")),
         _progress_event(_skill_call("_bash", "echo good", pid="sk1")),
         _progress_event(_skill_output("_bash", "Good result from first skill", pid="so1")),
         _progress_event(_llm_delta("", think="step 2")),
         _progress_event(_skill_call("_bash", "bad command", pid="sk2")),
-        # Failed output: has error signature
         _progress_event(_skill_output("_bash", "Command exited with code 1", pid="so2")),
         _progress_event(_llm_delta("", think="done")),
     ]
@@ -1239,29 +1259,18 @@ async def test_skill_output_fallback_ignores_failed_skill_output():
         events.append(te)
 
     complete = next(e for e in events if e.type == TurnEventType.TURN_COMPLETE)
-    assert complete.answer, "Expected fallback to successful skill output"
-    assert "Good result" in complete.answer
-    assert "exited with code 1" not in complete.answer
+    assert "Good result" not in (complete.answer or "")
+    assert "exited with code 1" not in (complete.answer or "")
 
 
 @pytest.mark.asyncio
-async def test_skill_output_fallback_ignores_status_failed_without_signature():
-    """BUG: When a skill reports status='failed' but its output text does NOT
-    match any known failure pattern (no 'exit code', no 'Error:', etc.),
-    _extract_failure_signature() returns None.  The fallback tracking code
-    only checks `not fail_sig`, ignoring the explicit status='failed' field.
-    Result: failed skill output is stored as last_successful_tool_output and
-    surfaced to the user as the response — leaking internal error details.
-
-    The fix should also check `status != 'failed'` before tracking fallback.
-    """
+async def test_status_failed_skill_output_not_used_as_answer():
     script = [
         _progress_event(_llm_delta("", think="step 1")),
         _progress_event(_skill_call("_bash", "echo good", pid="sk1")),
         _progress_event(_skill_output("_bash", "Good result", pid="so1")),
         _progress_event(_llm_delta("", think="step 2")),
         _progress_event(_skill_call("_bash", "do something", pid="sk2")),
-        # status="failed" but output has NO recognized failure pattern
         _progress_event(_skill_output(
             "_bash",
             "The operation could not be completed due to insufficient permissions",
@@ -1277,69 +1286,12 @@ async def test_skill_output_fallback_ignores_status_failed_without_signature():
         events.append(te)
 
     complete = next(e for e in events if e.type == TurnEventType.TURN_COMPLETE)
-    # The failed skill output should NOT become the fallback response
-    assert "insufficient permissions" not in (complete.answer or ""), (
-        "BUG: status='failed' skill output was used as fallback because "
-        "_extract_failure_signature() returned None (no pattern match). "
-        "The code should also check the explicit status field."
-    )
-    # The earlier successful output should be preserved
-    assert complete.answer == "Good result", (
-        f"Expected earlier successful output 'Good result', got: {complete.answer!r}"
-    )
+    assert "insufficient permissions" not in (complete.answer or "")
+    assert "Good result" not in (complete.answer or "")
 
 
 @pytest.mark.asyncio
-async def test_skill_output_fallback_truncated_to_max_chars():
-    """Skill output used as fallback should be truncated to max_tool_output_preview_chars."""
-    long_output = "X" * 500
-    script = [
-        _progress_event(_llm_delta("", think="analyzing")),
-        _progress_event(_skill_call("_bash", "long command", pid="sk1")),
-        _progress_event(_skill_output("_bash", long_output, pid="so1")),
-        _progress_event(_llm_delta("", think="done")),
-    ]
-    agent = _ScriptedAgent(script)
-    orch = TurnOrchestrator(TurnPolicy(max_attempts=1, max_tool_calls=10, max_tool_output_preview_chars=100))
-    events: list[TurnEvent] = []
-    async for te in orch.run_turn(agent, "go"):
-        events.append(te)
-
-    complete = next(e for e in events if e.type == TurnEventType.TURN_COMPLETE)
-    assert complete.answer, "Expected truncated fallback"
-    assert len(complete.answer) == 100
-
-
-@pytest.mark.asyncio
-async def test_skill_output_overwrites_earlier_tool_output_fallback():
-    """A later successful skill output should overwrite an earlier tool_output fallback."""
-    script = [
-        _progress_event(_llm_delta("", think="step 1")),
-        # Regular tool_call/tool_output stage
-        _progress_event(_tool_call("_bash", "echo old", pid="tc1")),
-        _progress_event(_tool_output("_bash", "Old tool_output result", pid="to1")),
-        _progress_event(_llm_delta("", think="step 2")),
-        # Skill stage (should overwrite the tool_output fallback)
-        _progress_event(_skill_call("_bash", "echo new", pid="sk1")),
-        _progress_event(_skill_output("_bash", "New skill result", pid="so1")),
-        _progress_event(_llm_delta("", think="done")),
-    ]
-    agent = _ScriptedAgent(script)
-    orch = TurnOrchestrator(TurnPolicy(max_attempts=1, max_tool_calls=10))
-    events: list[TurnEvent] = []
-    async for te in orch.run_turn(agent, "go"):
-        events.append(te)
-
-    complete = next(e for e in events if e.type == TurnEventType.TURN_COMPLETE)
-    assert complete.answer, "Expected skill output to be the fallback"
-    assert "New skill result" in complete.answer
-
-
-@pytest.mark.asyncio
-async def test_skill_only_flow_no_tool_output_stage():
-    """Pure skill-only flow (no tool_call/tool_output stages at all).
-    This is the most common production scenario where the bug manifests:
-    Dolphin emits only skill events, never tool_call/tool_output events."""
+async def test_skill_only_flow_empty_llm_stays_empty():
     script = [
         _progress_event(_llm_delta("", think="I'll use skills to solve this")),
         _progress_event(_skill_call("_load_resource_skill", "paper-discovery", pid="sk1")),
@@ -1347,10 +1299,8 @@ async def test_skill_only_flow_no_tool_output_stage():
         _progress_event(_llm_delta("", think="now search")),
         _progress_event(_skill_call("_bash", "search papers", pid="sk2")),
         _progress_event(_skill_output("_bash", "Found 3 papers: A, B, C", pid="so2")),
-        _progress_event(_llm_delta("", think="now analyze")),
         _progress_event(_skill_call("_bash", "analyze results", pid="sk3")),
         _progress_event(_skill_output("_bash", "Final analysis: Paper A is best", pid="so3")),
-        # LLM never produces visible text
     ]
     agent = _ScriptedAgent(script)
     orch = TurnOrchestrator(TurnPolicy(max_attempts=1, max_tool_calls=10))
@@ -1359,8 +1309,8 @@ async def test_skill_only_flow_no_tool_output_stage():
         events.append(te)
 
     complete = next(e for e in events if e.type == TurnEventType.TURN_COMPLETE)
-    assert complete.answer, "Pure skill flow should have fallback answer, not empty '(无响应)'"
-    assert "Final analysis" in complete.answer
+    assert "Final analysis" not in (complete.answer or "")
+    assert not (complete.answer or "").strip()
 
 
 # ---------------------------------------------------------------------------
@@ -1413,6 +1363,31 @@ async def test_drain_prefers_llm_over_tool_outputs():
 
 
 @pytest.mark.asyncio
+async def test_drain_llm_plus_envelope_prefers_llm():
+    envelope = (
+        '{"objectId": "obj:sha256:ab", "stdout": "aleabitoreddit dump"}'
+    )
+    items = [
+        {"_progress": [{"stage": "llm", "delta": "Hello there."}]},
+        {"_progress": [{
+            "stage": "skill",
+            "status": "completed",
+            "skill_info": {"name": "run_command"},
+            "answer": envelope,
+        }]},
+    ]
+    results = []
+    await _drain_after_timeout(
+        _FakeAsyncIter(items),
+        on_result=lambda r: results.append(r),
+        extra_timeout=5.0,
+    )
+    assert results == ["Hello there."]
+    assert "objectId" not in results[0]
+    assert "aleabitoreddit" not in results[0]
+
+
+@pytest.mark.asyncio
 async def test_drain_llm_only():
     """Drain with only LLM text works correctly."""
     items = [
@@ -1430,7 +1405,7 @@ async def test_drain_llm_only():
 
 @pytest.mark.asyncio
 async def test_drain_tool_only():
-    """Drain with only tool output works correctly."""
+    """Tool-only drain must not deliver stdout as a deferred user reply."""
     items = [
         {"_progress": [{"stage": "skill", "status": "completed", "output": "Tool only."}]},
     ]
@@ -1440,8 +1415,34 @@ async def test_drain_tool_only():
         on_result=lambda r: results.append(r),
         extra_timeout=5.0,
     )
-    assert len(results) == 1
-    assert results[0] == "Tool only."
+    assert results == []
+
+
+@pytest.mark.asyncio
+async def test_drain_milkie_envelope_not_delivered():
+    """Soft-timeout drain must not dump milkie run_command envelopes."""
+    envelope = (
+        '{"objectId": "obj:sha256:59173f96abb48c52972dd0c705a4718fb02f46832875a19e4f",'
+        ' "stdout": "aleabitoreddit (@aleaditorebdit) / Posts / X"}'
+    )
+    items = [
+        {"_progress": [{
+            "stage": "skill",
+            "status": "completed",
+            "skill_info": {"name": "run_command"},
+            "answer": envelope,
+        }]},
+    ]
+    results = []
+    await _drain_after_timeout(
+        _FakeAsyncIter(items),
+        on_result=lambda r: results.append(r),
+        extra_timeout=5.0,
+    )
+    assert results == []
+    joined = "\n".join(results)
+    assert "objectId" not in joined
+    assert "aleabitoreddit" not in joined
 
 
 @pytest.mark.asyncio
@@ -1772,10 +1773,11 @@ async def test_drain_filters_load_resource_skill():
         on_result=lambda r: results.append(r),
         extra_timeout=5.0,
     )
-    assert len(results) == 1
-    assert "Real command result" in results[0]
-    assert "Coding Master" not in results[0]
-    assert "[PIN]" not in results[0]
+    assert results == []
+    joined = "\n".join(results)
+    assert "Real command result" not in joined
+    assert "Coding Master" not in joined
+    assert "[PIN]" not in joined
 
 
 @pytest.mark.asyncio
@@ -1850,9 +1852,10 @@ async def test_drain_strips_pin_marker_from_tool_output():
         on_result=lambda r: results.append(r),
         extra_timeout=5.0,
     )
-    assert len(results) == 1
-    assert "[PIN]" not in results[0]
-    assert "should be cleaned" in results[0]
+    assert results == []
+    joined = "\n".join(results)
+    assert "[PIN]" not in joined
+    assert "should be cleaned" not in joined
 
 
 @pytest.mark.asyncio
@@ -1870,9 +1873,8 @@ async def test_drain_collects_skill_answer_field():
         on_result=lambda r: results.append(r),
         extra_timeout=5.0,
     )
-    assert len(results) == 1
-    # answer takes precedence over output
-    assert "Answer field value" in results[0]
+    assert results == []
+    assert "Answer field value" not in "\n".join(results)
 
 
 @pytest.mark.asyncio
@@ -1891,8 +1893,8 @@ async def test_drain_collects_skill_block_answer_field():
         on_result=lambda r: results.append(r),
         extra_timeout=5.0,
     )
-    assert len(results) == 1
-    assert "Block answer value" in results[0]
+    assert results == []
+    assert "Block answer value" not in "\n".join(results)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 背景

Fixes #211。Telegram `hi` 被 mailbox 后台任务压在前面，glm 空收尾后把 milkie `{objectId, stdout}` 当用户回复发出。

## 改动

- mailbox compose：用户原话在前，Background Updates 在后，以 recency closer 收尾
- 空 LLM turn 不再把 last tool/skill stdout 回填为用户回复
- 软超时 drain 无 LLM 文本时不投递拼接的 tool stdout
- milkie adapter 把 `run_command` 信封投影为 stdout

## 测试

`pytest tests/unit/test_mailbox_runtime.py tests/unit/test_turn_orchestrator.py tests/unit/test_milkie_adapter.py` → 150 passed

## 评审

Independent reviewer (Grok / grok-4.5): **PASS**（无 P0–P2）

## 关联

- Issue #211
- #60