### PR TITLE
【milkie】sidecar PATH 前置工作区 bin

### DIFF
--- a/src/everbot/core/agent/provider/milkie/launcher.py
+++ b/src/everbot/core/agent/provider/milkie/launcher.py
@@ -155,6 +155,12 @@ class SidecarLauncher:
         # #155: skill scripts (analyze.py) inherit agent model intent via env.
         env["EVERBOT_AGENT"] = agent_name
         env["ALFRED_AGENT"] = agent_name
+        # Workspace ``bin/`` (e.g. a kairo write-guard wrapper) must win PATH
+        # inside the sidecar, including run_command children.
+        if agent_workspace is not None:
+            ws_bin = Path(agent_workspace).expanduser().resolve() / "bin"
+            if ws_bin.is_dir():
+                env["PATH"] = f"{ws_bin}:{env.get('PATH', '')}"
         default_cloud = self._llms[default]["cloud"]  # per-agent 模型的 cloud(决定 key/VOLCENGINE 处理)
         api_key = self._clouds[default_cloud].get("api_key")
         if api_key:

--- a/tests/unit/test_milkie_launcher.py
+++ b/tests/unit/test_milkie_launcher.py
@@ -70,6 +70,26 @@ def test_build_injects_everbot_agent_env_for_skill_model_intent(tmp_path):
     assert spec.env.get("ALFRED_AGENT") == "demo_agent"
 
 
+def test_build_prepends_workspace_bin_to_path_when_present(tmp_path, monkeypatch):
+    monkeypatch.setenv("PATH", "/usr/bin:/bin")
+    ws = tmp_path / "agent-ws"
+    bindir = ws / "bin"
+    bindir.mkdir(parents=True)
+    (bindir / "kairo").write_text("#!/bin/sh\n", encoding="utf-8")
+    spec = _launcher(tmp_path).build(
+        "demo_agent", system_prompt="x", agent_workspace=ws
+    )
+    path = spec.env.get("PATH") or ""
+    assert path.split(":")[0] == str(bindir.resolve())
+    assert "/usr/bin" in path
+
+
+def test_build_does_not_prepend_missing_workspace_bin(tmp_path, monkeypatch):
+    monkeypatch.setenv("PATH", "/usr/bin:/bin")
+    spec = _launcher(tmp_path).build("demo_agent", system_prompt="x")
+    assert spec.env.get("PATH") == "/usr/bin:/bin"
+
+
 def test_build_unknown_model_fails_fast(tmp_path):
     launcher = SidecarLauncher(
         dist_path=tmp_path / "x.js", data_dir_root=tmp_path / "d", node_bin="node",


### PR DESCRIPTION
## 背景

#213。demo_agent 需要 sidecar 的 `run_command` 优先使用工作区 `bin/` 包装命令。

## 改动

`SidecarLauncher.build`：若 `agent_workspace/bin` 存在，将其前置到 env PATH。

## 测试

`pytest tests/unit/test_milkie_launcher.py`（含有/无 bin 两例）。

## 关联

Closes #213