### PR TITLE
【kairo-ingest】全局库已有材料扫描跳过且确认入库不造第二份 home

### DIFF
--- a/skills/kairo-ingest/SKILL.md
+++ b/skills/kairo-ingest/SKILL.md
@@ -49,6 +49,7 @@ python "$INGEST/apply.py" --plan /tmp/kairo-ingest-plan.json --title "标题-YYM
 
 - `--title` 可重复；只入库这些标题。plan 里其余条目会 skip。
 - 条目已有唯一匹配 `topic` 时不必改 JSON。用户改选 Topic 时，改 plan 里该条的 `"topic"` 再 apply。
+- 源已在 `.kairo/global-home`（或 Topic `references/`）时，apply 只 `tag add` + `title`，**禁止** `cd Topic && kairo add` 造第二份 home。
 - 默认 `--no-step`（避免 ASR/compose 撑爆会话）。用户明确要求 step/run 时再对那个 Topic 单独走 kairo 技能。
 - 禁止再 scan 考古、禁止复述步骤。
 

--- a/skills/kairo-ingest/scripts/apply.py
+++ b/skills/kairo-ingest/scripts/apply.py
@@ -17,10 +17,24 @@ def kairo_bin() -> str:
     return os.environ.get("KAIRO_REAL_BIN") or str(Path.home() / ".local/bin/kairo")
 
 
+def _scan_mod():
+    import importlib.util
+
+    path = Path(__file__).resolve().parent / "scan.py"
+    spec = importlib.util.spec_from_file_location("_kairo_ingest_scan", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
 def build_actions(plan: dict, *, step: bool = True) -> list[dict]:
     root = Path(plan["root"])
     actions: list[dict] = []
     stepped: list[str] = []
+    scan = _scan_mod()
+    existing_records = scan.lookup_existing_refs(root)
+    find_existing = scan.find_existing_ref
     for item in plan.get("items") or []:
         if item.get("action") == "skip":
             continue
@@ -34,6 +48,58 @@ def build_actions(plan: dict, *, step: bool = True) -> list[dict]:
             continue
         cwd = str(root)
         primary, *rest = forms
+        names = {Path(form["path"]).name for form in forms}
+        form_paths = {form["path"] for form in forms}
+        existing = find_existing(
+            root,
+            title=item["title"],
+            basenames=names,
+            paths=form_paths,
+            records=existing_records,
+        )
+        if existing:
+            rid = existing["id"]
+            home = existing.get("home") or ""
+            tag_args = ["tag", "add", rid, topic, "--root", str(root)]
+            if home:
+                tag_args.extend(["--home", home])
+            actions.append(
+                {
+                    "kind": "tag",
+                    "cwd": cwd,
+                    "args": tag_args,
+                    "title": item["title"],
+                    "topic": topic,
+                    "ref_id": rid,
+                }
+            )
+            actions.append(
+                {
+                    "kind": "title",
+                    "cwd": cwd,
+                    "args": ["title", rid, item["title"], "--topic", topic],
+                    "title": item["title"],
+                    "topic": topic,
+                    "ref_id": rid,
+                }
+            )
+            for form in rest:
+                attach_args = ["add", form["path"], "--to", rid]
+                if form.get("copy"):
+                    attach_args.append("--copy")
+                attach_args.extend(["--root", str(root)])
+                actions.append(
+                    {
+                        "kind": "attach",
+                        "cwd": cwd,
+                        "args": attach_args,
+                        "title": item["title"],
+                        "topic": topic,
+                    }
+                )
+            if topic not in stepped:
+                stepped.append(topic)
+            continue
         add_args = ["add", primary["path"]]
         if primary.get("copy"):
             add_args.append("--copy")
@@ -41,6 +107,8 @@ def build_actions(plan: dict, *, step: bool = True) -> list[dict]:
             [
                 "--occurred",
                 item["occurred"],
+                "--title",
+                item["title"],
                 "--topic",
                 topic,
                 "--root",
@@ -170,7 +238,9 @@ def run_actions(
             "topic": action.get("topic") or "",
         }
         if dry_run:
-            if action["kind"] == "add":
+            if action["kind"] in ("add", "tag"):
+                if action["kind"] == "tag":
+                    record["ref_id"] = action.get("ref_id")
                 added.append(record)
             elif action["kind"] == "step":
                 stepped.append(record)
@@ -195,6 +265,14 @@ def run_actions(
             added.append(record)
             if root is not None:
                 record_seen(root, action["title"], [args[1]])
+        elif action["kind"] == "tag":
+            ref_id = action.get("ref_id") or ""
+            if ref_id:
+                ref_by_title[action["title"]] = ref_id
+            record["ref_id"] = ref_id
+            added.append(record)
+            if root is not None:
+                record_seen(root, action["title"], [])
         elif action["kind"] == "attach":
             if root is not None:
                 record_seen(root, action["title"], [args[1]])
@@ -218,7 +296,8 @@ def format_receipt(plan: dict, result: dict) -> str:
     for rec in result.get("added") or []:
         rid = rec.get("ref_id") or REF_PLACEHOLDER
         dest = rec.get("topic") or Path(rec["cwd"]).name
-        lines.append(f"- add {rec['title']} → {dest} ref {rid}")
+        verb = "tag" if rec.get("kind") == "tag" else "add"
+        lines.append(f"- {verb} {rec['title']} → {dest} ref {rid}")
     for rec in result.get("stepped") or []:
         extra = rec.get("stdout") or ""
         suffix = f" ({extra})" if extra else ""
@@ -252,6 +331,8 @@ def filter_plan(plan: dict, titles: list[str] | None) -> dict:
         copy = dict(item)
         if copy.get("title") not in wanted:
             copy["action"] = "skip"
+        else:
+            copy["action"] = "add"
         items.append(copy)
     return {**plan, "items": items}
 

--- a/skills/kairo-ingest/scripts/scan.py
+++ b/skills/kairo-ingest/scripts/scan.py
@@ -289,23 +289,107 @@ def load_seen_ledger(root: Path) -> tuple[set[str], set[str], set[str]]:
     return titles, basenames, paths
 
 
+def iter_ref_manifests(root: Path) -> list[tuple[str, str, Path]]:
+    """List (home, ref_id, manifest). home is '' for global-home refs."""
+    root = Path(root)
+    found: list[tuple[str, str, Path]] = []
+    if not root.is_dir():
+        return found
+    for manifest in sorted(root.glob("*/references/*/manifest.yaml")):
+        if ".kairo" in manifest.parts:
+            continue
+        found.append((manifest.parents[2].name, manifest.parent.name, manifest))
+    global_refs = root / ".kairo" / "global-home" / "references"
+    if global_refs.is_dir():
+        for manifest in sorted(global_refs.glob("*/manifest.yaml")):
+            found.append(("", manifest.parent.name, manifest))
+    return found
+
+
+def parse_manifest_index(text: str) -> tuple[str, set[str], set[str]]:
+    """Return (title, basenames, paths) from a manifest.yaml body."""
+    title = ""
+    basenames: set[str] = set()
+    paths: set[str] = set()
+    for line in text.splitlines():
+        if line.startswith("id:"):
+            continue
+        if line.startswith("title:"):
+            title = line.split(":", 1)[1].strip().strip("'\"")
+            continue
+        stripped = line.strip()
+        if "location:" in stripped:
+            loc = stripped.split("location:", 1)[1].strip()
+            if loc:
+                basenames.add(Path(loc).name)
+                paths.add(loc)
+    return title, basenames, paths
+
+
+def lookup_existing_refs(root: Path) -> list[dict]:
+    """Disk refs under Topic homes and `.kairo/global-home`."""
+    records: list[dict] = []
+    for home, ref_id, manifest in iter_ref_manifests(root):
+        try:
+            text = manifest.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        title, basenames, paths = parse_manifest_index(text)
+        records.append(
+            {
+                "home": home,
+                "id": ref_id,
+                "title": title,
+                "basenames": basenames,
+                "paths": paths,
+            }
+        )
+    return records
+
+
+def find_existing_ref(
+    root: Path,
+    *,
+    title: str,
+    basenames: set[str] | None = None,
+    paths: set[str] | None = None,
+    records: list[dict] | None = None,
+) -> dict | None:
+    """Match a plan item to an existing ref. Prefer global-home when both exist."""
+    wanted_title = {title}
+    canon = canonical_title(title)
+    if canon:
+        wanted_title.add(canon)
+    wanted_bases = set(basenames or ())
+    wanted_paths = set(paths or ())
+    hits: list[dict] = []
+    for rec in records if records is not None else lookup_existing_refs(root):
+        rec_titles = {rec.get("title") or ""}
+        extra = canonical_title(rec.get("title") or "")
+        if extra:
+            rec_titles.add(extra)
+        if (
+            wanted_title & rec_titles
+            or wanted_bases & set(rec.get("basenames") or ())
+            or wanted_paths & set(rec.get("paths") or ())
+        ):
+            hits.append(rec)
+    if not hits:
+        return None
+    globals_ = [h for h in hits if not h.get("home")]
+    return (globals_ or hits)[0]
+
+
 def load_existing(root: Path) -> tuple[set[str], set[str], set[str]]:
     titles: set[str] = set()
     basenames: set[str] = set()
     paths: set[str] = set()
     if not root.is_dir():
         return titles, basenames, paths
-    for manifest in root.glob("*/references/*/manifest.yaml"):
-        text = manifest.read_text(encoding="utf-8")
-        for line in text.splitlines():
-            if line.startswith("title:"):
-                _add_title(titles, line.split(":", 1)[1].strip().strip("'\""))
-            stripped = line.strip()
-            if "location:" in stripped:
-                loc = stripped.split("location:", 1)[1].strip()
-                if loc:
-                    basenames.add(Path(loc).name)
-                    paths.add(loc)
+    for rec in lookup_existing_refs(root):
+        _add_title(titles, rec.get("title") or "")
+        basenames |= set(rec.get("basenames") or ())
+        paths |= set(rec.get("paths") or ())
     led_titles, led_bases, led_paths = load_seen_ledger(root)
     titles |= led_titles
     basenames |= led_bases

--- a/tests/unit/test_kairo_ingest.py
+++ b/tests/unit/test_kairo_ingest.py
@@ -651,9 +651,11 @@ def test_apply_never_emits_new_or_run(apply):
         }
     )
     flat = [" ".join(a["args"]) for a in actions]
-    assert all("new" not in s.split()[:1] for s in flat)
+    assert all(s.split()[0] != "new" for s in flat)
     assert all(s.split()[0] != "run" for s in flat)
-    assert all("tag" not in s.split()[:1] for s in flat)
+    assert all(not s.startswith("tag create") for s in flat)
+    assert all(a["cwd"] == "/kairo" for a in actions)
+    assert all("add" != a["args"][0] or "--topic" in a["args"] for a in actions)
 
 
 def test_render_only_new_json_is_apply_plan(scan, tmp_path):
@@ -725,3 +727,179 @@ def test_apply_main_receipt_only_by_default(apply, tmp_path, capsys):
     assert out.startswith("kairo-ingest 预览")
     assert "---" not in out
     assert '"ok"' not in out
+
+
+def _write_global_home_ref(root: Path, *, ref_id: str, title: str, location: str) -> None:
+    ref = root / ".kairo" / "global-home" / "references" / ref_id
+    ref.mkdir(parents=True)
+    (ref / "manifest.yaml").write_text(
+        f"id: {ref_id}\ntitle: {title}\nforms:\n- location: {location}\n",
+        encoding="utf-8",
+    )
+
+
+def test_load_existing_includes_global_home(scan, tmp_path):
+    _write_global_home_ref(
+        tmp_path,
+        ref_id="2026-09-10-20260910-093216",
+        title="数仓技术评审-260910",
+        location=".kairo/uploads/20260910 093216.m4a",
+    )
+    titles, bases, paths = scan.load_existing(tmp_path)
+    assert "数仓技术评审-260910" in titles
+    assert "20260910 093216.m4a" in bases
+    assert ".kairo/uploads/20260910 093216.m4a" in paths
+
+
+def test_merge_skips_global_home_title(scan, tmp_path):
+    _write_global_home_ref(
+        tmp_path,
+        ref_id="2026-09-10-20260910-093216",
+        title="数仓技术评审-260910",
+        location=".kairo/uploads/20260910 093216.m4a",
+    )
+    titles, bases, paths = scan.load_existing(tmp_path)
+    items = scan.merge_items(
+        [
+            {
+                "title": "数仓技术评审-260910",
+                "xxx": "数仓技术评审",
+                "occurred": "2026-09-10",
+                "path": "/rec/20260910 093216.m4a",
+                "source": "voice-memo",
+                "copy": True,
+            }
+        ],
+        TOPICS,
+        existing_titles=titles,
+        existing_basenames=bases,
+        existing_paths=paths,
+    )
+    assert items[0]["action"] == "skip"
+    assert items[0]["skip_reason"] == "already-ingested"
+
+
+def test_find_existing_prefers_global_home(scan, tmp_path):
+    topic_ref = tmp_path / "生态平台" / "references" / "2026-09-10-20260910-093216"
+    topic_ref.mkdir(parents=True)
+    (topic_ref / "manifest.yaml").write_text(
+        "id: 2026-09-10-20260910-093216\ntitle: 20260910 093216\n"
+        "forms:\n- location: .kairo/uploads/20260910 093216.m4a\n",
+        encoding="utf-8",
+    )
+    _write_global_home_ref(
+        tmp_path,
+        ref_id="2026-09-10-20260910-093216",
+        title="数仓技术评审-260910",
+        location=".kairo/uploads/20260910 093216.m4a",
+    )
+    found = scan.find_existing_ref(
+        tmp_path,
+        title="数仓技术评审-260910",
+        basenames={"20260910 093216.m4a"},
+        paths={"/rec/20260910 093216.m4a"},
+    )
+    assert found is not None
+    assert found["home"] == ""
+    assert found["id"] == "2026-09-10-20260910-093216"
+
+
+def test_apply_tags_existing_global_home_instead_of_add(apply, tmp_path):
+    _write_global_home_ref(
+        tmp_path,
+        ref_id="2026-09-10-20260910-093216",
+        title="数仓技术评审-260910",
+        location=".kairo/uploads/20260910 093216.m4a",
+    )
+    actions = apply.build_actions(
+        {
+            "root": str(tmp_path),
+            "items": [
+                {
+                    "title": "数仓技术评审-260910",
+                    "occurred": "2026-09-10",
+                    "topic": "生态平台",
+                    "action": "add",
+                    "forms": [
+                        {
+                            "path": "/rec/20260910 093216.m4a",
+                            "copy": True,
+                        }
+                    ],
+                }
+            ],
+        },
+        step=False,
+    )
+    kinds = [a["kind"] for a in actions]
+    assert kinds == ["tag", "title"]
+    assert actions[0]["args"][:4] == [
+        "tag",
+        "add",
+        "2026-09-10-20260910-093216",
+        "生态平台",
+    ]
+    assert "--home" not in actions[0]["args"]
+    assert actions[1]["args"] == [
+        "title",
+        "2026-09-10-20260910-093216",
+        "数仓技术评审-260910",
+        "--topic",
+        "生态平台",
+    ]
+    assert all(a["cwd"] == str(tmp_path) for a in actions)
+    assert all(a["args"][0] != "add" for a in actions)
+
+
+def test_filter_plan_reopens_already_ingested_wanted_title(apply):
+    plan = {
+        "root": "/kairo",
+        "items": [
+            {
+                "title": "数仓技术评审-260910",
+                "topic": "生态平台",
+                "action": "skip",
+                "occurred": "2026-09-10",
+                "forms": [{"path": "/rec/a.m4a", "copy": True}],
+            }
+        ],
+    }
+    filtered = apply.filter_plan(plan, ["数仓技术评审-260910"])
+    assert filtered["items"][0]["action"] == "add"
+
+
+def test_apply_dry_run_existing_global_home_receipt(apply, tmp_path, capsys):
+    _write_global_home_ref(
+        tmp_path,
+        ref_id="2026-09-10-20260910-103828",
+        title="C 端菜品制作流程讨论-260910",
+        location=".kairo/uploads/20260910 103828.m4a",
+    )
+    plan = {
+        "root": str(tmp_path),
+        "items": [
+            {
+                "title": "C 端菜品制作流程讨论-260910",
+                "topic": "康医通产品逻辑",
+                "action": "skip",
+                "occurred": "2026-09-10",
+                "forms": [{"path": "/rec/20260910 103828.m4a", "copy": True}],
+            }
+        ],
+    }
+    plan_path = tmp_path / "plan.json"
+    plan_path.write_text(json.dumps(plan), encoding="utf-8")
+    rc = apply.main(
+        [
+            "--plan",
+            str(plan_path),
+            "--dry-run",
+            "--no-step",
+            "--title",
+            "C 端菜品制作流程讨论-260910",
+        ]
+    )
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "tag C 端菜品制作流程讨论-260910 → 康医通产品逻辑 ref 2026-09-10-20260910-103828" in out
+    assert "add C 端菜品制作流程讨论-260910" not in out


### PR DESCRIPTION
## 摘要
scan 把 `.kairo/global-home` 视为已入库；确认入库对已有全局库 Ref 只 `tag add` + `title`，不再 `cd Topic && add`。

## 关联
- Closes #225
- 延续 #223 S2
- kairo CLI：xforce-io/kairo#360

## 测试
`python -m pytest tests/unit/test_kairo_ingest.py -v`（50 passed）