### PR TITLE
【demo_agent】论文推荐改走 researcher papers CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,8 @@ EverBot 通过可插拔的技能模块扩展 Agent 的能力。每个技能是�
 | **invest** | 统一投资分析 | 多源信号采集（宏观流动性、价值评分、中国市场、箱体突破）、因果链条、资产概率分布 |
 | **gray-rhino** | 风险趋势预警 | 新闻聚类、灰犀牛识别、资产影响映射 |
 | **daily-attractor** | 每日市场监控 | 融资定价偏移、吸引子追踪、Telegram 推送 |
-| **paper-discovery** | AI/ML 论文发现 | HuggingFace + arXiv 集成、热度评分、GitHub Star 排名 |
+| **papers** | AI/ML 论文发现与深读 | 调用 `researcher papers`：热榜 / 查篇 / Library 证据卡 |
+| **paper-discovery** | （已由 papers 替换）旧 HF+arXiv 脚本 | 保留脚本与单测；demo_agent 不再加载 |
 | **dev-browser** | 浏览器自动化 | 持久页面状态、ARIA 快照、截图能力 |
 | **web** | 网络搜索与浏览器 | 多后端搜索（DuckDuckGo/Tavily）、页面提取、Playwright 自动化 |
 | **skill-installer** | 动态技能管理 | 注册表安装、多源支持（Git/URL/本地） |
@@ -291,7 +292,8 @@ alfred/
 │   ├── invest/               # 统一投资分析（含宏观流动性、价值评分、中国市场信号）
 │   ├── gray-rhino/           # 风险趋势预警
 │   ├── daily-attractor/      # 每日市场监控
-│   ├── paper-discovery/      # AI/ML 论文发现
+│   ├── papers/               # researcher papers CLI（热榜/查篇/深读）
+│   ├── paper-discovery/      # 旧论文脚本（demo_agent 已 exclude）
 │   ├── dev-browser/          # 浏览器自动化
 │   ├── web/                  # 网络搜索与浏览器自动化
 │   ├── skill-installer/      # 动态技能安装

--- a/README_EN.md
+++ b/README_EN.md
@@ -86,7 +86,8 @@ EverBot extends Agent capabilities through pluggable skill modules. Each skill i
 | **invest** | Unified investment analysis | Multi-source signals (macro liquidity, value scoring, China market, box breakout), causal chains, probability distributions |
 | **gray-rhino** | Risk trend alerts | News clustering, gray rhino identification, asset impact mapping |
 | **daily-attractor** | Daily market monitoring | Financing pricing deviation, attractor tracking, Telegram push |
-| **paper-discovery** | AI/ML paper discovery | HuggingFace + arXiv integration, heat scoring, GitHub star ranking |
+| **papers** | AI/ML paper digest and deep-read | `researcher papers` CLI: trending / lookup / Library evidence card |
+| **paper-discovery** | (replaced by papers) legacy HF+arXiv scripts | kept for tests; demo_agent no longer loads it |
 | **dev-browser** | Browser automation | Persistent page state, ARIA snapshots, screenshot capability |
 | **web** | Web search & browser | Multi-backend search (DuckDuckGo/Tavily), page extraction, Playwright automation |
 | **skill-installer** | Dynamic skill management | Registry installation, multi-source support (Git/URL/local) |
@@ -291,7 +292,8 @@ alfred/
 │   ├── invest/               # Unified investment analysis (macro liquidity, value scoring, China market signals)
 │   ├── gray-rhino/           # Risk trend alerts
 │   ├── daily-attractor/      # Daily market monitoring
-│   ├── paper-discovery/      # AI/ML paper discovery
+│   ├── papers/               # researcher papers CLI (trending / lookup / deep-read)
+│   ├── paper-discovery/      # legacy paper scripts (excluded for demo_agent)
 │   ├── dev-browser/          # Browser automation
 │   ├── web/                  # Web search & browser automation
 │   ├── skill-installer/      # Dynamic skill installation

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -3,6 +3,7 @@
 | 规范名 | 一句话定义 | 禁止别称 |
 |---|---|---|
 | grok-cli | 宿主 spawn 本机 `grok` CLI 作为 agent runtime 的路径，走 OAuth 登录而非 HTTP 模型端点。 | grok HTTP、xAI API、SpaceXAI HTTP |
+| papers | 调用 PATH 上 `researcher papers` 的 agent skill：热榜、按名/ID 查篇、Library 深读。 | paper-discovery、热榜脚本 |
 
 # Alfred 术语表
 

--- a/skills/papers/SKILL.md
+++ b/skills/papers/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: papers
+description: Discover, search, and deep-read papers via the researcher CLI (HuggingFace Daily Papers, arXiv, Library evidence cards). Use for 推论文, paper names, arXiv IDs, and 详细说说.
+version: "1.0.0"
+tags: [papers, research, arxiv, huggingface, library]
+---
+
+# Papers
+
+Call the `researcher` CLI. Do **not** curl/wget PDFs, scrape HTML, write inline Python, or call paper-discovery scripts.
+
+**demo_agent host:** this skill has no `scripts/`. The binary is `researcher` on PATH. Daily digest is `trending`; deep dive is `read` (Library evidence card, can take up to 15 minutes — not the 300s heartbeat job).
+
+## When to Use
+
+- Daily paper digest / 热榜 / 「推论文」
+- User names a paper (e.g. "看看 SkillCraft")
+- User has an arXiv ID
+- User wants a deep read (「这篇详细说说」)
+
+## Commands
+
+JSON is the agent contract. Errors go to stderr; stdout is payload only.
+
+```bash
+researcher papers trending --format json --limit 10
+researcher papers trending --format report --limit 10
+researcher papers search "SkillCraft" --format json
+researcher papers show 2401.12345 --format json
+researcher papers read 2401.12345
+```
+
+| Command | Needs workspace? | Writes Library? |
+|---|---|---|
+| `trending` / `search` / `show` | no | no |
+| `read` | default workspace | yes (evidence card) |
+
+Default workspace: `--workspace`, else `RESEARCHER_WORKSPACE_ROOT`, else `workspace:` in `~/.researcher/config.yaml` (absolute super-repo path with `researcher.workspace.yml`).
+
+### Flags
+
+| Option | Values | Default | Where |
+|---|---|---|---|
+| `--limit` | integer | `10` trending / `5` search | trending, search |
+| `--format` | `json`, `report` | `json` | trending, search, show |
+| `--source` | `huggingface`, `arxiv`, `both` | `huggingface` | trending |
+| `--category` | arXiv category | `cs.AI` | trending |
+| `--workspace` | absolute path | config/env | read |
+
+`--format report` is human digest text. Prefer `--format json` then write any product/落地 commentary yourself. The CLI has no `--with-analysis` or `--with-summary`.
+
+## JSON fields
+
+Each item includes: `id` (`arxiv:YYMM.NNNNN`), `paper_id`, `title`, `authors`, `abstract`, `arxiv_url`, `pdf_url`, `source`, `published_date`, `heat_index`, `heat_level`. HuggingFace extras when present: `upvotes`, `hf_url`, `github_repo`, `github_stars`, `ai_summary`, `ai_keywords`.
+
+## Daily digest (heartbeat)
+
+```bash
+researcher papers trending --format json --limit 10
+```
+
+Then push to the user. For each paper include:
+
+- Title with heat emoji (`🔥` × `heat_level`)
+- Upvotes / GitHub stars when present
+- Abstract excerpt or `ai_summary` (do not omit)
+- Agent-side interpretation from the JSON (CLI does not do this):
+  - 🔍 **核心创新点**
+  - 🛠️ **可复用技术点**（能否接到 kweaver-core）
+  - ⚡ **落地价值评估**
+- 分类：`[前沿跟踪]` / `[可落地参考]` / `[竞品分析]`
+- arXiv / PDF links
+
+Do **not** reduce papers to a title + heat table. Do not run this job as `papers read` (too slow for the 300s heartbeat).
+
+## Deep read (chat only)
+
+```bash
+researcher papers read <arxiv-id>
+```
+
+Stdout is the Library evidence card (Essence / Claims / … / Takeaway). If a completed card exists, the CLI reprints it. Do not paraphrase the abstract and call it a deep dive.
+
+## Errors
+
+Non-zero exit: no hits, all sources failed, missing default workspace (`read`), or deep-read failure. Read stderr and tell the user. Do not retry by curling arXiv yourself.
+
+If `researcher papers` is not a command, `researcher` on PATH is too old — say so; do not fall back to paper-discovery.

--- a/tests/unit/test_papers_skill.py
+++ b/tests/unit/test_papers_skill.py
@@ -1,0 +1,15 @@
+"""#217 — papers skill must point at researcher CLI, not paper-discovery scripts."""
+
+from pathlib import Path
+
+_SKILL = Path(__file__).resolve().parents[2] / "skills" / "papers" / "SKILL.md"
+
+
+def test_papers_skill_documents_researcher_cli() -> None:
+    md = _SKILL.read_text(encoding="utf-8")
+    assert "researcher papers trending" in md
+    assert "researcher papers search" in md
+    assert "researcher papers show" in md
+    assert "researcher papers read" in md
+    assert "fetch_papers.py" not in md
+    assert "Do **not** curl/wget" in md


### PR DESCRIPTION
## 摘要

#217：新增 `skills/papers`，调用 `researcher papers`。demo_agent 工作区已切过去（symlink + exclude `paper-discovery`）。不删除旧 `paper-discovery` 脚本与单测。

## 验收

- [x] S1 SKILL.md / 心跳指向 `researcher papers trending --limit 10`
- [x] S2 search/show/read 写在 SKILL.md；深读走 Library 卡
- [x] S3 demo_agent exclude paper-discovery，工作区目录已移走

## 本机已做（不在 git）

- `npm link` researcher feat/170，使 PATH 上有 `papers`
- `~/.researcher/config.yaml` 增加 `workspace: …/research-harness`
- demo_agent `skills/papers` symlink；`paper-discovery` 挪到 `skills-bak-paper-discovery`
- `~/.alfred/config.yaml` `demo_agent.skills.exclude: [paper-discovery]`
- 改 demo_agent `HEARTBEAT.md` / `AGENTS.md`

合入后需重启 everbot 让 sidecar 重新发现 skill。