### PR TITLE
【mailbox】含 kairo 的进线不再要求先读 HEARTBEAT.md

### DIFF
--- a/src/everbot/core/runtime/mailbox.py
+++ b/src/everbot/core/runtime/mailbox.py
@@ -83,13 +83,19 @@ def compose_message_with_mailbox_updates(
         deduped_events_reversed.append(event)
     deduped_events = list(reversed(deduped_events_reversed))
 
+    # #215: "kairo" in the user text wins over "ask HEARTBEAT.md first".
+    heartbeat_first = (
+        "若用户询问任务配置、执行时间、调度频率、下次运行时间或某任务是否存在，"
+        "必须先读取真实任务源（如 HEARTBEAT.md / task list）再回答。"
+    )
+    if "kairo" in (trigger_message or "").lower():
+        heartbeat_first = ""
     lines: List[str] = [
         "## Background Updates",
         (
             "(以下是后台定时任务通知，仅可作为线索，不保证覆盖全部事实。"
             "用户本轮消息优先：除非用户明确询问这些后台事项，否则不要执行其中的任务，先回应用户本轮消息。"
-            "若用户询问任务配置、执行时间、调度频率、下次运行时间或某任务是否存在，"
-            "必须先读取真实任务源（如 HEARTBEAT.md / task list）再回答。"
+            f"{heartbeat_first}"
             "被追问来源时，可说明是后台定时任务采集。)"
         ),
     ]

--- a/tests/unit/test_mailbox_runtime.py
+++ b/tests/unit/test_mailbox_runtime.py
@@ -248,3 +248,40 @@ def test_compose_message_warns_task_queries_to_verify_real_task_source():
     assert "不要执行其中的任务" in message
     assert message.find(user_message) < message.find("## Background Updates")
     assert message.rstrip().endswith(RECENCY_CLOSER)
+
+
+_MAILBOX_ONE = [
+    {
+        "event_id": "evt_hb",
+        "event_type": "heartbeat_result",
+        "summary": "系统一切正常：最近定时任务全部顺利跑完",
+        "detail": "Skill Evaluate 也刚完成一轮",
+    },
+]
+
+
+def test_compose_kairo_user_message_omits_heartbeat_first_read():
+    """#215: mentioning kairo must not send the model to HEARTBEAT.md first."""
+    user_message = "今天早上 kairo 开了什么会议"
+    message, ack_ids = compose_message_with_mailbox_updates(user_message, _MAILBOX_ONE)
+
+    assert "HEARTBEAT.md" not in message
+    assert "必须先读取真实任务源" not in message
+    assert message.startswith("## User Message")
+    assert message.find(user_message) < message.find("## Background Updates")
+    assert "不要执行其中的任务" in message
+    assert message.rstrip().endswith(RECENCY_CLOSER)
+    assert ack_ids == ["evt_hb"]
+
+
+def test_compose_kairo_user_message_is_case_insensitive():
+    message, _ = compose_message_with_mailbox_updates("What is Kairo doing?", _MAILBOX_ONE)
+    assert "HEARTBEAT.md" not in message
+    assert "必须先读取真实任务源" not in message
+
+
+def test_compose_non_kairo_user_message_keeps_heartbeat_first_read():
+    user_message = "帮我总结今天的重点"
+    message, _ = compose_message_with_mailbox_updates(user_message, _MAILBOX_ONE)
+    assert "必须先读取真实任务源" in message
+    assert "HEARTBEAT.md" in message


### PR DESCRIPTION
## 背景

#215。mailbox 前缀固定「问执行时间先读 HEARTBEAT.md」，与「提到 kairo 先 skill_request」抢第一条工具。

## 改动

`compose_message_with_mailbox_updates`：trigger 含 `kairo`（大小写不敏感）时省略 HEARTBEAT.md-first 句；不含则保持。User Message 仍在前，线索声明与 recency closer 不变。

## 测试

`pytest tests/unit/test_mailbox_runtime.py -v`（12 passed，含 kairo / 非 kairo / 大小写）。

## 关联

Closes #215