### PR TITLE
【mailbox】HEARTBEAT 指引仅针对定时任务问句，去掉 kairo 硬编码

### DIFF
--- a/src/everbot/core/runtime/mailbox.py
+++ b/src/everbot/core/runtime/mailbox.py
@@ -83,19 +83,13 @@ def compose_message_with_mailbox_updates(
         deduped_events_reversed.append(event)
     deduped_events = list(reversed(deduped_events_reversed))
 
-    # #215: "kairo" in the user text wins over "ask HEARTBEAT.md first".
-    heartbeat_first = (
-        "若用户询问任务配置、执行时间、调度频率、下次运行时间或某任务是否存在，"
-        "必须先读取真实任务源（如 HEARTBEAT.md / task list）再回答。"
-    )
-    if "kairo" in (trigger_message or "").lower():
-        heartbeat_first = ""
     lines: List[str] = [
         "## Background Updates",
         (
             "(以下是后台定时任务通知，仅可作为线索，不保证覆盖全部事实。"
             "用户本轮消息优先：除非用户明确询问这些后台事项，否则不要执行其中的任务，先回应用户本轮消息。"
-            f"{heartbeat_first}"
+            "仅当本轮明确问本 agent 的定时任务或调度时，才读 HEARTBEAT.md / task list；"
+            "其他问题不要先翻任务表。"
             "被追问来源时，可说明是后台定时任务采集。)"
         ),
     ]

--- a/tests/unit/test_mailbox_runtime.py
+++ b/tests/unit/test_mailbox_runtime.py
@@ -29,7 +29,7 @@ def test_compose_message_with_mailbox_updates_prefixes_user_message():
     assert message.startswith("## User Message")
     assert "仅可作为线索" in message
     assert "不要执行其中的任务" in message
-    assert "必须先读取真实任务源" in message
+    assert "必须先读取真实任务源" not in message
     assert "[heartbeat_result] 你有新的日报" in message
     assert "Detail: 详见日报附件" in message
     user_pos = message.find(user_message)
@@ -242,9 +242,8 @@ def test_compose_message_warns_task_queries_to_verify_real_task_source():
 
     message, _ = compose_message_with_mailbox_updates(user_message, mailbox)
 
-    assert "任务配置、执行时间、调度频率、下次运行时间" in message
-    assert "必须先读取真实任务源" in message
-    assert "HEARTBEAT.md / task list" in message
+    assert "HEARTBEAT.md" in message
+    assert "必须先读取真实任务源" not in message
     assert "不要执行其中的任务" in message
     assert message.find(user_message) < message.find("## Background Updates")
     assert message.rstrip().endswith(RECENCY_CLOSER)
@@ -260,12 +259,11 @@ _MAILBOX_ONE = [
 ]
 
 
-def test_compose_kairo_user_message_omits_heartbeat_first_read():
-    """#215: mentioning kairo must not send the model to HEARTBEAT.md first."""
+def test_compose_kairo_meeting_query_does_not_require_heartbeat_first():
+    """#219: kairo meeting questions must not get must-read-HEARTBEAT-first."""
     user_message = "今天早上 kairo 开了什么会议"
     message, ack_ids = compose_message_with_mailbox_updates(user_message, _MAILBOX_ONE)
 
-    assert "HEARTBEAT.md" not in message
     assert "必须先读取真实任务源" not in message
     assert message.startswith("## User Message")
     assert message.find(user_message) < message.find("## Background Updates")
@@ -274,14 +272,19 @@ def test_compose_kairo_user_message_omits_heartbeat_first_read():
     assert ack_ids == ["evt_hb"]
 
 
-def test_compose_kairo_user_message_is_case_insensitive():
+def test_compose_kairo_english_query_does_not_require_heartbeat_first():
     message, _ = compose_message_with_mailbox_updates("What is Kairo doing?", _MAILBOX_ONE)
-    assert "HEARTBEAT.md" not in message
     assert "必须先读取真实任务源" not in message
 
 
-def test_compose_non_kairo_user_message_keeps_heartbeat_first_read():
+def test_compose_generic_summary_does_not_require_heartbeat_first():
     user_message = "帮我总结今天的重点"
     message, _ = compose_message_with_mailbox_updates(user_message, _MAILBOX_ONE)
-    assert "必须先读取真实任务源" in message
-    assert "HEARTBEAT.md" in message
+    assert "必须先读取真实任务源" not in message
+
+
+def test_mailbox_composer_source_has_no_kairo_preamble_branch():
+    from pathlib import Path
+
+    src = Path("src/everbot/core/runtime/mailbox.py").read_text(encoding="utf-8")
+    assert "kairo" not in src.lower()


### PR DESCRIPTION
## 背景

#219。#215 用产品名 `kairo` 分支省略 HEARTBEAT.md-first 句。应改成一条共享前缀。

## 改动

`compose_message_with_mailbox_updates`：删除 `kairo` 分支；前缀改为「仅当本轮明确问定时任务或调度时才读 HEARTBEAT.md / task list」。

## 测试

`pytest tests/unit/test_mailbox_runtime.py -v`（13 passed）。

## 关联

Closes #219. Supersedes the kairo exception in #215 / #216.